### PR TITLE
Add CLI overrides for security limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ To get started with configuration:
     npx wcli0 --config ./my-config.json --initialDir /path/to/start
     ```
 
+   You can override global command limits directly from the CLI:
+
+    ```bash
+    npx wcli0 --config ./my-config.json \
+      --maxCommandLength 5000 --commandTimeout 60
+    ```
+
    You can also start the server with a specific shell and allowed directories
    without a configuration file:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import path from 'path';
 import { buildToolDescription } from './utils/toolDescription.js';
 import { buildExecuteCommandSchema, buildValidateDirectoriesSchema } from './utils/toolSchemas.js';
 import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, buildGetConfigDescription } from './utils/toolDescription.js';
-import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs } from './utils/config.js';
+import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig } from './types/config.js';
 import { fileURLToPath } from 'url';
@@ -82,6 +82,14 @@ const parseArgs = async () => {
       type: 'string',
       array: true,
       description: 'Allowed directory, can be specified multiple times'
+    })
+    .option('maxCommandLength', {
+      type: 'number',
+      description: 'Maximum length for command strings'
+    })
+    .option('commandTimeout', {
+      type: 'number',
+      description: 'Command timeout in seconds'
     })
     .option('debug', {
       type: 'boolean',
@@ -925,6 +933,11 @@ const main = async () => {
       config,
       args.shell as string | undefined,
       args.allowedDir as string[] | undefined
+    );
+    applyCliSecurityOverrides(
+      config,
+      args.maxCommandLength as number | undefined,
+      args.commandTimeout as number | undefined
     );
 
     const server = new CLIServer(config);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -444,3 +444,21 @@ export function applyCliShellAndAllowedDirs(
     config.global.security.enableInjectionProtection = false;
   }
 }
+
+export function applyCliSecurityOverrides(
+  config: ServerConfig,
+  maxCommandLength?: number,
+  commandTimeout?: number
+): void {
+  if (typeof maxCommandLength === 'number' && maxCommandLength > 0) {
+    config.global.security.maxCommandLength = maxCommandLength;
+  } else if (maxCommandLength !== undefined) {
+    debugWarn(`WARN: Invalid maxCommandLength '${maxCommandLength}', ignoring.`);
+  }
+
+  if (typeof commandTimeout === 'number' && commandTimeout > 0) {
+    config.global.security.commandTimeout = commandTimeout;
+  } else if (commandTimeout !== undefined) {
+    debugWarn(`WARN: Invalid commandTimeout '${commandTimeout}', ignoring.`);
+  }
+}

--- a/tests/securityCliOverride.test.ts
+++ b/tests/securityCliOverride.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { applyCliSecurityOverrides } from '../src/utils/config.js';
+import { buildTestConfig } from './helpers/testUtils.js';
+import { setDebugLogging } from '../src/utils/log.js';
+
+describe('applyCliSecurityOverrides', () => {
+  test('overrides security values with valid numbers', () => {
+    const config = buildTestConfig();
+    applyCliSecurityOverrides(config, 1234, 45);
+    expect(config.global.security.maxCommandLength).toBe(1234);
+    expect(config.global.security.commandTimeout).toBe(45);
+  });
+
+  test('logs warning and ignores invalid values', () => {
+    const config = buildTestConfig();
+    setDebugLogging(true);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    applyCliSecurityOverrides(config, 0, -1);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(config.global.security.maxCommandLength).not.toBe(0);
+    expect(config.global.security.commandTimeout).not.toBe(-1);
+    warnSpy.mockRestore();
+    setDebugLogging(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow overriding `maxCommandLength` and `commandTimeout` from CLI
- expose helper `applyCliSecurityOverrides`
- document new flags in README
- cover new helper with unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869960e5ac08320ac12ea414da0ecfb