### PR TITLE
Add tasks for implementing shell type

### DIFF
--- a/docs/tacks/type_of_shell/task1-shell-type-config.md
+++ b/docs/tacks/type_of_shell/task1-shell-type-config.md
@@ -1,0 +1,23 @@
+# Task 1: Add Shell Type Property to Configuration
+
+## Priority
+HIGH - Required foundation for custom shells.
+
+## Description
+Introduce a new `type` property for each shell configuration. This value defines whether a shell uses Windows, Unix, mixed (Git Bash) or WSL semantics. Existing built‑in shell entries must be updated to include the correct type and configuration loaders must preserve it.
+
+## Scope
+- Extend `BaseShellConfig` and `WslShellConfig` in `src/types/config.ts` with a required `type` field.
+- Update `DEFAULT_CONFIG` in `src/utils/config.ts` with `type` for each shell.
+- Modify `mergeConfigs`, `resolveShellConfiguration` and related helpers so the property is retained.
+- Ensure `createDefaultConfig` writes the new property.
+
+## Files to Modify/Create
+- `src/types/config.ts`
+- `src/utils/config.ts`
+- `src/utils/configMerger.ts`
+
+## Acceptance Criteria
+1. Configuration interfaces compile with the new property.
+2. Loading and merging configs keeps the `type` value intact.
+3. Default config file generated with `--init-config` contains the new field for all shells.

--- a/docs/tacks/type_of_shell/task2-server-support.md
+++ b/docs/tacks/type_of_shell/task2-server-support.md
@@ -1,0 +1,21 @@
+# Task 2: Integrate Shell Type into Server Logic
+
+## Priority
+HIGH - Necessary to actually support new shell entries.
+
+## Description
+Update runtime logic so the server determines path rules and validation behavior based on the `type` property rather than hard coded shell names. Validation context and helper utilities must reference this field.
+
+## Scope
+- Change `createValidationContext` in `src/utils/validationContext.ts` to derive `isWindowsShell`, `isUnixShell` and `isWslShell` from the `type` field.
+- Update all utilities under `src/utils/` that switch on shell name to instead consult the new type information.
+- Adjust `CLIServer` in `src/index.ts` to store the type when resolving shell configs.
+
+## Files to Modify/Create
+- `src/utils/validationContext.ts`
+- `src/utils/pathValidation.ts`
+- `src/index.ts`
+
+## Acceptance Criteria
+1. Validation logic works for both built‑in and custom shells.
+2. Tests confirm that commands execute with correct path normalization depending on shell type.

--- a/docs/tacks/type_of_shell/task3-tests.md
+++ b/docs/tacks/type_of_shell/task3-tests.md
@@ -1,0 +1,24 @@
+# Task 3: Unit Tests for Shell Type Feature
+
+## Priority
+MEDIUM - Ensure reliability of the new feature.
+
+## Description
+Add comprehensive unit tests covering configuration loading, validation context creation and path normalization for custom shells defined with the `type` property.
+
+## Scope
+- Create tests that load a config containing a "custom-bash" shell with `type: 'unix'` and verify that `getResolvedShellConfig` returns the proper structure.
+- Add tests for `createValidationContext` to ensure the flags are set correctly for each shell type.
+- Extend existing path validation tests to use a custom shell entry.
+
+## Files to Modify/Create
+- `tests/configNormalization.test.ts` (add cases)
+- `tests/validation/context.test.ts` (update)
+- Potentially new test files for additional path checks.
+
+## Expected Coverage After Implementation
+- Overall coverage should remain above current levels.
+
+## Acceptance Criteria
+1. All test suites pass with `npm test`.
+2. New tests demonstrate functionality of custom shells defined via `type`.

--- a/docs/tacks/type_of_shell/task4-documentation.md
+++ b/docs/tacks/type_of_shell/task4-documentation.md
@@ -1,0 +1,21 @@
+# Task 4: Documentation Updates
+
+## Priority
+LOW - Completes the feature by documenting usage.
+
+## Description
+All user facing documentation should describe the new `type` field and provide an updated example of adding a custom shell.
+
+## Scope
+- Update `README.md` sections on configuration and shell setup.
+- Expand `FAQ.md` answer about custom shells to mention that `type` must be specified and explain the possible values.
+- Add short notes in `CONFIGURATION_EXAMPLES.md` or other relevant docs if needed.
+
+## Files to Modify/Create
+- `README.md`
+- `docs/FAQ.md`
+- Other configuration docs as appropriate.
+
+## Acceptance Criteria
+1. Documentation clearly describes the `type` property with at least one example.
+2. All markdown files build without linting errors.


### PR DESCRIPTION
## Summary
- add planned tasks for introducing a `type` property for shells

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc9ffad148320be96d2a111d0c7b4