### PR TITLE
Add per-test documentation

### DIFF
--- a/docs/unit_tests/asyncOperations.md
+++ b/docs/unit_tests/asyncOperations.md
@@ -1,0 +1,5 @@
+# asyncOperations
+
+- **should handle concurrent command executions** – runs multiple commands in parallel and verifies that each completes successfully.
+- **should queue commands when limit reached** – ensures additional commands wait when a concurrency limit is exceeded.
+- **should handle concurrent errors independently** – confirms that failures in one command do not affect others running at the same time.

--- a/docs/unit_tests/commandChain.md
+++ b/docs/unit_tests/commandChain.md
@@ -1,0 +1,6 @@
+# commandChain
+
+- **allows cd within allowed path** – verifies that chained commands containing a `cd` to a directory under the allowed paths list do not throw an error when validated.
+- **rejects cd to disallowed path** – ensures that attempting to `cd` into a directory outside the allowed paths causes validation to throw.
+- **rejects relative cd escaping allowed path** – checks that using a relative `cd ..` to leave the permitted directory is blocked.
+- **rejects blocked commands and arguments in chain** – confirms that blocked commands or arguments in a chained command cause validation to fail.

--- a/docs/unit_tests/commandSettings.md
+++ b/docs/unit_tests/commandSettings.md
@@ -1,0 +1,6 @@
+# commandSettings
+
+- **blocks dangerous operators when injection protection enabled** – ensures chained commands containing blocked shell operators are rejected when injection protection is active.
+- **allows command chaining when injection protection disabled** – verifies that disabling injection protection permits safe chained commands.
+- **allows changing directory outside allowed paths when restriction disabled** – confirms unrestricted working directory settings allow `cd` into disallowed paths.
+- **rejects changing directory outside allowed paths when restriction enabled** – checks that enabling the restriction prevents `cd` to directories beyond the allowed list.

--- a/docs/unit_tests/conditionalShells.md
+++ b/docs/unit_tests/conditionalShells.md
@@ -1,0 +1,5 @@
+# conditionalShells
+
+- **WSL only included with explicit configuration** – ensures the WSL shell is available only when the `wsl` shell is specified in configuration.
+- **backward compatibility with explicit shell list** – specifying all shells explicitly retains each shell entry in the loaded config.
+- **assigns validatePath and blockedOperators for shells** – enabled shells have default path validators and blocked operator lists populated.

--- a/docs/unit_tests/configMerge.md
+++ b/docs/unit_tests/configMerge.md
@@ -1,0 +1,5 @@
+# configMerge
+
+- **handles user config enabling subset of shells** – merging honours explicit enable/disable flags while keeping defaults for others.
+- **uses defaults when sections omitted** – missing global sections retain default values during merge.
+- **omitted shells retain defaults** – unspecified shells are included with default configuration.

--- a/docs/unit_tests/configNormalization.md
+++ b/docs/unit_tests/configNormalization.md
@@ -1,0 +1,5 @@
+# configNormalization
+
+- **loadConfig lower-cases and normalizes allowedPaths** – tests that loading configuration normalizes path casing and formats allowed paths consistently.
+- **loadConfig fills missing security settings with defaults** – verifies that any security settings not supplied in the config file are populated with default values.
+- **includeDefaultWSL setting is ignored (deprecated)** – ensures deprecated `includeDefaultWSL` in the security section does not enable WSL.

--- a/docs/unit_tests/configValidation.md
+++ b/docs/unit_tests/configValidation.md
@@ -1,0 +1,6 @@
+# configValidation
+
+- **throws for nonpositive maxCommandLength** – ensures validation rejects negative or zero maxCommandLength values.
+- **throws for enabled shell missing executable fields** – detects incomplete shell executable settings.
+- **throws for commandTimeout below 1** – enforces a minimum timeout of one second.
+- **passes for valid configuration** – confirms that a properly formed config does not throw.

