### PR TITLE
Add CLI options for single shell and allowed directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,15 @@ To get started with configuration:
    working directory defined in your configuration file:
 
    ```bash
-   npx wcli0 --config ./my-config.json --initialDir /path/to/start
+npx wcli0 --config ./my-config.json --initialDir /path/to/start
+```
+
+   You can also start the server with a specific shell and allowed directories
+   without a configuration file:
+
+   ```bash
+   npx wcli0 --shell powershell \
+     --allowedDir C:\safe --allowedDir D:\projects
    ```
 
 3. **Update your Claude Desktop configuration** to use your config file:

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import path from 'path';
 import { buildToolDescription } from './utils/toolDescription.js';
 import { buildExecuteCommandSchema, buildValidateDirectoriesSchema } from './utils/toolSchemas.js';
 import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, buildGetConfigDescription } from './utils/toolDescription.js';
-import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir } from './utils/config.js';
+import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig } from './types/config.js';
 import { fileURLToPath } from 'url';
@@ -73,6 +73,15 @@ const parseArgs = async () => {
     .option('initialDir', {
       type: 'string',
       description: 'Initial working directory (overrides config)'
+    })
+    .option('shell', {
+      type: 'string',
+      description: 'Enable only this shell and disable others'
+    })
+    .option('allowedDir', {
+      type: 'string',
+      array: true,
+      description: 'Allowed directory, can be specified multiple times'
     })
     .option('debug', {
       type: 'boolean',
@@ -912,6 +921,11 @@ const main = async () => {
 
     // Apply command line override for initialDir
     applyCliInitialDir(config, args.initialDir as string | undefined);
+    applyCliShellAndAllowedDirs(
+      config,
+      args.shell as string | undefined,
+      args.allowedDir as string[] | undefined
+    );
 
     const server = new CLIServer(config);
     await server.run();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -368,3 +368,30 @@ export function applyCliInitialDir(config: ServerConfig, dir?: string): void {
     config.global.paths.allowedPaths
   );
 }
+
+export function applyCliShellAndAllowedDirs(
+  config: ServerConfig,
+  shellName?: string,
+  allowedDirs: string[] = []
+): void {
+  if (shellName) {
+    for (const name of Object.keys(config.shells)) {
+      const shell = (config.shells as Record<string, any>)[name];
+      if (shell) {
+        shell.enabled = name === shellName;
+      }
+    }
+
+    const key = shellName as keyof ServerConfig['shells'];
+    if (allowedDirs.length > 0 && config.shells[key]) {
+      const shell = config.shells[key]!;
+      shell.overrides = shell.overrides || {};
+      shell.overrides.paths = shell.overrides.paths || {};
+      shell.overrides.paths.allowedPaths = [...allowedDirs];
+    }
+  }
+
+  if (allowedDirs.length > 0) {
+    config.global.paths.allowedPaths = normalizeAllowedPaths(allowedDirs);
+  }
+}

--- a/tests/shellCliOverride.test.ts
+++ b/tests/shellCliOverride.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from '@jest/globals';
+import { applyCliShellAndAllowedDirs } from '../src/utils/config.js';
+import { buildTestConfig } from './helpers/testUtils.js';
+import { normalizeAllowedPaths } from '../src/utils/validation.js';
+
+describe('applyCliShellAndAllowedDirs', () => {
+  test('enables only selected shell and sets allowed directories', () => {
+    const config = buildTestConfig({
+      shells: {
+        cmd: {
+          enabled: true,
+          executable: { command: 'cmd.exe', args: ['/c'] }
+        },
+        powershell: {
+          enabled: true,
+          executable: { command: 'powershell.exe', args: ['-Command'] }
+        }
+      }
+    });
+    applyCliShellAndAllowedDirs(config, 'cmd', ['C\\one', 'D\\two']);
+    expect(config.shells.cmd?.enabled).toBe(true);
+    expect(config.shells.powershell?.enabled).toBe(false);
+    expect(config.global.paths.allowedPaths).toEqual(
+      normalizeAllowedPaths(['C\\one', 'D\\two'])
+    );
+    expect((config.shells.cmd?.overrides?.paths?.allowedPaths)).toEqual(
+      ['C\\one', 'D\\two']
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `applyCliShellAndAllowedDirs` helper
- parse `--shell` and `--allowedDir` flags
- use overrides when launching server
- document new flags in README
- test shell CLI override

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692ebf38e88320adc9c6a7dc88354e