### PR TITLE
Filter disabled shells in get_config

### DIFF
--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -25,9 +25,9 @@ export function createSerializableConfig(config: ServerConfig): any {
     shells: {}
   };
 
-  // Add shell configurations
+  // Add shell configurations for enabled shells only
   for (const [shellName, shellConfig] of Object.entries(config.shells)) {
-    if (!shellConfig) continue;
+    if (!shellConfig || !shellConfig.enabled) continue;
 
     const shellInfo: any = {
       type: shellConfig.type,

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -116,7 +116,7 @@ describe('get_config tool', () => {
     }
     
     if (testConfig.shells.gitbash) {
-      expect(safeConfig.shells.gitbash.enabled).toBe(testConfig.shells.gitbash.enabled);
+      expect(safeConfig.shells.gitbash).toBeUndefined();
     }
     
     // Verify that function properties are not included in the serializable config
@@ -168,6 +168,14 @@ describe('get_config tool', () => {
       }
     });
 
+  });
+
+  test('createSerializableConfig omits disabled shells', () => {
+    const safeConfig = createSerializableConfig(testConfig);
+
+    expect(safeConfig.shells.gitbash).toBeUndefined();
+    expect(safeConfig.shells.powershell).toBeDefined();
+    expect(safeConfig.shells.cmd).toBeDefined();
   });
 
   test('createSerializableConfig handles empty shells config', () => {


### PR DESCRIPTION
## Summary
- filter disabled shells when building serializable config
- update get_config tests to expect disabled shells omitted

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68699106c4ec83209566d6840d931efa