### PR TITLE
Align shell type fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The server uses an inheritance-based configuration system where global defaults 
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -258,7 +258,7 @@ If no configuration file is found, the server will use a default (restricted) co
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -266,7 +266,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -274,7 +274,7 @@ If no configuration file is found, the server will use a default (restricted) co
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -356,7 +356,7 @@ Global settings provide defaults that apply to all shells unless overridden.
 #### Shell Configuration
 
 Each shell can be individually configured and can override global settings.
-Each shell entry must include a `type` field indicating the shell semantics. Valid values are `windows`, `unix`, `mixed` (Git Bash style), and `wsl`.
+Each shell entry must include a `type` field indicating the shell semantics. Valid values are `cmd`, `powershell`, `gitbash` and `wsl`.
 
 ##### Basic Shell Configuration
 
@@ -364,7 +364,7 @@ Each shell entry must include a `type` field indicating the shell semantics. Val
 {
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -381,7 +381,7 @@ Each shell entry must include a `type` field indicating the shell semantics. Val
 {
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -449,7 +449,7 @@ Example of inheritance in action:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "overrides": {
         "security": { "commandTimeout": 45 },
         "restrictions": { "blockedCommands": ["Remove-Item"] }

--- a/config.development.json
+++ b/config.development.json
@@ -31,7 +31,7 @@
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -44,7 +44,7 @@
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -52,7 +52,7 @@
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/config.examples/development.json
+++ b/config.examples/development.json
@@ -7,22 +7,33 @@
       "restrictWorkingDirectory": true
     },
     "restrictions": {
-      "blockedCommands": ["format", "shutdown"],
-      "blockedArguments": ["--system"],
+      "blockedCommands": [
+        "format",
+        "shutdown"
+      ],
+      "blockedArguments": [
+        "--system"
+      ],
       "blockedOperators": []
     },
     "paths": {
-      "allowedPaths": ["C:\\Dev", "D:\\Projects"],
+      "allowedPaths": [
+        "C:\\Dev",
+        "D:\\Projects"
+      ],
       "initialDir": "C:\\Dev"
     }
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "pwsh.exe",
-        "args": ["-NoProfile", "-Command"]
+        "args": [
+          "-NoProfile",
+          "-Command"
+        ]
       },
       "overrides": {
         "security": {
@@ -35,7 +46,9 @@
       "enabled": true,
       "executable": {
         "command": "wsl.exe",
-        "args": ["-e"]
+        "args": [
+          "-e"
+        ]
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
@@ -50,7 +63,11 @@
           "commandTimeout": 600
         },
         "paths": {
-          "allowedPaths": ["/home/dev", "/var/www", "/opt"]
+          "allowedPaths": [
+            "/home/dev",
+            "/var/www",
+            "/opt"
+          ]
         }
       }
     }

--- a/config.examples/minimal.json
+++ b/config.examples/minimal.json
@@ -5,13 +5,15 @@
       "enableInjectionProtection": true
     }
   },
