### PR TITLE
Add shell type docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The server uses an inheritance-based configuration system where global defaults 
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -196,6 +197,7 @@ The server uses an inheritance-based configuration system where global defaults 
       }
     },
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",
@@ -256,6 +258,7 @@ If no configuration file is found, the server will use a default (restricted) co
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -263,6 +266,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -270,6 +274,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -351,6 +356,7 @@ Global settings provide defaults that apply to all shells unless overridden.
 #### Shell Configuration
 
 Each shell can be individually configured and can override global settings.
+Each shell entry must include a `type` field indicating the shell semantics. Valid values are `windows`, `unix`, `mixed` (Git Bash style), and `wsl`.
 
 ##### Basic Shell Configuration
 
@@ -358,6 +364,7 @@ Each shell can be individually configured and can override global settings.
 {
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -374,6 +381,7 @@ Each shell can be individually configured and can override global settings.
 {
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -402,6 +410,7 @@ WSL shells have additional configuration options for path mapping:
 {
   "shells": {
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",
@@ -440,6 +449,7 @@ Example of inheritance in action:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "overrides": {
         "security": { "commandTimeout": 45 },
         "restrictions": { "blockedCommands": ["Remove-Item"] }

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -2,6 +2,8 @@
 
 This document provides practical examples of different configuration scenarios for the Windows CLI MCP Server.
 
+Each shell entry now requires a `type` property specifying the shell semantics (`windows`, `unix`, `mixed` or `wsl`).
+
 ## Basic Configurations
 
 ### Minimal Configuration
@@ -17,6 +19,7 @@ The simplest configuration that enables basic functionality:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -54,6 +57,7 @@ Configuration suitable for development work with multiple shells:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -61,6 +65,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -68,6 +73,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -113,6 +119,7 @@ Restrictive configuration for sensitive environments:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -163,6 +170,7 @@ Configuration that allows monitoring and logging:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -193,6 +201,7 @@ Configuration that only enables PowerShell with specific restrictions:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -287,6 +296,7 @@ Configuration supporting different environments with shell-specific overrides:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -302,6 +312,7 @@ Configuration supporting different environments with shell-specific overrides:
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -317,6 +328,7 @@ Configuration supporting different environments with shell-specific overrides:
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -374,6 +386,7 @@ Configuration suitable for automated testing:
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -386,6 +399,7 @@ Configuration suitable for automated testing:
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -393,6 +407,7 @@ Configuration suitable for automated testing:
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -303,12 +303,13 @@ A: Use the project's issue tracker:
 
 ### Q: Can I create custom shell configurations?
 
-A: Yes, you can add custom shells by specifying the executable and arguments:
+A: Yes, you can add custom shells by specifying the executable and arguments. Each custom shell must also define a `type` field indicating whether it uses `windows`, `unix`, `mixed` or `wsl` semantics:
 
 ```json
 {
   "shells": {
     "custom-bash": {
+      "type": "unix",
       "enabled": true,
       "executable": {
         "command": "/usr/bin/bash",


### PR DESCRIPTION
## Summary
- document `type` field for shells
- update custom shell FAQ entry
- add `type` in configuration examples

## Testing
- `npm test` *(fails: Working directory must be an absolute path)*

------
https://chatgpt.com/codex/tasks/task_e_685fdde6ac808320aa584cdad5bfb08f