### PR TITLE
Fix gitbash Windows working directory handling

### DIFF
--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -38,6 +38,7 @@ Each shell expects paths in specific formats:
 # Both formats work
 "workingDir": "C:\\Projects\\MyApp"
 "workingDir": "/c/Projects/MyApp"
+"workingDir": "d:\\Projects\\MyApp" # lowercase drive letters also supported
 ```
 
 ## Shell Usage Examples

--- a/docs/unit_tests/pathValidation.edge.md
+++ b/docs/unit_tests/pathValidation.edge.md
@@ -2,5 +2,6 @@
 
 - **WSL converts Windows paths before validation** – ensures Windows style paths are converted to `/mnt/` form for checking.
 - **WSL rejects paths outside allowed list after conversion** – disallowed paths remain blocked even after conversion.
-- **GitBash accepts Windows and Unix style paths** – verifies both `C:\` and `/c/` formats are permitted when allowed.
+- **GitBash accepts Windows and Unix style paths** – verifies both `C:\\` and `/c/` formats are permitted when allowed.
+- **handles lowercase drive letters for Windows paths** – ensures Git Bash accepts `d:\\foo` when the allowed list contains `D:\\foo`.
 - **throws when allowedPaths empty** – validation fails if no allowed paths are configured.

--- a/src/utils/pathValidation.ts
+++ b/src/utils/pathValidation.ts
@@ -132,7 +132,8 @@ function validateUnixPath(
   context: ValidationContext
 ): void {
   // Git Bash can use both Windows and Unix paths
-  const isWindowsFormat = /^[A-Z]:[\\\/]/i.test(dir) || dir.includes('\\');
+  const isWindowsFormat =
+    path.win32.isAbsolute(dir) || /^[A-Za-z]:/.test(dir) || dir.includes('\\');
   const isUnixFormat = dir.startsWith('/');
   
   if (!isWindowsFormat && !isUnixFormat) {

--- a/tests/pathValidation.edge.test.ts
+++ b/tests/pathValidation.edge.test.ts
@@ -37,6 +37,11 @@ describe('validateWorkingDirectory edge cases', () => {
     expect(() => validateWorkingDirectory('/c/Users', ctx)).not.toThrow();
     expect(() => validateWorkingDirectory('C:\\Users', ctx)).not.toThrow();
   });
+  test('GitBash accepts lowercase drive letter paths', () => {
+    const cfg = makeConfig('gitbash', ['D:\\Projects']);
+    const ctx = createValidationContext('gitbash', cfg);
+    expect(() => validateWorkingDirectory('d:\\Projects', ctx)).not.toThrow();
+  });
   test("GitBash converts allowed Unix paths to Windows for comparison", () => {
     const cfg = makeConfig("gitbash", ["/c/Allowed"]);
     const ctx = createValidationContext("gitbash", cfg);


### PR DESCRIPTION
## Summary
- improve Windows path detection for Git Bash
- document lowercase drive usage
- note lowercase drive test in docs
- test lowercase drive handling for Git Bash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686116b92698832084d69402d0a799a1