### PR TITLE
Add bash shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dt/wcli0.svg?style=flat)](https://www.npmjs.com/package/wcli0)
 [![NPM Version](https://img.shields.io/npm/v/wcli0.svg?style=flat)](https://www.npmjs.com/package/wcli0?activeTab=versions)
 
-[MCP server](https://modelcontextprotocol.io/introduction) for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, Git Bash shells.
+[MCP server](https://modelcontextprotocol.io/introduction) for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, Git Bash, and Bash shells.
 It allows MCP clients (like [Claude Desktop](https://claude.ai/download)) to perform operations on your system, similar to [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter).
 
 This enhanced version includes advanced configuration management, improved security features, and comprehensive testing capabilities.
@@ -56,7 +56,7 @@ This enhanced version includes advanced configuration management, improved secur
 
 ## Features
 
-- **Multi-Shell Support**: Execute commands in PowerShell, Command Prompt (CMD), Git Bash, and WSL
+ - **Multi-Shell Support**: Execute commands in PowerShell, Command Prompt (CMD), Git Bash, Bash, and WSL
 - **Inheritance-Based Configuration**: Global defaults with shell-specific overrides
 - **Shell-Specific Validation**: Each shell can have its own security settings and path formats
 - **Flexible Path Management**: Different shells support different path formats (Windows/Unix/Mixed)
@@ -375,7 +375,7 @@ Global settings provide defaults that apply to all shells unless overridden.
 #### Shell Configuration
 
 Each shell can be individually configured and can override global settings.
-Each shell entry must include a `type` field indicating the shell. Valid values are `powershell`, `cmd`, `gitbash`, and `wsl`.
+Each shell entry must include a `type` field indicating the shell. Valid values are `powershell`, `cmd`, `gitbash`, `bash`, and `wsl`.
 
 ##### Basic Shell Configuration
 
@@ -491,7 +491,7 @@ Results in PowerShell having:
 
   - Execute a command in the specified shell
   - Inputs:
-    - `shell` (string): Shell to use ("powershell", "cmd", "gitbash", or "wsl")
+    - `shell` (string): Shell to use ("powershell", "cmd", "gitbash", "bash", or "wsl")
     - `command` (string): Command to execute
     - `workingDir` (optional string): Working directory
   - Returns command output as text, or error message if execution fails

--- a/config.examples/config.development.json
+++ b/config.examples/config.development.json
@@ -59,6 +59,22 @@
         "args": ["-c"]
       }
     },
+    "bash": {
+      "type": "bash",
+      "enabled": true,
+      "executable": {
+        "command": "bash",
+        "args": ["-c"]
+      },
+      "wslConfig": {
+        "mountPoint": "/mnt/",
+        "inheritGlobalPaths": true,
+        "pathMapping": {
+          "enabled": true,
+          "windowsToWsl": true
+        }
+      }
+    },
     "wsl": {
       "type": "wsl",
       "enabled": true,

--- a/config.examples/config.sample.json
+++ b/config.examples/config.sample.json
@@ -65,6 +65,18 @@
         "command": "C:\\Program Files\\Git\\bin\\bash.exe",
         "args": ["-c"]
       }
+    },
+    "bash": {
+      "type": "bash",
+      "enabled": true,
+      "executable": {
+        "command": "bash",
+        "args": ["-c"]
+      },
+      "wslConfig": {
+        "mountPoint": "/mnt/",
+        "inheritGlobalPaths": true
+      }
     }
   }
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@
 
 ### Q: What is the Windows CLI MCP Server?
 
-A: The Windows CLI MCP Server is a Model Context Protocol (MCP) server that provides secure command-line access for Windows systems. It allows MCP clients like Claude Desktop to execute commands in various shells (PowerShell, CMD, Git Bash, WSL) with configurable security controls.
+A: The Windows CLI MCP Server is a Model Context Protocol (MCP) server that provides secure command-line access for Windows systems. It allows MCP clients like Claude Desktop to execute commands in various shells (PowerShell, CMD, Git Bash, Bash, WSL) with configurable security controls.
 
 ### Q: How does the inheritance-based configuration work?
 
@@ -20,6 +20,7 @@ A: The server supports:
 - **PowerShell** (`powershell`) - Windows PowerShell or PowerShell Core
 - **Command Prompt** (`cmd`) - Windows CMD
 - **Git Bash** (`gitbash`) - Git for Windows Bash
+- **Bash** (`bash`) - Standard Unix Bash shell
 - **WSL** (`wsl`) - Windows Subsystem for Linux
 
 ## Configuration Questions
@@ -126,6 +127,7 @@ A: Each shell has its own conventions:
 - **CMD/PowerShell**: Windows format (`C:\\Users\\Name`)
 - **WSL**: Unix format (`/home/user`, `/mnt/c/...`)
 - **Git Bash**: Both formats (`C:\\Projects` or `/c/Projects`)
+- **Bash**: Unix format (`/home/user`)
 
 ### Q: What does "restrictWorkingDirectory" do?
 
@@ -261,6 +263,7 @@ A: Choose based on your needs:
 - **PowerShell**: Windows administration, .NET operations, object-based commands
 - **CMD**: Simple Windows commands, batch files, legacy scripts
 - **Git Bash**: Git operations, Unix-like commands, cross-platform scripts
+- **Bash**: Native Linux commands and scripting
 - **WSL**: Linux development, Python/Node.js development, Unix tools
 
 ### Q: How can I optimize performance?

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,7 @@ class CLIServer {
       let shellProcess: ReturnType<typeof spawn>;
       let spawnArgs: string[];
 
-      if (shellConfig.type === 'wsl') {
+      if (shellConfig.type === 'wsl' || shellConfig.type === 'bash') {
         const parsedCommand = parseCommand(command);
         spawnArgs = [...shellConfig.executable.args, parsedCommand.command, ...parsedCommand.args];
       } else {
@@ -276,7 +276,7 @@ class CLIServer {
         // For WSL, convert WSL paths back to Windows paths for spawn cwd
         let spawnCwd = workingDir;
         let envVars = { ...process.env };
-        if (shellConfig.type === 'wsl') {
+        if (shellConfig.type === 'wsl' || shellConfig.type === 'bash') {
           if (workingDir.startsWith('/mnt/')) {
             // Convert /mnt/c/path to C:\path
             const match = workingDir.match(/^\/mnt\/([a-z])\/(.*)$/i);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -105,14 +105,14 @@ export interface ShellExecutableConfig {
 /**
  * Supported shell types
  */
-export type ShellType = 'cmd' | 'powershell' | 'gitbash' | 'wsl';
+export type ShellType = 'cmd' | 'powershell' | 'gitbash' | 'wsl' | 'bash';
 
 /**
  * Base configuration for all shell types
  */
 export interface BaseShellConfig {
   /**
-   * The type of shell (cmd, powershell, gitbash or wsl)
+   * The type of shell (cmd, powershell, gitbash, wsl or bash)
    */
   type: ShellType;
   /**
@@ -170,7 +170,7 @@ export interface WslSpecificConfig {
  * Extended configuration for WSL shell with WSL-specific options
  */
 export interface WslShellConfig extends BaseShellConfig {
-  type: 'wsl';
+  type: 'wsl' | 'bash';
   /**
    * WSL-specific configuration
    */
@@ -193,6 +193,7 @@ export interface ServerConfig {
     powershell?: BaseShellConfig;
     cmd?: BaseShellConfig;
     gitbash?: BaseShellConfig;
+    bash?: WslShellConfig;
     wsl?: WslShellConfig;
   };
 }

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -65,6 +65,20 @@ export function buildToolDescription(allowedShells: string[]): string[] {
     );
   }
 
+  if (allowedShells.includes('bash')) {
+    descriptionLines.push(
+      "Example usage (Bash):",
+      "```json",
+      "{",
+      "  \"shell\": \"bash\",",
+      "  \"command\": \"ls -la\",",
+      "  \"workingDir\": \"/home/user\"",
+      "}",
+      "```",
+      ""
+    );
+  }
+
   return descriptionLines;
 }
 
@@ -102,7 +116,7 @@ export function buildExecuteCommandDescription(
     }
     
     // Add path format information based on shell type
-    if (config.type === 'wsl') {
+    if (config.type === 'wsl' || config.type === 'bash') {
       lines.push(`- Path format: Unix-style (/home/user, /mnt/c/...)`);
       if (config.wslConfig?.inheritGlobalPaths) {
         lines.push(`- Inherits global Windows paths (converted to /mnt/...)`);
@@ -143,6 +157,18 @@ export function buildExecuteCommandDescription(
     lines.push('```json');
     lines.push('{');
     lines.push('  "shell": "wsl",');
+    lines.push('  "command": "ls -la",');
+    lines.push('  "workingDir": "/home/user"');
+    lines.push('}');
+    lines.push('```');
+    lines.push('');
+  }
+
+  if (resolvedConfigs.has('bash')) {
+    lines.push('Bash:');
+    lines.push('```json');
+    lines.push('{');
+    lines.push('  "shell": "bash",');
     lines.push('  "command": "ls -la",');
     lines.push('  "workingDir": "/home/user"');
     lines.push('}');

--- a/src/utils/toolSchemas.ts
+++ b/src/utils/toolSchemas.ts
@@ -26,7 +26,7 @@ export function buildExecuteCommandSchema(
       const parts = [`${shell} shell`];
       parts.push(`timeout: ${config.security.commandTimeout}s`);
 
-      if (config.type === 'wsl') {
+      if (config.type === 'wsl' || config.type === 'bash') {
         parts.push('Unix paths');
       } else if (config.type === 'cmd' || config.type === 'powershell') {
         parts.push('Windows paths');

--- a/src/utils/validationContext.ts
+++ b/src/utils/validationContext.ts
@@ -19,8 +19,8 @@ export function createValidationContext(
   shellConfig: ResolvedShellConfig
 ): ValidationContext {
   const isWindowsShell = shellConfig.type === 'cmd' || shellConfig.type === 'powershell';
-  const isUnixShell = shellConfig.type === 'gitbash' || shellConfig.type === 'wsl';
-  const isWslShell = shellConfig.type === 'wsl';
+  const isUnixShell = shellConfig.type === 'gitbash' || shellConfig.type === 'wsl' || shellConfig.type === 'bash';
+  const isWslShell = shellConfig.type === 'wsl' || shellConfig.type === 'bash';
   
   return {
     shellName,

--- a/tests/bash/bashShell.test.ts
+++ b/tests/bash/bashShell.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, beforeEach, expect } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+
+let server: CLIServer;
+let config: ServerConfig;
+
+beforeEach(() => {
+  config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+  if (config.shells) {
+    // enable bash shell using /bin/bash
+    config.shells.bash = {
+      type: 'bash',
+      enabled: true,
+      executable: { command: 'bash', args: ['-c'] },
+      validatePath: (dir: string) => /^(\/mnt\/[a-zA-Z]\/|\/)/.test(dir),
+      wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true }
+    };
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.wsl) config.shells.wsl.enabled = false;
+  }
+
+  config.global.paths.allowedPaths = ['/tmp'];
+  if (config.global.security) {
+    config.global.security.restrictWorkingDirectory = true;
+  }
+  server = new CLIServer(config);
+});
+
+describe('Bash shell basic execution', () => {
+  test('echo command', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'echo hello', workingDir: '/tmp' }
+    }) as any;
+    expect(result.isError).toBe(false);
+    expect((result.metadata as any).exitCode).toBe(0);
+  });
+
+  test('working directory validation', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'pwd', workingDir: '/tmp' }
+    }) as any;
+    expect(result.isError).toBe(false);
+    expect((result.metadata as any).workingDirectory).toBe('/tmp');
+
+    await expect(server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'pwd', workingDir: '/etc' }
+    })).rejects.toThrow();
+  });
+});

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -119,7 +119,8 @@ describe('Config Normalization', () => {
         },
         powershell: { enabled: false, executable: { command: 'powershell.exe', args: [] } },
         cmd: { enabled: false, executable: { command: 'cmd.exe', args: ['/c'] } },
-        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } },
+        bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } }
       }
     };
 