--- a/docs/unit_tests/defaultConfig.md
+++ b/docs/unit_tests/defaultConfig.md
@@ -1,0 +1,3 @@
+# defaultConfig
+
+- **writes default config without validatePath functions** – verifies that the file created by `createDefaultConfig` omits runtime validation functions.

--- a/docs/unit_tests/directoryValidator.md
+++ b/docs/unit_tests/directoryValidator.md
@@ -1,0 +1,13 @@
+# directoryValidator
+
+- **should return valid for directories within allowed paths** – validates that directories contained in the allowed list are accepted.
+- **should return invalid for directories outside allowed paths** – checks that directories outside the whitelist are reported as invalid.
+- **should handle a mix of valid and invalid directories** – ensures that only the directories outside the allowed paths are listed as invalid.
+- **should handle GitBash style paths** – confirms that Unix-style paths like `/c/Users/...` are normalized and validated correctly.
+- **should consider invalid paths that throw during normalization** – tests that paths causing normalization errors are treated as invalid.
+- **should not throw for valid directories** – verifies that the throwing validator passes silently when all directories are allowed.
+- **should throw McpError for invalid directories** – checks that a custom error is thrown when invalid directories are found.
+- **should include invalid directories in error message** – ensures the thrown error lists each offending directory and allowed paths for clarity.
+- **should use singular wording for a single invalid directory** – tests that the error message uses singular phrasing when only one directory is invalid.
+- **should handle empty directories array** – confirms that validating an empty list of directories succeeds.
+- **should handle empty allowed paths array** – ensures that an empty allowed path configuration results in an error when validating directories.

--- a/docs/unit_tests/documentation/configExamples.md
+++ b/docs/unit_tests/documentation/configExamples.md
@@ -1,0 +1,7 @@
+# documentation/configExamples
+
+- **sample config is valid** – ensures the example config file in `config.sample.json` parses and loads without errors.
+- **all shells in examples have correct structure** – verifies that each shell definition in the example configs has the required fields like `enabled`, `executable`, and optional override sections.
+- **development config allows longer timeouts** – checks that the development example enables higher command timeouts.
+- **production config is restrictive** – confirms that the production example applies strict security limits such as short timeouts and many blocked commands.
+- **minimal config has minimal restrictions** – validates that the minimal example only enables the bare minimum shell and keeps restrictions loose.

--- a/docs/unit_tests/errorHandling.md
+++ b/docs/unit_tests/errorHandling.md
@@ -1,0 +1,6 @@
+# errorHandling
+
+- **should handle malformed JSON-RPC requests** – invalid tool parameters result in an `InvalidParams` error.
+- **should recover from shell crashes** – spawning a nonexistent shell command triggers an `InternalError` with details from the spawn failure.
+- **should throw error on invalid configuration** – loading a config with invalid values raises an exception.
+- **should fall back to defaults when config read fails** – if reading the config file throws, defaults are returned and an error is logged.

--- a/docs/unit_tests/getConfig.md
+++ b/docs/unit_tests/getConfig.md
@@ -1,0 +1,5 @@
+# getConfig
+
+- **createSerializableConfig returns structured configuration** – verifies that `createSerializableConfig` produces a plain object without functions and with the expected fields from the configuration.
+- **createSerializableConfig returns consistent config structure** – checks that the structure of the serialized config always contains the necessary keys for security and shell settings.
+- **get_config tool response format** – ensures the response format produced by the configuration tool is correctly shaped and contains the serialized config.

--- a/docs/unit_tests/gitbashWorkingDir.md
+++ b/docs/unit_tests/gitbashWorkingDir.md
@@ -1,0 +1,3 @@
+# gitbashWorkingDir
+
+- **converts Git Bash style path to Windows format for spawn cwd** – verifies that when executing a command through the Git Bash shell the working directory passed to `spawn` is converted from `/d/dir` style to `D:\dir` so child processes run in the correct location.

