### PR TITLE
Implement shell type config features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "server-win-cli": "dist/index.js"
+        "wcli0": "dist/index.js"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ class CLIServer {
       let shellProcess: ReturnType<typeof spawn>;
       let spawnArgs: string[];
 
-      if (shellName === 'wsl') {
+      if (shellConfig.type === 'wsl') {
         const parsedCommand = parseCommand(command);
         spawnArgs = [...shellConfig.executable.args, parsedCommand.command, ...parsedCommand.args];
       } else {
@@ -257,7 +257,7 @@ class CLIServer {
         // For WSL, convert WSL paths back to Windows paths for spawn cwd
         let spawnCwd = workingDir;
         let envVars = { ...process.env };
-        if (shellName === 'wsl') {
+        if (shellConfig.type === 'wsl') {
           if (workingDir.startsWith('/mnt/')) {
             // Convert /mnt/c/path to C:\path
             const match = workingDir.match(/^\/mnt\/([a-z])\/(.*)$/i);
@@ -273,7 +273,7 @@ class CLIServer {
           }
           // Pass original WSL path to emulator via environment variable
           envVars.WSL_ORIGINAL_PATH = workingDir;
-        } else if (shellName === 'gitbash') {
+        } else if (shellConfig.type === 'mixed') {
           // Normalize Git Bash paths like /c/foo to Windows format for spawn
           spawnCwd = normalizeWindowsPath(workingDir);
         }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -103,9 +103,18 @@ export interface ShellExecutableConfig {
 }
 
 /**
+ * Supported shell semantics types
+ */
+export type ShellType = 'windows' | 'unix' | 'mixed' | 'wsl';
+
+/**
  * Base configuration for all shell types
  */
 export interface BaseShellConfig {
+  /**
+   * The type of shell semantics (windows, unix, mixed or wsl)
+   */
+  type: ShellType;
   /**
    * Whether this shell is enabled
    */
@@ -161,6 +170,7 @@ export interface WslSpecificConfig {
  * Extended configuration for WSL shell with WSL-specific options
  */
 export interface WslShellConfig extends BaseShellConfig {
+  type: 'wsl';
   /**
    * WSL-specific configuration
    */
@@ -192,6 +202,10 @@ export interface ServerConfig {
  * This is used internally and represents the final configuration for a shell
  */
 export interface ResolvedShellConfig {
+  /**
+   * The type of shell semantics
+   */
+  type: ShellType;
   /**
    * Whether this shell is enabled
    */

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,6 +38,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   },
   shells: {
     powershell: {
+      type: 'windows',
       enabled: true,
       executable: {
         command: 'powershell.exe',
@@ -46,6 +47,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       validatePath: (dir: string) => /^[a-zA-Z]:\\/.test(dir)
     },
     cmd: {
+      type: 'windows',
       enabled: true,
       executable: {
         command: 'cmd.exe',
@@ -59,6 +61,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       }
     },
     gitbash: {
+      type: 'mixed',
       enabled: true,
       executable: {
         command: 'C:\\Program Files\\Git\\bin\\bash.exe',
@@ -72,6 +75,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       }
     },
     wsl: {
+      type: 'wsl',
       enabled: true,
       executable: {
         command: 'wsl.exe',
@@ -154,7 +158,7 @@ export function getResolvedShellConfig(
   let resolved = resolveShellConfiguration(config.global, shell);
   
   // Special handling for WSL path inheritance
-  if (shellName === 'wsl' && resolved.wslConfig) {
+  if (resolved.type === 'wsl' && resolved.wslConfig) {
     resolved = applyWslPathInheritance(resolved, config.global.paths.allowedPaths);
   }
   
@@ -199,6 +203,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
   // Add each shell, ensuring required properties are always set
   if (shouldIncludePowerShell) {
     const baseShell = defaultConfig.shells.powershell || {
+      type: 'windows',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -220,6 +225,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeCmd) {
     const baseShell = defaultConfig.shells.cmd || {
+      type: 'windows',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -241,6 +247,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeGitBash) {
     const baseShell = defaultConfig.shells.gitbash || {
+      type: 'mixed',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -262,6 +269,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeWSL) {
     const baseShell = defaultConfig.shells.wsl || {
+      type: 'wsl',
       enabled: false,
       executable: { command: '', args: [] },
       wslConfig: {

--- a/src/utils/configMerger.ts
+++ b/src/utils/configMerger.ts
@@ -101,8 +101,9 @@ export function resolveShellConfiguration(
   shell: BaseShellConfig | WslShellConfig
 ): ResolvedShellConfig {
   const overrides = shell.overrides || {};
-  
+
   const resolved: ResolvedShellConfig = {
+    type: shell.type,
     enabled: shell.enabled,
     executable: shell.executable,
     security: overrides.security 

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -30,6 +30,7 @@ export function createSerializableConfig(config: ServerConfig): any {
     if (!shellConfig) continue;
 
     const shellInfo: any = {
+      type: shellConfig.type,
       enabled: shellConfig.enabled,
       executable: {
         command: shellConfig.executable.command,
@@ -88,6 +89,7 @@ export function createResolvedConfigSummary(
 ): any {
   return {
     shell: shellName,
+    type: resolved.type,
     enabled: resolved.enabled,
     executable: {
       command: resolved.executable.command,

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -101,15 +101,15 @@ export function buildExecuteCommandDescription(
       lines.push(`- Blocked operators: ${config.restrictions.blockedOperators.join(', ')}`);
     }
     
-    // Add path format information
-    if (shellName === 'wsl') {
+    // Add path format information based on shell type
+    if (config.type === 'wsl' || config.type === 'unix') {
       lines.push(`- Path format: Unix-style (/home/user, /mnt/c/...)`);
-      if (config.wslConfig?.inheritGlobalPaths) {
+      if (config.type === 'wsl' && config.wslConfig?.inheritGlobalPaths) {
         lines.push(`- Inherits global Windows paths (converted to /mnt/...)`);
       }
-    } else if (shellName === 'cmd' || shellName === 'powershell') {
+    } else if (config.type === 'windows') {
       lines.push(`- Path format: Windows-style (C:\\Users\\...)`);
-    } else if (shellName === 'gitbash') {
+    } else if (config.type === 'mixed') {
       lines.push(`- Path format: Mixed (C:\\... or /c/...)`);
     }
     

--- a/src/utils/toolSchemas.ts
+++ b/src/utils/toolSchemas.ts
@@ -25,12 +25,12 @@ export function buildExecuteCommandSchema(
     if (config) {
       const parts = [`${shell} shell`];
       parts.push(`timeout: ${config.security.commandTimeout}s`);
-      
-      if (shell === 'wsl') {
+
+      if (config.type === 'wsl' || config.type === 'unix') {
         parts.push('Unix paths');
-      } else if (shell === 'cmd' || shell === 'powershell') {
+      } else if (config.type === 'windows') {
         parts.push('Windows paths');
-      } else if (shell === 'gitbash') {
+      } else if (config.type === 'mixed') {
         parts.push('Mixed paths');
       }
       
@@ -54,9 +54,9 @@ export function buildExecuteCommandSchema(
       workingDir: {
         type: "string",
         description: "Working directory (optional). Format depends on shell type:\n" +
-                   "- Windows shells (cmd, powershell): Use C:\\Path\\Format\n" +
-                   "- WSL: Use /unix/path/format\n" +
-                   "- Git Bash: Both formats accepted"
+                   "- Windows shells: Use C:\\Path\\Format\n" +
+                   "- Unix/WSL shells: Use /unix/path/format\n" +
+                   "- Mixed shells: Both formats accepted"
       }
     },
     required: ["shell", "command"],

--- a/src/utils/validationContext.ts
+++ b/src/utils/validationContext.ts
@@ -18,9 +18,9 @@ export function createValidationContext(
   shellName: string,
   shellConfig: ResolvedShellConfig
 ): ValidationContext {
-  const isWindowsShell = ['cmd', 'powershell'].includes(shellName);
-  const isUnixShell = ['gitbash', 'wsl'].includes(shellName);
-  const isWslShell = shellName === 'wsl';
+  const isWindowsShell = shellConfig.type === 'windows';
+  const isUnixShell = shellConfig.type === 'unix' || shellConfig.type === 'wsl' || shellConfig.type === 'mixed';
+  const isWslShell = shellConfig.type === 'wsl';
   
   return {
     shellName,
@@ -37,6 +37,6 @@ export function createValidationContext(
 export function getExpectedPathFormat(context: ValidationContext): 'windows' | 'unix' | 'mixed' {
   if (context.isWindowsShell) return 'windows';
   if (context.isWslShell) return 'unix';
-  if (context.shellName === 'gitbash') return 'mixed'; // Git Bash accepts both
+  if (context.shellConfig.type === 'mixed') return 'mixed';
   return 'unix';
 }

--- a/tests/asyncOperations.test.ts
+++ b/tests/asyncOperations.test.ts
@@ -62,6 +62,7 @@ describe('Async Command Execution', () => {
     
     // Configure WSL shell to use the emulator for cross platform tests
     config.shells.wsl = {
+      type: 'wsl',
       enabled: true,
       executable: {
         command: 'node',

--- a/tests/commandChain.test.ts
+++ b/tests/commandChain.test.ts
@@ -46,6 +46,7 @@ beforeAll(() => {
     },
     shells: {
       cmd: {
+        type: 'windows',
         enabled: true,
         executable: {
           command: 'cmd.exe',

--- a/tests/commandSettings.test.ts
+++ b/tests/commandSettings.test.ts
@@ -42,6 +42,7 @@ beforeAll(() => {
     },
     shells: {
       cmd: {
+        type: 'windows',
         enabled: true,
         executable: {
           command: 'cmd.exe',
@@ -66,6 +67,7 @@ describe('validateCommand with different settings', () => {
       },
       shells: {
         cmd: {
+          type: 'windows',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -89,6 +91,7 @@ describe('validateCommand with different settings', () => {
       },
       shells: {
         cmd: {
+          type: 'windows',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -112,6 +115,7 @@ describe('validateCommand with different settings', () => {
       },
       shells: {
         cmd: {
+          type: 'windows',
           enabled: true,
           executable: {
             command: 'cmd.exe',

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -283,6 +283,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
+          type: 'windows',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -337,6 +338,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
+          type: 'windows',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -377,6 +379,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         wsl: {
+          type: 'wsl',
           enabled: true,
           executable: {
             command: 'node',

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -42,6 +42,7 @@ describe('get_config tool', () => {
     },
     shells: {
       powershell: {
+        type: 'windows',
         enabled: true,
         executable: {
           command: 'powershell.exe',
@@ -54,6 +55,7 @@ describe('get_config tool', () => {
         }
       },
       cmd: {
+        type: 'windows',
         enabled: true,
         executable: {
           command: 'cmd.exe',
@@ -66,6 +68,7 @@ describe('get_config tool', () => {
         }
       },
       gitbash: {
+        type: 'mixed',
         enabled: false,
         executable: {
           command: 'bash.exe',

--- a/tests/gitbashWorkingDir.test.ts
+++ b/tests/gitbashWorkingDir.test.ts
@@ -33,7 +33,7 @@ describe('Git Bash working directory handling', () => {
     const server = new CLIServer(buildTestConfig({
       global: { security: { restrictWorkingDirectory: false } },
       shells: {
-        gitbash: { enabled: true, executable: { command: 'bash.exe', args: ['-c'] } },
+        gitbash: { type: 'mixed', enabled: true, executable: { command: 'bash.exe', args: ['-c'] } },
         cmd: { enabled: false },
         powershell: { enabled: false },
         wsl: { enabled: false }

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -28,6 +28,7 @@ export class TestCLIServer {
     // Configure wsl shell to use the local emulator script
     const wslEmulatorPath = path.resolve(process.cwd(), 'scripts/wsl-emulator.js');
     const wslShell = {
+      type: 'wsl',
       enabled: true,
       executable: {
         command: 'node',

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -55,6 +55,7 @@ export function buildShellConfig(
   overrides: Partial<BaseShellConfig | WslShellConfig> = {}
 ): BaseShellConfig | WslShellConfig {
   const base: BaseShellConfig = {
+    type: shellType === 'wsl' ? 'wsl' : 'windows',
     enabled: true,
     executable: {
       command: 'test.exe',
@@ -82,6 +83,7 @@ export function createWslEmulatorConfig(overrides: Partial<WslShellConfig> = {})
   const wslEmulatorPath = path.resolve(process.cwd(), 'scripts/wsl-emulator.js');
   
   return {
+    type: 'wsl',
     enabled: true,
     executable: {
       command: 'node',

--- a/tests/pathValidation.edge.test.ts
+++ b/tests/pathValidation.edge.test.ts
@@ -5,6 +5,7 @@ import type { ResolvedShellConfig } from '../src/types/config.js';
 
 function makeConfig(shell: 'wsl' | 'gitbash', allowed: string[]): ResolvedShellConfig {
   const base: ResolvedShellConfig = {
+    type: shell === 'wsl' ? 'wsl' : 'mixed',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: { maxCommandLength: 1000, commandTimeout: 30, enableInjectionProtection: true, restrictWorkingDirectory: true },

--- a/tests/toolDescription.details.test.ts
+++ b/tests/toolDescription.details.test.ts
@@ -6,8 +6,9 @@ import {
 } from '../src/utils/toolDescription.js';
 import type { ResolvedShellConfig } from '../src/types/config.js';
 
-function sampleConfig(name: string): ResolvedShellConfig {
+function sampleConfig(name: string, type: ResolvedShellConfig['type'] = 'windows'): ResolvedShellConfig {
   return {
+    type,
     enabled: true,
     executable: { command: name, args: [] },
     security: {
@@ -25,7 +26,7 @@ describe('Detailed Tool Descriptions', () => {
   test('buildExecuteCommandDescription includes shell summaries and examples', () => {
     const configs = new Map<string, ResolvedShellConfig>();
     configs.set('cmd', sampleConfig('cmd.exe'));
-    configs.set('wsl', { ...sampleConfig('wsl.exe'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
+    configs.set('wsl', { ...sampleConfig('wsl.exe', 'wsl'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
 
     const result = buildExecuteCommandDescription(configs);
 
@@ -40,8 +41,8 @@ describe('Detailed Tool Descriptions', () => {
     const configs = new Map<string, ResolvedShellConfig>();
     configs.set('powershell', sampleConfig('powershell.exe'));
     configs.set('cmd', sampleConfig('cmd.exe'));
-    configs.set('gitbash', sampleConfig('bash.exe'));
-    configs.set('wsl', { ...sampleConfig('wsl.exe'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
+    configs.set('gitbash', sampleConfig('bash.exe', 'mixed'));
+    configs.set('wsl', { ...sampleConfig('wsl.exe', 'wsl'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
 
     const result = buildExecuteCommandDescription(configs);
 

--- a/tests/utils/toolSchemas.test.ts
+++ b/tests/utils/toolSchemas.test.ts
@@ -4,7 +4,11 @@ import type { ResolvedShellConfig } from '../../src/types/config.js';
 
 describe('Tool Schema Builders', () => {
   // Helper to create mock resolved shell configs
-  const createMockConfig = (shellName: string, overrides: Partial<ResolvedShellConfig> = {}): ResolvedShellConfig => ({
+  const createMockConfig = (
+    shellName: string,
+    overrides: Partial<ResolvedShellConfig> = {}
+  ): ResolvedShellConfig => ({
+    type: shellName === 'wsl' ? 'wsl' : shellName === 'gitbash' ? 'mixed' : 'windows',
     enabled: true,
     executable: { command: `${shellName}.exe`, args: [] },
     security: {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -26,12 +26,13 @@ import type { ResolvedShellConfig } from '../src/types/config.js';
  * Helper function to create a resolved shell config for testing
  */
 function createTestConfig(
-  blockedCommands: string[] = [], 
-  blockedArgs: string[] = [], 
+  blockedCommands: string[] = [],
+  blockedArgs: string[] = [],
   blockedOperators: string[] = [],
   allowedPaths: string[] = []
 ): ResolvedShellConfig {
   return {
+    type: 'windows',
     enabled: true,
     executable: {
       command: 'test',
@@ -369,6 +370,7 @@ describe('Path Validation', () => {
   test('validateWorkingDirectory handles GitBash paths properly', () => {
     // Using memory of GitBash style paths in the new config system
     const gitbashConfig = createTestConfig([], [], [], ['C:\\Users\\test', 'D:\\Projects']);
+    gitbashConfig.type = 'mixed';
     const gitbashContext = createTestContext('gitbash', gitbashConfig);
     
     // GitBash paths format should be properly converted and validated
@@ -424,6 +426,7 @@ describe('WSL Path Validation', () => {
   test('validateWorkingDirectory with WSL validation context', () => {
     // Create a WSL config with allowedPaths
     const wslConfig = createTestConfig([], [], [], ['/mnt/c/allowed', '/tmp', '/home/user']);
+    wslConfig.type = 'wsl';
     wslConfig.wslConfig = {
       mountPoint: '/mnt/',
       inheritGlobalPaths: true
@@ -445,6 +448,7 @@ describe('WSL Path Validation', () => {
   test('validateWorkingDirectory with WSL context handles Windows paths', () => {
     // Create a WSL config with Windows paths being converted
     const wslConfig = createTestConfig([], [], [], ['/mnt/c/allowed', '/home/user']);
+    wslConfig.type = 'wsl';
     wslConfig.wslConfig = {
       mountPoint: '/mnt/',
       inheritGlobalPaths: true

--- a/tests/validation/context.test.ts
+++ b/tests/validation/context.test.ts
@@ -5,6 +5,7 @@ import { ResolvedShellConfig } from '../../src/types/config';
 // Helper to create mock shell configs
 function createMockShellConfig(overrides: Partial<ResolvedShellConfig> = {}): ResolvedShellConfig {
   return {
+    type: 'windows',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {
@@ -35,13 +36,14 @@ describe('ValidationContext', () => {
     expect(cmdContext.isWslShell).toBe(false);
     
     // Unix shell (gitbash)
-    const gitbashContext = createValidationContext('gitbash', createMockShellConfig());
+  const gitbashContext = createValidationContext('gitbash', createMockShellConfig({ type: 'mixed' }));
     expect(gitbashContext.isWindowsShell).toBe(false);
     expect(gitbashContext.isUnixShell).toBe(true);
     expect(gitbashContext.isWslShell).toBe(false);
     
     // WSL shell
-    const wslContext = createValidationContext('wsl', createMockShellConfig({
+  const wslContext = createValidationContext('wsl', createMockShellConfig({
+      type: 'wsl',
       wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true }
     }));
     expect(wslContext.isWindowsShell).toBe(false);

--- a/tests/validation/pathValidation.test.ts
+++ b/tests/validation/pathValidation.test.ts
@@ -4,9 +4,13 @@ import { createValidationContext } from '../../src/utils/validationContext';
 import { ResolvedShellConfig } from '../../src/types/config';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
-// Helper to create mock config
-function createMockConfig(allowedPaths: string[] = ['C:\\Windows', 'C:\\Users']): ResolvedShellConfig {
-  return {
+// Helper to create mock config. Allows passing either a list of allowed paths
+// or a partial ResolvedShellConfig to override defaults.
+function createMockConfig(
+  overrides: Partial<ResolvedShellConfig> | string[] = ['C:\\Windows', 'C:\\Users']
+): ResolvedShellConfig {
+  const base: ResolvedShellConfig = {
+    type: 'windows',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {
@@ -21,10 +25,25 @@ function createMockConfig(allowedPaths: string[] = ['C:\\Windows', 'C:\\Users'])
       blockedOperators: ['&']
     },
     paths: {
-      allowedPaths,
+      allowedPaths: Array.isArray(overrides) ? overrides : ['C:\\Windows', 'C:\\Users'],
       initialDir: undefined
     }
   };
+
+  if (!Array.isArray(overrides)) {
+    Object.assign(base, overrides);
+    if (overrides.paths) {
+      base.paths = { ...base.paths, ...overrides.paths };
+    }
+    if (overrides.security) {
+      base.security = { ...base.security, ...overrides.security };
+    }
+    if (overrides.restrictions) {
+      base.restrictions = { ...base.restrictions, ...overrides.restrictions };
+    }
+  }
+
+  return base;
 }
 
 describe('Path Validation', () => {
@@ -41,7 +60,7 @@ describe('Path Validation', () => {
     });
 
     test('normalizes Unix paths correctly', () => {
-      const context = createValidationContext('wsl', createMockConfig());
+      const context = createValidationContext('wsl', createMockConfig({ type: 'wsl' }));
       context.shellConfig.wslConfig = { mountPoint: '/mnt/', inheritGlobalPaths: true };
       
       expect(normalizePathForShell('/usr/bin', context)).toBe('/usr/bin');
@@ -51,7 +70,7 @@ describe('Path Validation', () => {
     });
 
     test('normalizes GitBash paths correctly', () => {
-      const context = createValidationContext('gitbash', createMockConfig());
+      const context = createValidationContext('gitbash', createMockConfig({ type: 'mixed' }));
       
       const normalizedGitBashPath = normalizePathForShell('/c/Windows/System32', context);
       // The actual normalization might differ from test expectations, so check key parts
@@ -77,7 +96,7 @@ describe('Path Validation', () => {
     });
 
     test('validates WSL paths with WSL shell', () => {
-      const wslConfig = createMockConfig();
+      const wslConfig = createMockConfig({ type: 'wsl' });
       wslConfig.wslConfig = { mountPoint: '/mnt/', inheritGlobalPaths: true };
       wslConfig.paths.allowedPaths = ['/mnt/c/Windows', '/mnt/c/Users', '/home/user'];
       
@@ -93,7 +112,7 @@ describe('Path Validation', () => {
     });
 
     test('validates GitBash paths with GitBash shell', () => {
-      const context = createValidationContext('gitbash', createMockConfig());
+      const context = createValidationContext('gitbash', createMockConfig({ type: 'mixed' }));
       
       // Valid GitBash paths should not throw - use /c/ format which is properly recognized
       expect(() => validateWorkingDirectory('/c/Windows', context)).not.toThrow();

--- a/tests/validation/shellSpecific.test.ts
+++ b/tests/validation/shellSpecific.test.ts
@@ -16,6 +16,7 @@ function createMockShellConfig(
   blockedOps: string[] = ['&', '|', ';']
 ): ResolvedShellConfig {
   return {
+    type: shellName === 'wsl' ? 'wsl' : (shellName === 'gitbash' ? 'mixed' : 'windows'),
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {

--- a/tests/wsl.test.ts
+++ b/tests/wsl.test.ts
@@ -25,6 +25,7 @@ describe('WSL Shell Execution via Emulator (Tests 1-4)', () => {
     if (testConfig.shells) {
       // Setup WSL shell with emulator
       testConfig.shells.wsl = {
+        type: 'wsl',
         enabled: true,
         executable: {
           command: 'node',
@@ -166,6 +167,7 @@ describe('WSL Working Directory Validation (Test 5)', () => { // Removed .only
     if (cwdTestConfig.shells) {
       // Setup WSL shell with emulator
       cwdTestConfig.shells.wsl = {
+        type: 'wsl',
         enabled: true,
         executable: {
           command: 'node',

--- a/tests/wsl/pathConversion.test.ts
+++ b/tests/wsl/pathConversion.test.ts
@@ -74,6 +74,7 @@ describe('convertWindowsToWslPath', () => {
 
 describe('validateWslPath with Windows drives', () => {
   const baseConfig: ResolvedShellConfig = {
+    type: 'wsl',
     enabled: true,
     executable: { command: 'wsl.exe', args: [] },
     security: {

--- a/tests/wsl/pathResolution.test.ts
+++ b/tests/wsl/pathResolution.test.ts
@@ -4,6 +4,7 @@ import { createValidationContext } from '../../src/utils/validationContext.js';
 import type { ResolvedShellConfig } from '../../src/types/config.js';
 
 const baseResolved: Readonly<ResolvedShellConfig> = {
+  type: 'wsl',
   enabled: true,
   executable: { command: 'wsl.exe', args: [] },
   security: {


### PR DESCRIPTION
## Summary
- handle mixed shell as Unix in validation context
- update helper configs and tests to include shell type
- correct path descriptions for command tools
- ensure GitBash and WSL tests pass with type-aware configs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fd17d47a083209d8db5fde680b870