@@ -132,6 +133,7 @@ describe('Config Normalization', () => {
     // Other shells might be present but should be disabled
     if (cfg.shells.powershell) expect(cfg.shells.powershell.enabled).toBe(false);
     if (cfg.shells.cmd) expect(cfg.shells.cmd.enabled).toBe(false);
+    if (cfg.shells.bash) expect(cfg.shells.bash.enabled).toBe(false);
     if (cfg.shells.wsl) expect(cfg.shells.wsl.enabled).toBe(false);
 
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
@@ -157,6 +159,7 @@ describe('Config Normalization', () => {
         powershell: { enabled: false, executable: { command: 'powershell.exe', args: [] } },
         cmd: { enabled: false, executable: { command: 'cmd.exe', args: ['/c'] } },
         gitbash: { enabled: false, executable: { command: 'bash.exe', args: ['-c'] } },
+        bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } },
         wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     });
@@ -205,6 +208,7 @@ describe('Config Normalization', () => {
           }
         },
         gitbash: { enabled: false, executable: { command: 'bash.exe', args: ['-c'] } },
+        bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } },
         wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     };
@@ -219,6 +223,7 @@ describe('Config Normalization', () => {
     
     // These shells might be present but should be disabled
     if (cfg.shells.gitbash) expect(cfg.shells.gitbash.enabled).toBe(false);
+    if (cfg.shells.bash) expect(cfg.shells.bash.enabled).toBe(false);
     if (cfg.shells.wsl) expect(cfg.shells.wsl.enabled).toBe(false);
 
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -55,6 +55,7 @@ export class TestCLIServer {
       if (baseConfig.shells.powershell) baseConfig.shells.powershell.enabled = false;
       if (baseConfig.shells.cmd) baseConfig.shells.cmd.enabled = false;
       if (baseConfig.shells.gitbash) baseConfig.shells.gitbash.enabled = false;
+      if (baseConfig.shells.bash) baseConfig.shells.bash.enabled = false;
       
       // Add WSL shell
       baseConfig.shells.wsl = wslShell;
@@ -259,7 +260,7 @@ export class TestCLIServer {
     resolvedConfigs: Map<string, any>
   ): string {
     const lines = [
-      'Execute a command in the specified shell (cmd, gitbash)'
+      'Execute a command in the specified shell (cmd, gitbash, bash)'
     ];
     
     // Add shell-specific descriptions
@@ -273,6 +274,8 @@ export class TestCLIServer {
           pathFormat = 'Path format: Windows-style';
         } else if (shell === 'gitbash') {
           pathFormat = 'Path format: Mixed';
+        } else if (shell === 'bash') {
+          pathFormat = 'Path format: Unix-style';
         }
         
         lines.push(`${shell}: Command timeout: ${config.security.commandTimeout}s - ${pathFormat}`);


### PR DESCRIPTION
## Summary
- extend shell types with `bash`
- allow bash config in server configuration and defaults
- treat bash like WSL for path handling and validation
- document bash shell in README and FAQ
- update example configs with bash section
- add tests for bash shell execution

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693dd4fb888320b7ff00d281c33743