### PR TITLE
Update shell type identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The server uses an inheritance-based configuration system where global defaults 
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -258,7 +258,7 @@ If no configuration file is found, the server will use a default (restricted) co
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -266,7 +266,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -274,7 +274,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -356,7 +356,7 @@ Global settings provide defaults that apply to all shells unless overridden.
 #### Shell Configuration
 
 Each shell can be individually configured and can override global settings.
-Each shell entry must include a `type` field indicating the shell semantics. Valid values are `windows`, `unix`, `mixed` (Git Bash style), and `wsl`.
+Each shell entry must include a `type` field indicating the shell. Valid values are `powershell`, `cmd`, `gitbash`, and `wsl`.
 
 ##### Basic Shell Configuration
 
@@ -364,7 +364,7 @@ Each shell entry must include a `type` field indicating the shell semantics. Val
 {
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -381,7 +381,7 @@ Each shell entry must include a `type` field indicating the shell semantics. Val
 {
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -449,7 +449,7 @@ Example of inheritance in action:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "overrides": {
         "security": { "commandTimeout": 45 },
         "restrictions": { "blockedCommands": ["Remove-Item"] }

--- a/config.development.json
+++ b/config.development.json
@@ -31,7 +31,7 @@
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -44,7 +44,7 @@
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -52,7 +52,7 @@
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/config.examples/development.json
+++ b/config.examples/development.json
@@ -18,7 +18,7 @@
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "pwsh.exe",

--- a/config.examples/minimal.json
+++ b/config.examples/minimal.json
@@ -7,7 +7,7 @@
   },
     "shells": {
       "cmd": {
-        "type": "windows",
+        "type": "cmd",
         "enabled": true,
       "executable": {
         "command": "cmd.exe",

--- a/config.examples/production.json
+++ b/config.examples/production.json
@@ -37,7 +37,7 @@
   },
   "shells": {
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",

--- a/config.sample.json
+++ b/config.sample.json
@@ -43,7 +43,7 @@
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -51,7 +51,7 @@
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -59,7 +59,7 @@
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/config.secure.json
+++ b/config.secure.json
@@ -51,7 +51,7 @@
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -2,7 +2,7 @@
 
 This document provides practical examples of different configuration scenarios for the Windows CLI MCP Server.
 
-Each shell entry now requires a `type` property specifying the shell semantics (`windows`, `unix`, `mixed` or `wsl`).
+Each shell entry now requires a `type` property specifying the shell (`powershell`, `cmd`, `gitbash` or `wsl`).
 
 ## Basic Configurations
 
@@ -19,7 +19,7 @@ The simplest configuration that enables basic functionality:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -57,7 +57,7 @@ Configuration suitable for development work with multiple shells:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -65,7 +65,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -73,7 +73,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -119,7 +119,7 @@ Restrictive configuration for sensitive environments:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -170,7 +170,7 @@ Configuration that allows monitoring and logging:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -201,7 +201,7 @@ Configuration that only enables PowerShell with specific restrictions:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -296,7 +296,7 @@ Configuration supporting different environments with shell-specific overrides:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -311,8 +311,8 @@ Configuration supporting different environments with shell-specific overrides:
         }
       }
     },
-    "cmd": {
-      "type": "windows",
+   "cmd": {
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -327,8 +327,8 @@ Configuration supporting different environments with shell-specific overrides:
         }
       }
     },
-    "gitbash": {
-      "type": "mixed",
+   "gitbash": {
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -386,7 +386,7 @@ Configuration suitable for automated testing:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -399,7 +399,7 @@ Configuration suitable for automated testing:
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -407,7 +407,7 @@ Configuration suitable for automated testing:
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -244,6 +244,7 @@ Configuration optimized for WSL development:
   },
   "shells": {
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",
@@ -341,6 +342,7 @@ Configuration supporting different environments with shell-specific overrides:
       }
     },
     "wsl": {
+      "type": "wsl",
       "enabled": true,
       "executable": {
         "command": "wsl.exe",

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -303,13 +303,13 @@ A: Use the project's issue tracker:
 
 ### Q: Can I create custom shell configurations?
 
-A: Yes, you can add custom shells by specifying the executable and arguments. Each custom shell must also define a `type` field indicating whether it uses `windows`, `unix`, `mixed` or `wsl` semantics:
+A: Yes, you can add custom shells by specifying the executable and arguments. Each custom shell must also define a `type` field indicating the shell (`cmd`, `powershell`, `gitbash` or `wsl`):
 
 ```json
 {
   "shells": {
     "custom-bash": {
-      "type": "unix",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "/usr/bin/bash",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
@@ -11,6 +11,11 @@ export default {
       'ts-jest',
       {
         useESM: true,
+        tsconfig: {
+          module: 'ES2022',
+          target: 'ES2022',
+          moduleResolution: 'node',
+        },
       },
     ],
   },
@@ -20,5 +25,7 @@ export default {
     '/node_modules/',
     '/dist/',
     '/scripts/wsl.sh'
-  ]
+  ],
+  resolver: undefined,
+  globals: {}
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,7 +273,7 @@ class CLIServer {
           }
           // Pass original WSL path to emulator via environment variable
           envVars.WSL_ORIGINAL_PATH = workingDir;
-        } else if (shellConfig.type === 'mixed') {
+        } else if (shellConfig.type === 'gitbash') {
           // Normalize Git Bash paths like /c/foo to Windows format for spawn
           spawnCwd = normalizeWindowsPath(workingDir);
         }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -103,16 +103,16 @@ export interface ShellExecutableConfig {
 }
 
 /**
- * Supported shell semantics types
+ * Supported shell types
  */
-export type ShellType = 'windows' | 'unix' | 'mixed' | 'wsl';
+export type ShellType = 'cmd' | 'powershell' | 'gitbash' | 'wsl';
 
 /**
  * Base configuration for all shell types
  */
 export interface BaseShellConfig {
   /**
-   * The type of shell semantics (windows, unix, mixed or wsl)
+   * The type of shell (cmd, powershell, gitbash or wsl)
    */
   type: ShellType;
   /**
@@ -203,8 +203,8 @@ export interface ServerConfig {
  */
 export interface ResolvedShellConfig {
   /**
-   * The type of shell semantics
-   */
+ * The type of shell
+ */
   type: ShellType;
   /**
    * Whether this shell is enabled

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,7 +38,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   },
   shells: {
     powershell: {
-      type: 'windows',
+      type: 'powershell',
       enabled: true,
       executable: {
         command: 'powershell.exe',
@@ -47,7 +47,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       validatePath: (dir: string) => /^[a-zA-Z]:\\/.test(dir)
     },
     cmd: {
-      type: 'windows',
+      type: 'cmd',
       enabled: true,
       executable: {
         command: 'cmd.exe',
@@ -61,7 +61,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       }
     },
     gitbash: {
-      type: 'mixed',
+      type: 'gitbash',
       enabled: true,
       executable: {
         command: 'C:\\Program Files\\Git\\bin\\bash.exe',
@@ -203,7 +203,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
   // Add each shell, ensuring required properties are always set
   if (shouldIncludePowerShell) {
     const baseShell = defaultConfig.shells.powershell || {
-      type: 'windows',
+      type: 'powershell',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -225,7 +225,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeCmd) {
     const baseShell = defaultConfig.shells.cmd || {
-      type: 'windows',
+      type: 'cmd',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -247,7 +247,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeGitBash) {
     const baseShell = defaultConfig.shells.gitbash || {
-      type: 'mixed',
+      type: 'gitbash',
       enabled: false,
       executable: { command: '', args: [] }
     };

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -102,14 +102,14 @@ export function buildExecuteCommandDescription(
     }
     
     // Add path format information based on shell type
-    if (config.type === 'wsl' || config.type === 'unix') {
+    if (config.type === 'wsl') {
       lines.push(`- Path format: Unix-style (/home/user, /mnt/c/...)`);
-      if (config.type === 'wsl' && config.wslConfig?.inheritGlobalPaths) {
+      if (config.wslConfig?.inheritGlobalPaths) {
         lines.push(`- Inherits global Windows paths (converted to /mnt/...)`);
       }
-    } else if (config.type === 'windows') {
+    } else if (config.type === 'cmd' || config.type === 'powershell') {
       lines.push(`- Path format: Windows-style (C:\\Users\\...)`);
-    } else if (config.type === 'mixed') {
+    } else if (config.type === 'gitbash') {
       lines.push(`- Path format: Mixed (C:\\... or /c/...)`);
     }
     

--- a/src/utils/toolSchemas.ts
+++ b/src/utils/toolSchemas.ts
@@ -26,11 +26,11 @@ export function buildExecuteCommandSchema(
       const parts = [`${shell} shell`];
       parts.push(`timeout: ${config.security.commandTimeout}s`);
 
-      if (config.type === 'wsl' || config.type === 'unix') {
+      if (config.type === 'wsl') {
         parts.push('Unix paths');
-      } else if (config.type === 'windows') {
+      } else if (config.type === 'cmd' || config.type === 'powershell') {
         parts.push('Windows paths');
-      } else if (config.type === 'mixed') {
+      } else if (config.type === 'gitbash') {
         parts.push('Mixed paths');
       }
       

--- a/src/utils/validationContext.ts
+++ b/src/utils/validationContext.ts
@@ -18,8 +18,8 @@ export function createValidationContext(
   shellName: string,
   shellConfig: ResolvedShellConfig
 ): ValidationContext {
-  const isWindowsShell = shellConfig.type === 'windows';
-  const isUnixShell = shellConfig.type === 'unix' || shellConfig.type === 'wsl';
+  const isWindowsShell = shellConfig.type === 'cmd' || shellConfig.type === 'powershell';
+  const isUnixShell = shellConfig.type === 'gitbash' || shellConfig.type === 'wsl';
   const isWslShell = shellConfig.type === 'wsl';
   
   return {
@@ -37,6 +37,6 @@ export function createValidationContext(
 export function getExpectedPathFormat(context: ValidationContext): 'windows' | 'unix' | 'mixed' {
   if (context.isWindowsShell) return 'windows';
   if (context.isWslShell) return 'unix';
-  if (context.shellConfig.type === 'mixed') return 'mixed';
+  if (context.shellConfig.type === 'gitbash') return 'mixed';
   return 'unix';
 }

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -283,7 +283,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
-          type: 'windows',
+          type: 'cmd',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -338,7 +338,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
-          type: 'windows',
+          type: 'cmd',
           enabled: true,
           executable: {
             command: 'cmd.exe',

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -42,7 +42,7 @@ describe('get_config tool', () => {
     },
     shells: {
       powershell: {
-        type: 'windows',
+        type: 'powershell',
         enabled: true,
         executable: {
           command: 'powershell.exe',
@@ -55,7 +55,7 @@ describe('get_config tool', () => {
         }
       },
       cmd: {
-        type: 'windows',
+        type: 'cmd',
         enabled: true,
         executable: {
           command: 'cmd.exe',
@@ -68,7 +68,7 @@ describe('get_config tool', () => {
         }
       },
       gitbash: {
-        type: 'mixed',
+        type: 'gitbash',
         enabled: false,
         executable: {
           command: 'bash.exe',

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -39,6 +39,9 @@ export function buildTestConfig(overrides: DeepPartial<ServerConfig> = {}): Serv
     const shells = overrides.shells;
     Object.entries(shells).forEach(([key, shellConfig]) => {
       if (shellConfig) {
+        if (!(shellConfig as any).type) {
+          (shellConfig as any).type = key;
+        }
         (config.shells as any)[key] = shellConfig;
       }
     });
@@ -55,7 +58,7 @@ export function buildShellConfig(
   overrides: Partial<BaseShellConfig | WslShellConfig> = {}
 ): BaseShellConfig | WslShellConfig {
   const base: BaseShellConfig = {
-    type: shellType === 'wsl' ? 'wsl' : 'windows',
+    type: shellType === 'wsl' ? 'wsl' : 'cmd',
     enabled: true,
     executable: {
       command: 'test.exe',

--- a/tests/pathValidation.edge.test.ts
+++ b/tests/pathValidation.edge.test.ts
@@ -5,6 +5,7 @@ import type { ResolvedShellConfig } from '../src/types/config.js';
 
 function makeConfig(shell: 'wsl' | 'gitbash', allowed: string[]): ResolvedShellConfig {
   const base: ResolvedShellConfig = {
+    type: shell,
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: { maxCommandLength: 1000, commandTimeout: 30, enableInjectionProtection: true, restrictWorkingDirectory: true },

--- a/tests/toolDescription.details.test.ts
+++ b/tests/toolDescription.details.test.ts
@@ -6,8 +6,9 @@ import {
 } from '../src/utils/toolDescription.js';
 import type { ResolvedShellConfig } from '../src/types/config.js';
 
-function sampleConfig(name: string): ResolvedShellConfig {
+function sampleConfig(name: string, type: 'cmd' | 'powershell' | 'gitbash' | 'wsl' = 'cmd'): ResolvedShellConfig {
   return {
+    type,
     enabled: true,
     executable: { command: name, args: [] },
     security: {
@@ -24,8 +25,8 @@ function sampleConfig(name: string): ResolvedShellConfig {
 describe('Detailed Tool Descriptions', () => {
   test('buildExecuteCommandDescription includes shell summaries and examples', () => {
     const configs = new Map<string, ResolvedShellConfig>();
-    configs.set('cmd', sampleConfig('cmd.exe'));
-    configs.set('wsl', { ...sampleConfig('wsl.exe'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
+    configs.set('cmd', sampleConfig('cmd.exe', 'cmd'));
+    configs.set('wsl', { ...sampleConfig('wsl.exe', 'wsl'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
 
     const result = buildExecuteCommandDescription(configs);
 
@@ -38,10 +39,10 @@ describe('Detailed Tool Descriptions', () => {
 
   test('buildExecuteCommandDescription notes path formats for all shells', () => {
     const configs = new Map<string, ResolvedShellConfig>();
-    configs.set('powershell', sampleConfig('powershell.exe'));
-    configs.set('cmd', sampleConfig('cmd.exe'));
-    configs.set('gitbash', sampleConfig('bash.exe'));
-    configs.set('wsl', { ...sampleConfig('wsl.exe'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
+    configs.set('powershell', sampleConfig('powershell.exe', 'powershell'));
+    configs.set('cmd', sampleConfig('cmd.exe', 'cmd'));
+    configs.set('gitbash', sampleConfig('bash.exe', 'gitbash'));
+    configs.set('wsl', { ...sampleConfig('wsl.exe', 'wsl'), wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true } });
 
     const result = buildExecuteCommandDescription(configs);
 

--- a/tests/utils/toolSchemas.test.ts
+++ b/tests/utils/toolSchemas.test.ts
@@ -5,6 +5,7 @@ import type { ResolvedShellConfig } from '../../src/types/config.js';
 describe('Tool Schema Builders', () => {
   // Helper to create mock resolved shell configs
   const createMockConfig = (shellName: string, overrides: Partial<ResolvedShellConfig> = {}): ResolvedShellConfig => ({
+    type: shellName as any,
     enabled: true,
     executable: { command: `${shellName}.exe`, args: [] },
     security: {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -32,7 +32,7 @@ function createTestConfig(
   allowedPaths: string[] = []
 ): ResolvedShellConfig {
   return {
-    type: 'windows',
+    type: 'cmd',
     enabled: true,
     executable: {
       command: 'test',
@@ -370,7 +370,7 @@ describe('Path Validation', () => {
   test('validateWorkingDirectory handles GitBash paths properly', () => {
     // Using memory of GitBash style paths in the new config system
     const gitbashConfig = createTestConfig([], [], [], ['C:\\Users\\test', 'D:\\Projects']);
-    gitbashConfig.type = 'mixed';
+    gitbashConfig.type = 'gitbash';
     const gitbashContext = createTestContext('gitbash', gitbashConfig);
     
     // GitBash paths format should be properly converted and validated

--- a/tests/validation/context.test.ts
+++ b/tests/validation/context.test.ts
@@ -5,7 +5,7 @@ import { ResolvedShellConfig } from '../../src/types/config';
 // Helper to create mock shell configs
 function createMockShellConfig(overrides: Partial<ResolvedShellConfig> = {}): ResolvedShellConfig {
   return {
-    type: 'windows',
+    type: 'cmd',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {
@@ -36,7 +36,7 @@ describe('ValidationContext', () => {
     expect(cmdContext.isWslShell).toBe(false);
     
     // Unix shell (gitbash)
-  const gitbashContext = createValidationContext('gitbash', createMockShellConfig({ type: 'mixed' }));
+  const gitbashContext = createValidationContext('gitbash', createMockShellConfig({ type: 'gitbash' }));
     expect(gitbashContext.isWindowsShell).toBe(false);
     expect(gitbashContext.isUnixShell).toBe(true);
     expect(gitbashContext.isWslShell).toBe(false);

--- a/tests/validation/pathValidation.test.ts
+++ b/tests/validation/pathValidation.test.ts
@@ -7,7 +7,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 // Helper to create mock config
 function createMockConfig(
   overrides: Partial<ResolvedShellConfig> = {},
-  allowedPaths: string[] = ['C\\\\Windows', 'C\\\\Users']
+  allowedPaths: string[] = ['C:\\Windows', 'C:\\Users']  // Fixed: Use proper Windows paths
 ): ResolvedShellConfig {
   return {
     type: 'cmd',
@@ -97,7 +97,8 @@ describe('Path Validation', () => {
     });
 
     test('validates GitBash paths with GitBash shell', () => {
-      const context = createValidationContext('gitbash', createMockConfig({ type: 'gitbash' }));
+      // Fixed: Use proper Windows paths that will be converted to Git Bash format for comparison
+      const context = createValidationContext('gitbash', createMockConfig({ type: 'gitbash' }, ['C:\\Windows', 'C:\\Users']));
       
       // Valid GitBash paths should not throw - use /c/ format which is properly recognized
       expect(() => validateWorkingDirectory('/c/Windows', context)).not.toThrow();

--- a/tests/validation/shellSpecific.test.ts
+++ b/tests/validation/shellSpecific.test.ts
@@ -16,7 +16,7 @@ function createMockShellConfig(
   blockedOps: string[] = ['&', '|', ';']
 ): ResolvedShellConfig {
   return {
-    type: shellName === 'wsl' ? 'wsl' : (shellName === 'gitbash' ? 'mixed' : 'windows'),
+    type: shellName as any,
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {

--- a/tests/wsl/pathConversion.test.ts
+++ b/tests/wsl/pathConversion.test.ts
@@ -74,6 +74,7 @@ describe('convertWindowsToWslPath', () => {
 
 describe('validateWslPath with Windows drives', () => {
   const baseConfig: ResolvedShellConfig = {
+    type: 'wsl',
     enabled: true,
     executable: { command: 'wsl.exe', args: [] },
     security: {

--- a/tests/wsl/pathResolution.test.ts
+++ b/tests/wsl/pathResolution.test.ts
@@ -4,6 +4,7 @@ import { createValidationContext } from '../../src/utils/validationContext.js';
 import type { ResolvedShellConfig } from '../../src/types/config.js';
 
 const baseResolved: Readonly<ResolvedShellConfig> = {
+  type: 'wsl',
   enabled: true,
   executable: { command: 'wsl.exe', args: [] },
   security: {


### PR DESCRIPTION
## Summary
- change shell `type` fields to be specific to each shell
- adjust configs, docs and code for new types
- update test helpers and expectations

## Testing
- `npm test --silent` *(fails: Working directory must be within allowed paths)*

------
https://chatgpt.com/codex/tasks/task_e_686035b829d88320945f2d31aa743991