-    "shells": {
-      "cmd": {
-        "type": "windows",
-        "enabled": true,
+  "shells": {
+    "cmd": {
+      "type": "cmd",
+      "enabled": true,
       "executable": {
         "command": "cmd.exe",
-        "args": ["/c"]
+        "args": [
+          "/c"
+        ]
       }
     }
   }

--- a/config.examples/production.json
+++ b/config.examples/production.json
@@ -8,47 +8,93 @@
     },
     "restrictions": {
       "blockedCommands": [
-        "format", "del", "rm", "rmdir", "rd",
-        "shutdown", "restart", "reboot",
-        "reg", "regedit", "regedt32",
-        "net", "netsh", "netstat",
-        "taskkill", "tasklist",
-        "sc", "wmic",
-        "bcdedit", "diskpart",
-        "cipher", "sfc",
-        "powershell", "pwsh", "cmd", "bash", "sh"
+        "format",
+        "del",
+        "rm",
+        "rmdir",
+        "rd",
+        "shutdown",
+        "restart",
+        "reboot",
+        "reg",
+        "regedit",
+        "regedt32",
+        "net",
+        "netsh",
+        "netstat",
+        "taskkill",
+        "tasklist",
+        "sc",
+        "wmic",
+        "bcdedit",
+        "diskpart",
+        "cipher",
+        "sfc",
+        "powershell",
+        "pwsh",
+        "cmd",
+        "bash",
+        "sh"
       ],
       "blockedArguments": [
-        "--exec", "-e", "/c", "-c",
-        "-enc", "-encodedcommand",
-        "-command", "-file",
-        "--interactive", "-i",
-        "--login", "-l",
-        "--system", "-s",
-        "--force", "-f",
-        "--recursive", "-r", "-rf"
+        "--exec",
+        "-e",
+        "/c",
+        "-c",
+        "-enc",
+        "-encodedcommand",
+        "-command",
+        "-file",
+        "--interactive",
+        "-i",
+        "--login",
+        "-l",
+        "--system",
+        "-s",
+        "--force",
+        "-f",
+        "--recursive",
+        "-r",
+        "-rf"
       ],
-      "blockedOperators": ["&", "|", ";", "`", "$(", "||", "&&", ">", ">>", "<"]
+      "blockedOperators": [
+        "&",
+        "|",
+        ";",
+        "`",
+        "$(",
+        "||",
+        "&&",
+        ">",
+        ">>",
+        "<"
+      ]
     },
     "paths": {
-      "allowedPaths": ["C:\\SafeScripts"],
+      "allowedPaths": [
+        "C:\\SafeScripts"
+      ],
       "initialDir": "C:\\SafeScripts"
     }
   },
   "shells": {
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
-        "args": ["/c"]
+        "args": [
+          "/c"
+        ]
       },
       "overrides": {
         "security": {
           "maxCommandLength": 200
         },
         "restrictions": {
-          "blockedCommands": ["*"]
+          "blockedCommands": [
+            "*"
+          ]
         }
       }
     }

--- a/config.sample.json
+++ b/config.sample.json
@@ -33,37 +33,53 @@
         "--login",
         "--system"
       ],
-      "blockedOperators": ["&", "|", ";", "`"]
+      "blockedOperators": [
+        "&",
+        "|",
+        ";",
+        "`"
+      ]
     },
     "paths": {
-      "allowedPaths": ["C:\\Users\\YourUsername", "C:\\Projects"],
+      "allowedPaths": [
+        "C:\\Users\\YourUsername",
+        "C:\\Projects"
+      ],
       "initialDir": null,
       "restrictWorkingDirectory": true
     }
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
-        "args": ["-NoProfile", "-NonInteractive", "-Command"]
+        "args": [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command"
+        ]
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
-        "args": ["/c"]
+        "args": [
+          "/c"
+        ]
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
-        "args": ["-c"]
+        "args": [
+          "-c"
+        ]
       }
     }
   }

--- a/config.secure.json
+++ b/config.secure.json
@@ -42,20 +42,37 @@
         "--admin",
         "sudo"
       ],
