### PR TITLE
Implement unit tests for config and path validation

### DIFF
--- a/TEST_DESCRIPTIONS.md
+++ b/TEST_DESCRIPTIONS.md
@@ -28,6 +28,17 @@ This document summarizes the purpose of each unit test in the project.
 - **loadConfig fills missing security settings with defaults** – verifies that any security settings not supplied in the config file are populated with default values.
 - **includeDefaultWSL setting is ignored (deprecated)** – ensures deprecated `includeDefaultWSL` in the security section does not enable WSL.
 
+## tests/configValidation.test.ts
+
+- **throws for nonpositive maxCommandLength** – ensures validation rejects negative or zero maxCommandLength values.
+- **throws for enabled shell missing executable fields** – detects incomplete shell executable settings.
+- **throws for commandTimeout below 1** – enforces a minimum timeout of one second.
+- **passes for valid configuration** – confirms that a properly formed config does not throw.
+
+## tests/defaultConfig.test.ts
+
+- **writes default config without validatePath functions** – verifies that the file created by `createDefaultConfig` omits runtime validation functions.
+
 ## tests/directoryValidator.test.ts
 
 - **should return valid for directories within allowed paths** – validates that directories contained in the allowed list are accepted.
@@ -73,6 +84,14 @@ This document summarizes the purpose of each unit test in the project.
 - **generates correct description with powershell and gitbash enabled** – ensures that only the relevant examples for enabled shells are present.
 - **handles empty allowed shells array** – confirms that an empty shell list results in a minimal description without examples.
 - **handles unknown shell names** – tests that unrecognized shell names appear in the header but no examples are generated.
+
+## tests/toolDescription.details.test.ts
+
+- **buildExecuteCommandDescription includes shell summaries and examples** – verifies that the detailed description lists each enabled shell with sample usage.
+- **buildExecuteCommandDescription notes path formats for all shells** – ensures path format hints for Windows, mixed, and Unix shells appear.
+- **buildValidateDirectoriesDescription describes shell specific mode** – confirms the shell-specific validation block is documented when enabled.
+- **buildValidateDirectoriesDescription without shell specific mode** – checks the simpler description when shell-specific validation is disabled.
+- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned.
 
 ## tests/validation.test.ts
 
