### PR TITLE
Fix config docs to include shell type

### DIFF
--- a/config.development.json
+++ b/config.development.json
@@ -31,6 +31,7 @@
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -43,6 +44,7 @@
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -50,6 +52,7 @@
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -57,6 +60,7 @@
       }
     },
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",

--- a/config.examples/development.json
+++ b/config.examples/development.json
@@ -18,6 +18,7 @@
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "pwsh.exe",
@@ -30,6 +31,7 @@
       }
     },
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",

--- a/config.examples/minimal.json
+++ b/config.examples/minimal.json
@@ -5,9 +5,10 @@
       "enableInjectionProtection": true
     }
   },
-  "shells": {
-    "cmd": {
-      "enabled": true,
+    "shells": {
+      "cmd": {
+        "type": "windows",
+        "enabled": true,
       "executable": {
         "command": "cmd.exe",
         "args": ["/c"]

--- a/config.examples/production.json
+++ b/config.examples/production.json
@@ -37,6 +37,7 @@
   },
   "shells": {
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",

--- a/config.sample.json
+++ b/config.sample.json
@@ -43,6 +43,7 @@
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -50,6 +51,7 @@
       }
     },
     "cmd": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -57,6 +59,7 @@
       }
     },
     "gitbash": {
+      "type": "mixed",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/config.secure.json
+++ b/config.secure.json
@@ -51,6 +51,7 @@
   },
   "shells": {
     "powershell": {
+      "type": "windows",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",


### PR DESCRIPTION
## Summary
- include `type` field in example config files under `config.*` and `config.examples`

## Testing
- `npm install`
- `npm test` *(fails: Working directory must be an absolute path)*

------
https://chatgpt.com/codex/tasks/task_e_685fe62853308320afd7228788cc147f