-      "blockedOperators": ["&", "|", ";", "`", "&&", "||", ">>", ">"]
+      "blockedOperators": [
+        "&",
+        "|",
+        ";",
+        "`",
+        "&&",
+        "||",
+        ">>",
+        ">"
+      ]
     },
     "paths": {
-      "allowedPaths": ["C:\\SecureWorkspace"],
+      "allowedPaths": [
+        "C:\\SecureWorkspace"
+      ],
       "initialDir": "C:\\SecureWorkspace"
     }
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
-        "args": ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Restricted", "-Command"]
+        "args": [
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Restricted",
+          "-Command"
+        ]
       },
       "overrides": {
         "security": {

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -2,7 +2,7 @@
 
 This document provides practical examples of different configuration scenarios for the Windows CLI MCP Server.
 
-Each shell entry now requires a `type` property specifying the shell semantics (`windows`, `unix`, `mixed` or `wsl`).
+Each shell entry now requires a `type` property specifying the shell semantics (`cmd`, `powershell`, `gitbash` or `wsl`).
 
 ## Basic Configurations
 
@@ -19,7 +19,7 @@ The simplest configuration that enables basic functionality:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -57,7 +57,7 @@ Configuration suitable for development work with multiple shells:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -65,7 +65,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -73,7 +73,7 @@ Configuration suitable for development work with multiple shells:
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -119,7 +119,7 @@ Restrictive configuration for sensitive environments:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -170,7 +170,7 @@ Configuration that allows monitoring and logging:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -201,7 +201,7 @@ Configuration that only enables PowerShell with specific restrictions:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -296,7 +296,7 @@ Configuration supporting different environments with shell-specific overrides:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -312,7 +312,7 @@ Configuration supporting different environments with shell-specific overrides:
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -328,7 +328,7 @@ Configuration supporting different environments with shell-specific overrides:
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
@@ -386,7 +386,7 @@ Configuration suitable for automated testing:
   },
   "shells": {
     "powershell": {
-      "type": "windows",
+      "type": "powershell",
       "enabled": true,
       "executable": {
         "command": "powershell.exe",
@@ -399,7 +399,7 @@ Configuration suitable for automated testing:
       }
     },
     "cmd": {
-      "type": "windows",
+      "type": "cmd",
       "enabled": true,
       "executable": {
         "command": "cmd.exe",
@@ -407,7 +407,7 @@ Configuration suitable for automated testing:
       }
     },
     "gitbash": {
-      "type": "mixed",
+      "type": "gitbash",
       "enabled": true,
       "executable": {
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -303,7 +303,7 @@ A: Use the project's issue tracker:
 
 ### Q: Can I create custom shell configurations?
 
-A: Yes, you can add custom shells by specifying the executable and arguments. Each custom shell must also define a `type` field indicating whether it uses `windows`, `unix`, `mixed` or `wsl` semantics:
+A: Yes, you can add custom shells by specifying the executable and arguments. Each custom shell must also define a `type` field indicating whether it uses `cmd`, `powershell`, `gitbash` or `wsl` semantics:
 
 ```json
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,7 +273,7 @@ class CLIServer {
           }
           // Pass original WSL path to emulator via environment variable
           envVars.WSL_ORIGINAL_PATH = workingDir;
-        } else if (shellConfig.type === 'mixed') {
+        } else if (shellConfig.type === 'gitbash') {
           // Normalize Git Bash paths like /c/foo to Windows format for spawn
           spawnCwd = normalizeWindowsPath(workingDir);
         }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -105,14 +105,14 @@ export interface ShellExecutableConfig {
 /**
  * Supported shell semantics types
  */
-export type ShellType = 'windows' | 'unix' | 'mixed' | 'wsl';
+export type ShellType = 'cmd' | 'powershell' | 'gitbash' | 'wsl';
 
 /**
  * Base configuration for all shell types
  */
 export interface BaseShellConfig {
   /**
-   * The type of shell semantics (windows, unix, mixed or wsl)
+  * The type of shell semantics (cmd, powershell, gitbash or wsl)
    */
   type: ShellType;
   /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,7 +38,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   },
   shells: {
     powershell: {
-      type: 'windows',
+      type: 'powershell',
       enabled: true,
       executable: {
         command: 'powershell.exe',
@@ -47,7 +47,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       validatePath: (dir: string) => /^[a-zA-Z]:\\/.test(dir)
     },
     cmd: {
-      type: 'windows',
+      type: 'cmd',
       enabled: true,
       executable: {
         command: 'cmd.exe',
@@ -61,7 +61,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       }
     },
     gitbash: {
-      type: 'mixed',
+      type: 'gitbash',
       enabled: true,
       executable: {
         command: 'C:\\Program Files\\Git\\bin\\bash.exe',
@@ -203,7 +203,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
   // Add each shell, ensuring required properties are always set
   if (shouldIncludePowerShell) {
     const baseShell = defaultConfig.shells.powershell || {
-      type: 'windows',
+      type: 'powershell',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -225,7 +225,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeCmd) {
     const baseShell = defaultConfig.shells.cmd || {
-      type: 'windows',
+      type: 'cmd',
       enabled: false,
       executable: { command: '', args: [] }
     };
@@ -247,7 +247,7 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
 
   if (shouldIncludeGitBash) {
     const baseShell = defaultConfig.shells.gitbash || {
-      type: 'mixed',
+      type: 'gitbash',
       enabled: false,
       executable: { command: '', args: [] }
     };

--- a/src/utils/pathValidation.ts
+++ b/src/utils/pathValidation.ts
@@ -22,7 +22,7 @@ export function normalizePathForShell(inputPath: string, context: ValidationCont
       }
       return inputPath.replace(/\\/g, '/');
       
-    case 'mixed':
+    case 'gitbash':
       // Git Bash: Try to determine format and normalize accordingly
       if (inputPath.match(/^[A-Z]:\\/i) || inputPath.includes('\\')) {
         return normalizeWindowsPath(inputPath);
@@ -63,7 +63,7 @@ export function validateWorkingDirectory(
   } else if (context.isWindowsShell) {
     validateWindowsPath(normalizedDir, allowedPaths, context);
   } else {
-    // Git Bash or other mixed format shells
+    // Git Bash or other mixed-format shells
     validateMixedPath(normalizedDir, allowedPaths, context);
   }
 }
@@ -131,7 +131,7 @@ function validateWindowsPath(
 }
 
 /**
- * Validate mixed format paths (Git Bash)
+ * Validate mixed-format paths (Git Bash)
  */
 function validateMixedPath(
   dir: string,

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -102,14 +102,14 @@ export function buildExecuteCommandDescription(
     }
     
     // Add path format information based on shell type
-    if (config.type === 'wsl' || config.type === 'unix') {
+    if (config.type === 'wsl') {
       lines.push(`- Path format: Unix-style (/home/user, /mnt/c/...)`);
       if (config.type === 'wsl' && config.wslConfig?.inheritGlobalPaths) {
         lines.push(`- Inherits global Windows paths (converted to /mnt/...)`);
       }
-    } else if (config.type === 'windows') {
+    } else if (config.type === 'cmd' || config.type === 'powershell') {
       lines.push(`- Path format: Windows-style (C:\\Users\\...)`);
-    } else if (config.type === 'mixed') {
+    } else if (config.type === 'gitbash') {
       lines.push(`- Path format: Mixed (C:\\... or /c/...)`);
     }
     

--- a/src/utils/toolSchemas.ts
+++ b/src/utils/toolSchemas.ts
@@ -26,11 +26,11 @@ export function buildExecuteCommandSchema(
       const parts = [`${shell} shell`];
       parts.push(`timeout: ${config.security.commandTimeout}s`);
 
-      if (config.type === 'wsl' || config.type === 'unix') {
+      if (config.type === 'wsl') {
         parts.push('Unix paths');
-      } else if (config.type === 'windows') {
+      } else if (config.type === 'cmd' || config.type === 'powershell') {
         parts.push('Windows paths');
-      } else if (config.type === 'mixed') {
+      } else if (config.type === 'gitbash') {
         parts.push('Mixed paths');
       }
       

--- a/src/utils/validationContext.ts
+++ b/src/utils/validationContext.ts
@@ -18,8 +18,9 @@ export function createValidationContext(
   shellName: string,
   shellConfig: ResolvedShellConfig
 ): ValidationContext {
-  const isWindowsShell = shellConfig.type === 'windows';
-  const isUnixShell = shellConfig.type === 'unix' || shellConfig.type === 'wsl';
+  const isWindowsShell =
+    shellConfig.type === 'cmd' || shellConfig.type === 'powershell';
+  const isUnixShell = shellConfig.type === 'gitbash' || shellConfig.type === 'wsl';
   const isWslShell = shellConfig.type === 'wsl';
   
   return {
@@ -37,6 +38,6 @@ export function createValidationContext(
 export function getExpectedPathFormat(context: ValidationContext): 'windows' | 'unix' | 'mixed' {
   if (context.isWindowsShell) return 'windows';
   if (context.isWslShell) return 'unix';
-  if (context.shellConfig.type === 'mixed') return 'mixed';
+  if (context.shellConfig.type === 'gitbash') return 'mixed';
   return 'unix';
 }

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -283,7 +283,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
-          type: 'windows',
+          type: 'cmd',
           enabled: true,
           executable: {
             command: 'cmd.exe',
@@ -338,7 +338,7 @@ describe('Shell Config Resolution', () => {
       },
       shells: {
         cmd: {
-          type: 'windows',
+          type: 'cmd',
           enabled: true,
           executable: {
             command: 'cmd.exe',

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -42,7 +42,7 @@ describe('get_config tool', () => {
     },
     shells: {
       powershell: {
-        type: 'windows',
+        type: 'powershell',
         enabled: true,
         executable: {
           command: 'powershell.exe',
@@ -55,7 +55,7 @@ describe('get_config tool', () => {
         }
       },
       cmd: {
-        type: 'windows',
+        type: 'cmd',
         enabled: true,
         executable: {
           command: 'cmd.exe',
@@ -68,7 +68,7 @@ describe('get_config tool', () => {
         }
       },
       gitbash: {
-        type: 'mixed',
+        type: 'gitbash',
         enabled: false,
         executable: {
           command: 'bash.exe',

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -55,7 +55,7 @@ export function buildShellConfig(
   overrides: Partial<BaseShellConfig | WslShellConfig> = {}
 ): BaseShellConfig | WslShellConfig {
   const base: BaseShellConfig = {
-    type: shellType === 'wsl' ? 'wsl' : 'windows',
+    type: shellType === 'wsl' ? 'wsl' : 'cmd',
     enabled: true,
     executable: {
       command: 'test.exe',

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -32,7 +32,7 @@ function createTestConfig(
   allowedPaths: string[] = []
 ): ResolvedShellConfig {
   return {
-    type: 'windows',
+    type: 'cmd',
     enabled: true,
     executable: {
       command: 'test',
@@ -370,7 +370,7 @@ describe('Path Validation', () => {
   test('validateWorkingDirectory handles GitBash paths properly', () => {
     // Using memory of GitBash style paths in the new config system
     const gitbashConfig = createTestConfig([], [], [], ['C:\\Users\\test', 'D:\\Projects']);
-    gitbashConfig.type = 'mixed';
+    gitbashConfig.type = 'gitbash';
     const gitbashContext = createTestContext('gitbash', gitbashConfig);
     
     // GitBash paths format should be properly converted and validated

--- a/tests/validation/context.test.ts
+++ b/tests/validation/context.test.ts
@@ -5,7 +5,7 @@ import { ResolvedShellConfig } from '../../src/types/config';
 // Helper to create mock shell configs
 function createMockShellConfig(overrides: Partial<ResolvedShellConfig> = {}): ResolvedShellConfig {
   return {
-    type: 'windows',
+    type: 'cmd',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {
@@ -36,7 +36,7 @@ describe('ValidationContext', () => {
     expect(cmdContext.isWslShell).toBe(false);
     
     // Unix shell (gitbash)
-  const gitbashContext = createValidationContext('gitbash', createMockShellConfig({ type: 'mixed' }));
+  const gitbashContext = createValidationContext('gitbash', createMockShellConfig({ type: 'gitbash' }));
     expect(gitbashContext.isWindowsShell).toBe(false);
     expect(gitbashContext.isUnixShell).toBe(true);
     expect(gitbashContext.isWslShell).toBe(false);

--- a/tests/validation/pathValidation.test.ts
+++ b/tests/validation/pathValidation.test.ts
@@ -7,7 +7,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 // Helper to create mock config
 function createMockConfig(allowedPaths: string[] = ['C:\\Windows', 'C:\\Users']): ResolvedShellConfig {
   return {
-    type: 'windows',
+    type: 'cmd',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {
@@ -52,7 +52,7 @@ describe('Path Validation', () => {
     });
 
     test('normalizes GitBash paths correctly', () => {
-      const context = createValidationContext('gitbash', createMockConfig({ type: 'mixed' }));
+      const context = createValidationContext('gitbash', createMockConfig({ type: 'gitbash' }));
       
       const normalizedGitBashPath = normalizePathForShell('/c/Windows/System32', context);
       // The actual normalization might differ from test expectations, so check key parts
@@ -94,7 +94,7 @@ describe('Path Validation', () => {
     });
 
     test('validates GitBash paths with GitBash shell', () => {
-      const context = createValidationContext('gitbash', createMockConfig({ type: 'mixed' }));
+      const context = createValidationContext('gitbash', createMockConfig({ type: 'gitbash' }));
       
       // Valid GitBash paths should not throw - use /c/ format which is properly recognized
       expect(() => validateWorkingDirectory('/c/Windows', context)).not.toThrow();

--- a/tests/validation/shellSpecific.test.ts
+++ b/tests/validation/shellSpecific.test.ts
@@ -16,7 +16,14 @@ function createMockShellConfig(
   blockedOps: string[] = ['&', '|', ';']
 ): ResolvedShellConfig {
   return {
-    type: shellName === 'wsl' ? 'wsl' : (shellName === 'gitbash' ? 'mixed' : 'windows'),
+    type:
+      shellName === 'wsl'
+        ? 'wsl'
+        : shellName === 'gitbash'
+        ? 'gitbash'
+        : shellName === 'powershell'
+        ? 'powershell'
+        : 'cmd',
     enabled: true,
     executable: { command: 'test.exe', args: [] },
     security: {


### PR DESCRIPTION
## Summary
- change valid shell type values
- update default configs and docs
- adjust shell logic and config merging
- update tests

## Testing
- `npm test` *(fails: MCP error -32600: Working directory must be an absolute path)*

------
https://chatgpt.com/codex/tasks/task_e_686035b829d88320945f2d31aa743991