### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,14 +3,13 @@ name: Build and Test
 on:
   push:
     branches: [ main ]
-    paths:
-      - '**/*.ts'
-      - '**/*.js'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
-    branches: [ "**" ]
-    paths:
-      - '**/*.ts'
-      - '**/*.js'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 jobs:
   test-linux:
@@ -25,6 +24,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Lint
+        run: npm run lint
       - name: Test
         run: npm test
       - name: Test with open handles detection
@@ -43,6 +44,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Lint
+        run: npm run lint
       - name: Test
         run: npm test
 
@@ -58,6 +61,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Lint
+        run: npm run lint
       - name: Remove Git Bash from PATH
         shell: pwsh # Ensure this script runs with PowerShell
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish NPM Package
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
+    "lint": "tsc --noEmit",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",


### PR DESCRIPTION
## Summary
- add GitHub Action to publish npm package on release
- ensure tests and lint run for code changes (except docs-only changes)
- add lint script using `tsc --noEmit`

## Testing
- `npm run lint` *(fails: Cannot find type definition file for 'jest', etc.)*
- `npm test` *(fails: Cannot find module 'jest', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868190035dc83209a1de1b943f98d3e