### PR TITLE
Update unit test docs

### DIFF
--- a/docs/unit_tests/TEST_DESCRIPTIONS.md
+++ b/docs/unit_tests/TEST_DESCRIPTIONS.md
@@ -63,9 +63,14 @@ This document summarizes the purpose of each unit test in the project.
 
 - **valid initialDir with restriction adds to allowedPaths** – verifies that a provided initial directory is normalized and added to `allowedPaths` when `restrictWorkingDirectory` is true.
 - **valid initialDir without restriction leaves allowedPaths unchanged** – ensures the path is normalized but not appended when restrictions are disabled.
-- **invalid initialDir logs warning and is unset** – an invalid path triggers a warning and the setting becomes `undefined`.
+- **invalid initialDir logs warning and is undefined** – an invalid path triggers a warning and the setting becomes `undefined`.
 - **initialDir omitted results in undefined** – confirms the default when no `initialDir` is specified.
-- **non-string initialDir logs warning and is unset** – non-string values produce a warning and are ignored.
+- **non-string initialDir preserved when null without warning** – a `null` value remains in the configuration and does not trigger a warning.
+
+## tests/initialDirCliOverride.test.ts
+
+- **overrides config initialDir and updates allowedPaths** – applying the CLI option replaces the configured `initialDir` with the provided path and appends it to `allowedPaths`.
+- **invalid directory logs warning and does not override** – supplying a nonexistent directory causes a warning and the original configuration remains unchanged.
 
 ## tests/serverCwdInitialization.test.ts
 

--- a/docs/unit_tests/initialDirCliOverride.md
+++ b/docs/unit_tests/initialDirCliOverride.md
@@ -1,0 +1,4 @@
+# initialDirCliOverride
+
+- **overrides config initialDir and updates allowedPaths** – applying the CLI option replaces the configured `initialDir` with the provided path and adds it to `allowedPaths`.
+- **invalid directory logs warning and does not override** – when the CLI path does not exist a warning is logged and the configuration remains unchanged.

--- a/docs/unit_tests/initialDirConfig.md
+++ b/docs/unit_tests/initialDirConfig.md
@@ -2,6 +2,6 @@
 
 - **valid initialDir with restriction adds to allowedPaths** – verifies that a provided initial directory is normalized and added to `allowedPaths` when `restrictWorkingDirectory` is true.
 - **valid initialDir without restriction leaves allowedPaths unchanged** – ensures the path is normalized but not appended when restrictions are disabled.
-- **invalid initialDir logs warning and is unset** – an invalid path triggers a warning and the setting becomes `undefined`.
+- **invalid initialDir logs warning and is undefined** – an invalid path triggers a warning and the setting becomes `undefined`.
 - **initialDir omitted results in undefined** – confirms the default when no `initialDir` is specified.
-- **non-string initialDir logs warning and is unset** – non-string values produce a warning and are ignored.
+- **non-string initialDir preserved when null without warning** – a `null` value remains in the configuration and does not trigger a warning.


### PR DESCRIPTION
## Summary
- clarify `initialDirConfig` behavior for null values
- document `initialDirCliOverride` test
- list new test in master `TEST_DESCRIPTIONS.md`

## Testing
- `n/a` (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68684949170c832099392d93be833b22