--- a/docs/unit_tests/handlers/resourceHandler.md
+++ b/docs/unit_tests/handlers/resourceHandler.md
@@ -1,0 +1,10 @@
+# handlers/resourceHandler
+
+- **lists all resource types** – checks that the ListResources handler returns URIs for configuration and security information when multiple shells are enabled.
+- **only lists enabled shells** – verifies that disabled shell entries are omitted from the list output.
+- **returns full configuration** – ensures that reading the `cli://config` URI yields the entire server configuration object.
+- **returns global configuration only** – confirms that requesting `cli://config/global` omits the per-shell section.
+- **returns resolved shell configuration** – validates that a shell-specific URI combines global and override settings.
+- **returns security information summary** – tests that `cli://info/security` summarizes enabled shells and key security settings.
+- **returns error for unknown resource** – ensures an unknown URI is rejected with an error.
+- **returns error for disabled shell resource** – verifies that requesting configuration for a disabled shell produces an error.

--- a/docs/unit_tests/handlers/toolListHandler.md
+++ b/docs/unit_tests/handlers/toolListHandler.md
@@ -1,0 +1,7 @@
+# handlers/toolListHandler
+
+- **lists only enabled shells in execute_command** – ensures the execute_command tool schema lists only shells that are enabled in the configuration.
+- **includes shell-specific settings in description** – verifies that the tool descriptions note per-shell settings such as command timeouts.
+- **indicates path format for each shell** – checks that descriptions mention the expected path style for each shell.
+- **validate_directories shows shell option when shells enabled** – confirms that the directory validation tool exposes a shell parameter when relevant.
+- **omits validate_directories when restrictions disabled** – ensures the tool list excludes the directory validation tool when working directory restrictions are off.

--- a/docs/unit_tests/initialDirConfig.md
+++ b/docs/unit_tests/initialDirConfig.md
@@ -1,0 +1,7 @@
+# initialDirConfig
+
+- **valid initialDir with restriction adds to allowedPaths** – verifies that a provided initial directory is normalized and added to `allowedPaths` when `restrictWorkingDirectory` is true.
+- **valid initialDir without restriction leaves allowedPaths unchanged** – ensures the path is normalized but not appended when restrictions are disabled.
+- **invalid initialDir logs warning and is unset** – an invalid path triggers a warning and the setting becomes `undefined`.
+- **initialDir omitted results in undefined** – confirms the default when no `initialDir` is specified.
+- **non-string initialDir logs warning and is unset** – non-string values produce a warning and are ignored.

--- a/docs/unit_tests/integration/endToEnd.md
+++ b/docs/unit_tests/integration/endToEnd.md
@@ -1,0 +1,3 @@
+# integration/endToEnd
+
+- **should execute shell command with proper isolation** – uses the helper server to run a command end‑to‑end and verifies the output and working directory metadata.

--- a/docs/unit_tests/integration/mcpProtocol.md
+++ b/docs/unit_tests/integration/mcpProtocol.md
@@ -1,0 +1,4 @@
+# integration/mcpProtocol
+
+- **should return configuration via get_config tool** – parses the JSON response and ensures required keys are present.
+- **should validate directories correctly** – calling the directory validation tool succeeds for allowed paths.

--- a/docs/unit_tests/integration/shellExecution.md
+++ b/docs/unit_tests/integration/shellExecution.md
@@ -1,0 +1,5 @@
+# integration/shellExecution
+
+- **should reject commands with blocked operators** – executing a command containing `;` results in an `McpError`.
+- **should enforce working directory restrictions** – commands fail when executed from disallowed directories.
+- **should execute when working directory allowed** – succeeds when the directory is permitted by the configuration.

