### PR TITLE
Apply CLI shell mode restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ npx wcli0 --config ./my-config.json --initialDir /path/to/start
      --allowedDir C:\safe --allowedDir D:\projects
    ```
 
+   When started this way, `restrictWorkingDirectory` is forced on and
+   `enableInjectionProtection` is disabled to ensure the allowed paths apply
+   without shell injection checks.
+
 3. **Update your Claude Desktop configuration** to use your config file:
 
    ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wcli0",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wcli0",
-      "version": "1.0.4",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -393,5 +393,7 @@ export function applyCliShellAndAllowedDirs(
 
   if (allowedDirs.length > 0) {
     config.global.paths.allowedPaths = normalizeAllowedPaths(allowedDirs);
+    config.global.security.restrictWorkingDirectory = true;
+    config.global.security.enableInjectionProtection = false;
   }
 }

--- a/tests/shellCliOverride.test.ts
+++ b/tests/shellCliOverride.test.ts
@@ -26,5 +26,7 @@ describe('applyCliShellAndAllowedDirs', () => {
     expect((config.shells.cmd?.overrides?.paths?.allowedPaths)).toEqual(
       ['C\\one', 'D\\two']
     );
+    expect(config.global.security.restrictWorkingDirectory).toBe(true);
+    expect(config.global.security.enableInjectionProtection).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- ensure CLI shell mode forces restrictWorkingDirectory
- disable injection protection in CLI shell mode
- document CLI shell mode behavior
- test the new defaults

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869348905ac83208e3592b31155cb98