### PR TITLE
Implement initialDir CLI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ To get started with configuration:
    npx wcli0 --init-config ./my-config.json
    ```
 
+   The server also accepts an `--initialDir` flag to override the initial
+   working directory defined in your configuration file:
+
+   ```bash
+   npx wcli0 --config ./my-config.json --initialDir /path/to/start
+   ```
+
 3. **Update your Claude Desktop configuration** to use your config file:
 
    ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import path from 'path';
 import { buildToolDescription } from './utils/toolDescription.js';
 import { buildExecuteCommandSchema, buildValidateDirectoriesSchema } from './utils/toolSchemas.js';
 import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, buildGetConfigDescription } from './utils/toolDescription.js';
-import { loadConfig, createDefaultConfig, getResolvedShellConfig } from './utils/config.js';
+import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig } from './types/config.js';
 import { fileURLToPath } from 'url';
@@ -68,6 +68,10 @@ const parseArgs = async () => {
     .option('init-config', {
       type: 'string',
       description: 'Create a default config file at the specified path'
+    })
+    .option('initialDir', {
+      type: 'string',
+      description: 'Initial working directory (overrides config)'
     })
     .help()
     .parse();
@@ -896,7 +900,10 @@ const main = async () => {
 
     // Load configuration
     const config = loadConfig(args.config);
-    
+
+    // Apply command line override for initialDir
+    applyCliInitialDir(config, args.initialDir as string | undefined);
+
     const server = new CLIServer(config);
     await server.run();
   } catch (error) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -347,3 +347,23 @@ export function createDefaultConfig(configPath: string): void {
   
   fs.writeFileSync(configPath, JSON.stringify(configForSave, null, 2));
 }
+
+export function applyCliInitialDir(config: ServerConfig, dir?: string): void {
+  if (!dir) return;
+
+  const normalized = normalizeWindowsPath(dir);
+  if (fs.existsSync(normalized) && fs.statSync(normalized).isDirectory()) {
+    config.global.paths.initialDir = normalized;
+    if (config.global.security.restrictWorkingDirectory) {
+      if (!config.global.paths.allowedPaths.includes(normalized)) {
+        config.global.paths.allowedPaths.push(normalized);
+      }
+    }
+  } else {
+    console.warn(`WARN: Provided initialDir '${dir}' does not exist.`);
+  }
+
+  config.global.paths.allowedPaths = normalizeAllowedPaths(
+    config.global.paths.allowedPaths
+  );
+}

--- a/tests/initialDirCliOverride.test.ts
+++ b/tests/initialDirCliOverride.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { applyCliInitialDir } from '../src/utils/config.js';
+import { buildTestConfig } from './helpers/testUtils.js';
+import { normalizeWindowsPath } from '../src/utils/validation.js';
+
+describe('applyCliInitialDir', () => {
+  test('overrides config initialDir and updates allowedPaths', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-initdir-'));
+    const config = buildTestConfig({
+      global: {
+        security: { restrictWorkingDirectory: true },
+        paths: { allowedPaths: ['C\\allowed'], initialDir: 'C\\old' }
+      }
+    });
+
+    applyCliInitialDir(config, dir);
+    const normalized = normalizeWindowsPath(dir);
+    expect(config.global.paths.initialDir).toBe(normalized);
+    expect(config.global.paths.allowedPaths.map(p => p.toLowerCase())).toContain(normalized.toLowerCase());
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('invalid directory logs warning and does not override', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const dir = path.join(os.tmpdir(), 'nonexistent-dir');
+    const config = buildTestConfig({
+      global: {
+        security: { restrictWorkingDirectory: true },
+        paths: { allowedPaths: ['C\\allowed'], initialDir: 'C\\old' }
+      }
+    });
+
+    applyCliInitialDir(config, dir);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(config.global.paths.initialDir).toBe('C\\old');
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `initialDir` argument to CLI parser
- support overriding the configuration value with `applyCliInitialDir`
- document new CLI parameter
- test CLI initialDir override

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867f1a8061c8320a0a712201bfb50e5