--- a/docs/unit_tests/pathValidation.edge.md
+++ b/docs/unit_tests/pathValidation.edge.md
@@ -1,0 +1,6 @@
+# pathValidation.edge
+
+- **WSL converts Windows paths before validation** – ensures Windows style paths are converted to `/mnt/` form for checking.
+- **WSL rejects paths outside allowed list after conversion** – disallowed paths remain blocked even after conversion.
+- **GitBash accepts Windows and Unix style paths** – verifies both `C:\` and `/c/` formats are permitted when allowed.
+- **throws when allowedPaths empty** – validation fails if no allowed paths are configured.

--- a/docs/unit_tests/processManagement.md
+++ b/docs/unit_tests/processManagement.md
@@ -1,0 +1,6 @@
+# processManagement
+
+- **should terminate process on timeout** – ensures that a long-running command is killed after exceeding the configured timeout.
+- **should handle process spawn errors gracefully** – verifies that spawn failures throw a descriptive `McpError`.
+- **should propagate shell process errors** – checks that errors emitted by the spawned process reject the command.
+- **should clear timeout when process exits normally** – confirms that the timeout is cleared and the process is not killed when it finishes before the limit.

--- a/docs/unit_tests/server/serverImplementation.md
+++ b/docs/unit_tests/server/serverImplementation.md
@@ -1,0 +1,7 @@
+# server/serverImplementation
+
+- **pre-resolves enabled shell configurations** – ensures the server computes resolved settings for enabled shells at startup.
+- **lists only enabled shells** – verifies that helper methods return the correct list of active shells.
+- **uses initialDir from global config** – tests that a valid `initialDir` changes the server's starting working directory.
+- **validates CWD against global allowed paths** – checks that starting in a disallowed directory leaves the active working directory undefined.
+- **handles initializeWorkingDirectory with restrictWorkingDirectory** – confirms that invalid initial directories are ignored when restrictions are enabled.

--- a/docs/unit_tests/server/toolHandlers.md
+++ b/docs/unit_tests/server/toolHandlers.md
@@ -1,0 +1,5 @@
+# server/toolHandlers
+
+- **returns both configuration and resolved settings** – the get_config tool should provide raw configuration plus resolved shell settings.
+- **supports shell-specific validation** – validate_directories must apply allowed path rules per-shell when a shell argument is provided.
+- **validates against global allowed paths** – set_current_directory uses the global allowed list to decide if changing the active directory is permitted.

--- a/docs/unit_tests/serverCwdInitialization.md
+++ b/docs/unit_tests/serverCwdInitialization.md
@@ -1,0 +1,9 @@
+# serverCwdInitialization
+
+- **launch outside allowed paths leaves cwd undefined** – starting the server in a disallowed directory results in no active working directory.
+- **execute_command fails when cwd undefined** – commands without a workingDir return an error when no active directory is set.
+- **set_current_directory sets active cwd** – using the tool successfully changes the active directory and calls `process.chdir`.
+- **get_current_directory reports unset state** – retrieving the current directory before one is set returns a helpful message.
+- **initialDir sets active cwd when valid** – a valid `initialDir` is used at startup and becomes the active directory.
+- **initialDir chdir failure falls back to process.cwd()** – if changing to `initialDir` fails the server falls back to the process directory.
+- **initialDir not in allowedPaths leaves active cwd undefined** – when restrictions prevent using the configured `initialDir`, the active directory remains unset.

--- a/docs/unit_tests/testCleanup.md
+++ b/docs/unit_tests/testCleanup.md
@@ -1,0 +1,3 @@
+# testCleanup
+
+- **ensures no residual open handles between tests** – placeholder verification that global cleanup completes without warnings.

--- a/docs/unit_tests/toolDescription.details.md
+++ b/docs/unit_tests/toolDescription.details.md
@@ -1,0 +1,7 @@
+# toolDescription.details
+
+- **buildExecuteCommandDescription includes shell summaries and examples** – verifies that the detailed description lists each enabled shell with sample usage.
+- **buildExecuteCommandDescription notes path formats for all shells** – ensures path format hints for Windows, mixed, and Unix shells appear.
+- **buildValidateDirectoriesDescription describes shell specific mode** – confirms the shell-specific validation block is documented when enabled.
+- **buildValidateDirectoriesDescription without shell specific mode** – checks the simpler description when shell-specific validation is disabled.
+- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned.

--- a/docs/unit_tests/toolDescription.md
+++ b/docs/unit_tests/toolDescription.md
@@ -1,0 +1,7 @@
+# toolDescription
+
+- **generates correct description with all shells enabled** – checks that the tool description lists every enabled shell and includes example blocks for each.
+- **generates correct description with only cmd enabled** – verifies that the description includes only the CMD example when other shells are disabled.
+- **generates correct description with powershell and gitbash enabled** – ensures that only the relevant examples for enabled shells are present.
+- **handles empty allowed shells array** – confirms that an empty shell list results in a minimal description without examples.
+- **handles unknown shell names** – tests that unrecognized shell names appear in the header but no examples are generated.

--- a/docs/unit_tests/types/configTypes.md
+++ b/docs/unit_tests/types/configTypes.md
@@ -1,0 +1,10 @@
+# types/configTypes
+
+- **identifies WSL shell config** – confirms that the type guard detects objects with a wslConfig section.
+- **identifies non-WSL shell config** – ensures standard shell configs are not mistaken for WSL configs.
+- **handles undefined** – the guard should safely return false for undefined values.
+- **handles empty object** – verifies an empty object is not treated as a WSL config.
+- **identifies objects with wslConfig** – ensures the hasWslConfig helper recognizes objects containing a wslConfig property.
+- **identifies objects without wslConfig** – verifies the helper returns false when the property is missing.
+- **handles null and undefined** – checks that null or undefined values do not cause errors and return false.
+- **handles wslConfig that is not an object** – ensures the helper ignores non-object wslConfig values.

--- a/docs/unit_tests/utils/configMerger.md
+++ b/docs/unit_tests/utils/configMerger.md
@@ -1,0 +1,11 @@
+# utils/configMerger
+
+- **returns global config when no overrides** – verifies resolveShellConfiguration falls back to the global settings if a shell has none.
+- **merges security overrides** – ensures shell specific security settings override the global values while preserving unspecified options.
+- **appends blocked commands and arguments** – checks that extra blocked items are appended to the global lists.
+- **replaces blocked operators** – confirms shell overrides completely replace the blocked operator list.
+- **replaces paths config** – validates that path overrides substitute the global allowedPaths and initialDir.
+- **includes WSL config for WSL shells** – tests that wslConfig is carried into the resolved configuration.
+- **converts and merges Windows paths for WSL** – applyWslPathInheritance should convert global Windows paths to `/mnt/` form when inheritGlobalPaths is true.
+- **does not convert paths when inheritance disabled** – ensures Windows paths are not added for WSL shells if inheritGlobalPaths is false.
+- **uses specified mount point** – confirms that conversions honor a custom mountPoint.

--- a/docs/unit_tests/utils/toolSchemas.md
+++ b/docs/unit_tests/utils/toolSchemas.md
@@ -1,0 +1,7 @@
+# utils/toolSchemas
+
+- **generates schema with all enabled shells** – verifies that the execute_command schema includes every enabled shell.
+- **includes shell descriptions with settings** – ensures enum descriptions mention shell-specific timeout values and path formats.
+- **throws error when no shells enabled** – buildExecuteCommandSchema should reject an empty shell list.
+- **includes shell parameter when shells are enabled** – buildValidateDirectoriesSchema should expose the shell property when shells exist.
+- **excludes shell parameter when no shells enabled** – confirms the schema omits the shell field when validation is purely global.

--- a/docs/unit_tests/validation.md
+++ b/docs/unit_tests/validation.md
@@ -1,0 +1,31 @@
+# validation
+
+- **extractCommandName handles various formats** – covers numerous command string formats to make sure only the executable name is returned.
+- **extractCommandName is case insensitive** – validates that command extraction works regardless of case.
+- **isCommandBlocked identifies blocked commands** – ensures commands in the blocked list are detected even with paths or extensions.
+- **isCommandBlocked is case insensitive** – checks detection of blocked commands independent of case.
+- **isCommandBlocked handles different extensions** – tests blocked command detection across `.cmd`, `.bat`, and other extensions.
+- **isArgumentBlocked identifies blocked arguments** – verifies arguments in the blocked list are found.
+- **isArgumentBlocked is case insensitive for security** – ensures argument checks are case insensitive.
+- **isArgumentBlocked handles multiple arguments** – confirms any blocked argument in a list triggers detection.
+- **parseCommand handles basic commands** – parses simple commands and ensures arguments are split properly.
+- **parseCommand handles quoted arguments** – supports arguments wrapped in quotes.
+- **parseCommand handles paths with spaces** – validates parsing when the executable path contains spaces.
+- **parseCommand handles empty input** – returns empty command and args when given whitespace.
+- **parseCommand handles mixed quotes** – supports quotes with embedded spaces and key=value pairs.
+- **normalizeWindowsPath handles various formats** – converts a mix of Windows, Unix, and UNC style paths into canonical Windows format.
+- **normalizeWindowsPath removes redundant separators** – collapses duplicate slashes and backslashes.
+- **normalizeWindowsPath resolves relative segments** – resolves `..` segments in Windows style paths.
+- **normalizeWindowsPath resolves git bash style relative segments** – handles `/c/../` style paths used by Git Bash.
+- **normalizeWindowsPath handles drive-relative paths** – normalizes paths like `C:folder/file`.
+- **removes duplicates and normalizes paths** – ensures normalization removes duplicate allowed paths.
+- **removes nested subpaths** – verifies that nested allowed paths are collapsed to the parent path.
+- **keeps multiple top-level paths** – multiple unrelated allowed paths remain after normalization.
+- **isPathAllowed validates paths correctly** – checks standard cases of allowed and disallowed path validation.
+- **isPathAllowed handles trailing slashes correctly** – ensures trailing slashes in either path do not affect validation.
+- **isPathAllowed is case insensitive** – path checking disregards letter case.
+- **isPathAllowed supports UNC paths** – validates UNC network paths.
+- **validateWorkingDirectory throws for invalid paths** – ensures relative or disallowed working directories are rejected.
+- **validateShellOperators blocks dangerous operators** – verifies that blocked shell operators cause validation failure.
+- **validateShellOperators allows safe operators when configured** – ensures allowed operators do not throw.
+- **validateShellOperators respects shell config** – checks that shell-specific operator settings are honored.

--- a/docs/unit_tests/validation/context.md
+++ b/docs/unit_tests/validation/context.md
@@ -1,0 +1,3 @@
+# validation/context
+
+- **createValidationContext creates context with correct shell type flags** – ensures that the helper sets the boolean flags (isWindowsShell, isUnixShell, isWslShell) based on the provided shell name and configuration.

--- a/docs/unit_tests/validation/pathValidation.md
+++ b/docs/unit_tests/validation/pathValidation.md
@@ -1,0 +1,10 @@
+# validation/pathValidation
+
+- **normalizes Windows paths correctly** – tests that Windows-style paths are normalized for comparison.
+- **normalizes Unix paths correctly** – ensures Unix paths remain consistent when normalized.
+- **normalizes GitBash paths correctly** – converts `/c/` style paths to a Windows format for validation.
+- **validates Windows paths with Windows shell** – allowed directories pass and disallowed ones throw errors.
+- **validates WSL paths with WSL shell** – confirms that `/mnt/<drive>` paths are checked against allowed entries.
+- **validates GitBash paths with GitBash shell** – ensures GitBash-specific paths are accepted when within allowed paths.
+- **allows any path when restriction is disabled** – verifies disabling restrictWorkingDirectory bypasses checks.
+- **handles empty allowed paths** – when no paths are configured validation should fail with a helpful message.

--- a/docs/unit_tests/validation/shellSpecific.md
+++ b/docs/unit_tests/validation/shellSpecific.md
@@ -1,0 +1,8 @@
+# validation/shellSpecific
+
+- **blocks operators based on shell context** – verifies that dangerous shell operators like `&` or `;` are rejected when blocked for that shell.
+- **allows all operators if none are blocked** – ensures commands are accepted when the blocked list is empty.
+- **blocks commands based on shell context** – tests that listed command names are correctly detected and rejected per shell.
+- **normalizes command names for validation** – confirms that file extensions or paths do not bypass blocked command checks.
+- **blocks arguments based on shell context** – ensures that prohibited arguments are found regardless of position.
+- **handles simple argument patterns** – checks that only exact argument matches are blocked, not substrings.

--- a/docs/unit_tests/wsl.md
+++ b/docs/unit_tests/wsl.md
@@ -1,0 +1,10 @@
+# wsl
+
+- **`should execute a simple command via WSL emulator`** – verifies basic command execution using the emulator and checks output.
+- **`should handle commands that result in an error`** – ensures non‑zero exit codes are reported correctly.
+- **`should capture stderr output`** – confirms that stderr from the executed command is returned.
+- **`should block commands with prohibited shell operators`** – validates injection protection against operators like `;`.
+- **WSL Working Directory Validation**
+  - **`should execute command in valid WSL working directory when allowed`** – commands run when the workingDir matches an allowed WSL path.
+  - **`should reject command in invalid WSL working directory (different root)`** – disallows execution from a path on an unapproved drive.
+  - **`should reject command in invalid WSL working directory (disallowed suffix)`** – blocks paths not covered by any allowed entry.

--- a/docs/unit_tests/wsl/isWslPathAllowed.md
+++ b/docs/unit_tests/wsl/isWslPathAllowed.md
@@ -1,0 +1,3 @@
+# wsl/isWslPathAllowed
+
+- **matches allowed and disallowed paths including `/mnt/<drive>` conversion** – parameterized cases verify path allowance and drive mount handling.

--- a/docs/unit_tests/wsl/pathConversion.md
+++ b/docs/unit_tests/wsl/pathConversion.md
@@ -1,0 +1,6 @@
+# wsl/pathConversion
+
+- **convertWindowsToWslPath handles standard and mixed separators** – converts typical Windows paths, forward slashes and mixed separators to `/mnt/<drive>/` form.
+- **handles drive roots and trailing slashes** – correctly processes paths like `C:/` and `C:\\Users\\`.
+- **supports custom mount points and paths with spaces** – allows overriding the mount root and preserves spaces during conversion.
+- **returns non-Windows paths unchanged and rejects UNC paths** – Unix-style or relative paths pass through while UNC paths throw an error.

--- a/docs/unit_tests/wsl/pathResolution.md
+++ b/docs/unit_tests/wsl/pathResolution.md
@@ -1,0 +1,5 @@
+# wsl/pathResolution
+
+- **resolves allowed paths based on global and WSL-specific settings** – merges and converts Windows paths, respecting the `inheritGlobalPaths` flag.
+- **ensures unique results and warns about unsupported UNC paths** – duplicates are removed and a warning is logged when global paths cannot be converted.
+- **honors custom `wslMountPoint` values** – converted paths reflect the configured mount prefix.

--- a/docs/unit_tests/wsl/validateWslWorkingDirectory.md
+++ b/docs/unit_tests/wsl/validateWslWorkingDirectory.md
@@ -1,0 +1,5 @@
+# wsl/validateWslWorkingDirectory
+
+- **accepts valid WSL directories from global or shell-specific lists** – directories under resolved allowed paths are permitted.
+- **rejects directories outside the allowed set or with invalid format** – errors are thrown for disallowed roots, relative paths or Windows-style paths.
+- **supports custom mount points and ignores unsupported global UNC paths** – validation uses the configured mount prefix and logs warnings for skipped UNC paths.


### PR DESCRIPTION
## Summary
- document unit tests in `docs/unit_tests`
- add one markdown file per test file describing each test and its purpose

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fee63dcbc8320a65b25237b90b988