@@ -174,6 +193,19 @@ The tests also cover the correct normalization and validation of WSL paths (e.g.
 ## tests/wsl/isWslPathAllowed.test.ts
 
 - **matches allowed and disallowed paths including `/mnt/<drive>` conversion** – parameterized cases verify path allowance and drive mount handling.
+
+## tests/pathValidation.edge.test.ts
+
+- **WSL converts Windows paths before validation** – ensures Windows style paths are converted to `/mnt/` form for checking.
+- **WSL rejects paths outside allowed list after conversion** – disallowed paths remain blocked even after conversion.
+- **GitBash accepts Windows and Unix style paths** – verifies both `C:\` and `/c/` formats are permitted when allowed.
+- **throws when allowedPaths empty** – validation fails if no allowed paths are configured.
+
+## tests/configMerge.test.ts
+
+- **handles user config enabling subset of shells** – merging honours explicit enable/disable flags while keeping defaults for others.
+- **uses defaults when sections omitted** – missing global sections retain default values during merge.
+- **omitted shells retain defaults** – unspecified shells are included with default configuration.
 
 ## tests/integration/endToEnd.test.ts
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -161,7 +161,7 @@ export function getResolvedShellConfig(
   return resolved;
 }
 
-function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerConfig>): ServerConfig {
+export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerConfig>): ServerConfig {
   const merged: ServerConfig = {
     global: {
       security: {
@@ -300,7 +300,7 @@ function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<ServerCon
   return merged;
 }
 
-function validateConfig(config: ServerConfig): void {
+export function validateConfig(config: ServerConfig): void {
   // Validate security settings
   if (config.global.security.maxCommandLength < 1) {
     throw new Error('maxCommandLength must be positive');

--- a/tests/configMerge.test.ts
+++ b/tests/configMerge.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from '@jest/globals';
+import { DEFAULT_CONFIG } from '../src/utils/config.js';
+import * as configModule from '../src/utils/config.js';
+import type { ServerConfig } from '../src/types/config.js';
+
+const mergeConfigs = (configModule as any).mergeConfigs as (def: ServerConfig, user: Partial<ServerConfig>) => ServerConfig;
+
+function clone(obj: any) { return JSON.parse(JSON.stringify(obj)); }
+
+describe('mergeConfigs edge cases', () => {
+  test('handles user config enabling subset of shells', () => {
+    const result = mergeConfigs(DEFAULT_CONFIG, {
+      shells: {
+        powershell: { enabled: false },
+        cmd: { enabled: true }
+      }
+    });
+    expect(result.shells.powershell.enabled).toBe(false);
+    expect(result.shells.cmd.enabled).toBe(true);
+    expect(result.shells.gitbash.enabled).toBe(true);
+    expect(result.shells.wsl.enabled).toBe(true);
+  });
+
+  test('uses defaults when sections omitted', () => {
+    const result = mergeConfigs(DEFAULT_CONFIG, { global: { paths: { allowedPaths: ['C\\Custom'] } } });
+    expect(result.global.security.maxCommandLength).toBe(DEFAULT_CONFIG.global.security.maxCommandLength);
+    expect(result.global.paths.allowedPaths).toEqual(['C\\Custom']);
+  });
+
+  test('omitted shells retain defaults', () => {
+    const result = mergeConfigs(DEFAULT_CONFIG, { shells: { gitbash: { enabled: true } } });
+    expect(result.shells.powershell.enabled).toBe(true);
+    expect(result.shells.cmd.enabled).toBe(true);
+    expect(result.shells.gitbash.enabled).toBe(true);
+    expect(result.shells.wsl.enabled).toBe(true);
+  });
+});

--- a/tests/configValidation.test.ts
+++ b/tests/configValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from '@jest/globals';
+import { DEFAULT_CONFIG } from '../src/utils/config.js';
+import * as configModule from '../src/utils/config.js';
+import type { ServerConfig } from '../src/types/config.js';
+
+const validateConfig = (configModule as any).validateConfig as (cfg: ServerConfig) => void;
+
+function cloneDefault(): ServerConfig {
+  return JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+}
+
+describe('validateConfig helper', () => {
+  test('throws for nonpositive maxCommandLength', () => {
+    const cfg = cloneDefault();
+    cfg.global.security.maxCommandLength = 0;
+    expect(() => validateConfig(cfg)).toThrow('maxCommandLength must be positive');
+  });
+
+  test('throws for enabled shell missing executable fields', () => {
+    const cfg = cloneDefault();
+    cfg.shells.powershell!.executable.command = '' as any;
+    expect(() => validateConfig(cfg)).toThrow(/Invalid configuration for powershell/);
+  });
+
+  test('throws for commandTimeout below 1', () => {
+    const cfg = cloneDefault();
+    cfg.global.security.commandTimeout = 0;
+    expect(() => validateConfig(cfg)).toThrow('commandTimeout must be at least 1 second');
+  });
+
+  test('passes for valid configuration', () => {
+    const cfg = cloneDefault();
+    expect(() => validateConfig(cfg)).not.toThrow();
+  });
+});

--- a/tests/defaultConfig.test.ts
+++ b/tests/defaultConfig.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createDefaultConfig, DEFAULT_CONFIG } from '../src/utils/config.js';
+
+describe('createDefaultConfig', () => {
+  test('writes default config without validatePath functions', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cfgtest-'));
+    const file = path.join(tmp, 'config.json');
+
+    createDefaultConfig(file);
+
+    const saved = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(saved.global.security.commandTimeout).toBe(DEFAULT_CONFIG.global.security.commandTimeout);
+
+    for (const shell of Object.values(saved.shells)) {
+      if (!shell) continue;
+      expect(shell.validatePath).toBeUndefined();
+    }
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/pathValidation.edge.test.ts
+++ b/tests/pathValidation.edge.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from '@jest/globals';
+import { validateWorkingDirectory } from '../src/utils/pathValidation.js';
+import { createValidationContext } from '../src/utils/validationContext.js';
+import type { ResolvedShellConfig } from '../src/types/config.js';
+
+function makeConfig(shell: 'wsl' | 'gitbash', allowed: string[]): ResolvedShellConfig {
+  const base: ResolvedShellConfig = {
+    enabled: true,
+    executable: { command: 'test.exe', args: [] },
+    security: { maxCommandLength: 1000, commandTimeout: 30, enableInjectionProtection: true, restrictWorkingDirectory: true },
+    restrictions: { blockedCommands: [], blockedArguments: [], blockedOperators: [] },
+    paths: { allowedPaths: allowed, initialDir: undefined }
+  } as ResolvedShellConfig;
+  if (shell === 'wsl') {
+    (base as any).wslConfig = { mountPoint: '/mnt/', inheritGlobalPaths: true };
+  }
+  return base;
+}
+
+describe('validateWorkingDirectory edge cases', () => {
+  test('WSL converts Windows paths before validation', () => {
+    const cfg = makeConfig('wsl', ['/mnt/c/Users']);
+    const ctx = createValidationContext('wsl', cfg);
+    expect(() => validateWorkingDirectory('C:\\Users', ctx)).not.toThrow();
+  });
+
+  test('WSL rejects paths outside allowed list after conversion', () => {
+    const cfg = makeConfig('wsl', ['/mnt/c/Allowed']);
+    const ctx = createValidationContext('wsl', cfg);
+    expect(() => validateWorkingDirectory('D:\\Other', ctx)).toThrow(/allowed paths/);
+  });
+
+  test('GitBash accepts Windows and Unix style paths', () => {
+    const cfg = makeConfig('gitbash', ['C:\\Users']);
+    const ctx = createValidationContext('gitbash', cfg);
+    expect(() => validateWorkingDirectory('/c/Users', ctx)).not.toThrow();
+    expect(() => validateWorkingDirectory('C:\\Users', ctx)).not.toThrow();
+  });
+  test("GitBash converts allowed Unix paths to Windows for comparison", () => {
+    const cfg = makeConfig("gitbash", ["/c/Allowed"]);
+    const ctx = createValidationContext("gitbash", cfg);
+    expect(() => validateWorkingDirectory("C:\\Allowed", ctx)).not.toThrow();
+  });
+
+  test('throws when allowedPaths empty', () => {
+    const cfg = makeConfig('gitbash', []);
+    const ctx = createValidationContext('gitbash', cfg);
+    expect(() => validateWorkingDirectory('/c/Users', ctx)).toThrow(/No allowed paths configured/);
+  });
+});

--- a/tests/toolDescription.details.test.ts
+++ b/tests/toolDescription.details.test.ts
@@ -36,6 +36,20 @@ describe('Detailed Tool Descriptions', () => {
     expect(result).toContain('Windows CMD:');
   });
 
+  test('buildExecuteCommandDescription notes path formats for all shells', () => {
+    const configs = new Map<string, ResolvedShellConfig>();
+    configs.set('powershell', sampleConfig('powershell.exe'));
+    configs.set('cmd', sampleConfig('cmd.exe'));
+    configs.set('gitbash', sampleConfig('bash.exe'));
+    configs.set('wsl', { ...sampleConfig('wsl.exe'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
+
+    const result = buildExecuteCommandDescription(configs);
+
+    expect(result).toContain('Path format: Windows-style');
+    expect(result).toContain('Path format: Mixed');
+    expect(result).toContain('Path format: Unix-style');
+  });
+
   test('buildValidateDirectoriesDescription describes shell specific mode', () => {
     const result = buildValidateDirectoriesDescription(true);
     expect(result).toContain('Check if directories are within allowed paths');


### PR DESCRIPTION
## Summary
- export `mergeConfigs` and `validateConfig`
- add config validation tests
- add default config creation test
- extend tool description tests for path format notes
- add edge-case path validation tests
- add merge configs tests
- document new tests

## Testing
- `npm test`
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_684e6887da7c8320beda70cb5b9e6ee2