### PR TITLE
Simplify get_config output

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -28,11 +28,11 @@ Execute a command in the specified shell with shell-specific validation and sett
 ```
 
 ### get_config Tool
-Get the complete configuration including resolved settings for each shell.
+Return the current server configuration.
 
 **Returns:**
-- `configuration`: The raw configuration structure
-- `resolvedShells`: Effective settings for each enabled shell
+- `global`: The default configuration applied to all shells
+- `shells`: Enabled shells with any security, restriction or path overrides
 
 ### validate_directories Tool
 Check if directories are valid for global or shell-specific contexts.

--- a/docs/unit_tests/TEST_DESCRIPTIONS.md
+++ b/docs/unit_tests/TEST_DESCRIPTIONS.md
@@ -96,7 +96,7 @@ This document summarizes the purpose of each unit test in the project.
 - **buildExecuteCommandDescription notes path formats for all shells** – ensures path format hints for Windows, mixed, and Unix shells appear.
 - **buildValidateDirectoriesDescription describes shell specific mode** – confirms the shell-specific validation block is documented when enabled.
 - **buildValidateDirectoriesDescription without shell specific mode** – checks the simpler description when shell-specific validation is disabled.
-- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned.
+- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned (`global` and `shells`).
 
 ## tests/validation.test.ts
 

--- a/docs/unit_tests/server/toolHandlers.md
+++ b/docs/unit_tests/server/toolHandlers.md
@@ -1,5 +1,5 @@
 # server/toolHandlers
 
-- **returns both configuration and resolved settings** – the get_config tool should provide raw configuration plus resolved shell settings.
+- **returns configuration summary** – the get_config tool should provide the cleaned configuration structure.
 - **supports shell-specific validation** – validate_directories must apply allowed path rules per-shell when a shell argument is provided.
 - **validates against global allowed paths** – set_current_directory uses the global allowed list to decide if changing the active directory is permitted.

--- a/docs/unit_tests/toolDescription.details.md
+++ b/docs/unit_tests/toolDescription.details.md
@@ -4,4 +4,4 @@
 - **buildExecuteCommandDescription notes path formats for all shells** – ensures path format hints for Windows, mixed, and Unix shells appear.
 - **buildValidateDirectoriesDescription describes shell specific mode** – confirms the shell-specific validation block is documented when enabled.
 - **buildValidateDirectoriesDescription without shell specific mode** – checks the simpler description when shell-specific validation is disabled.
-- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned.
+- **buildGetConfigDescription outlines return fields** – validates that the get_config tool documentation lists the configuration fields returned (`global` and `shells`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -849,20 +849,10 @@ class CLIServer {
       case "get_config": {
         const safeConfig = createSerializableConfig(this.config);
 
-        const resolvedConfigs: any = {};
-        for (const [shellName, resolved] of this.resolvedConfigs.entries()) {
-          resolvedConfigs[shellName] = createResolvedConfigSummary(shellName, resolved);
-        }
-
-        const fullConfig = {
-          configuration: safeConfig,
-          resolvedShells: resolvedConfigs
-        };
-
         return {
           content: [{
             type: "text",
-            text: JSON.stringify(fullConfig, null, 2)
+            text: JSON.stringify(safeConfig, null, 2)
           }],
           isError: false,
           metadata: {}

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -30,35 +30,27 @@ export function createSerializableConfig(config: ServerConfig): any {
     if (!shellConfig || !shellConfig.enabled) continue;
 
     const shellInfo: any = {
-      type: shellConfig.type,
-      enabled: shellConfig.enabled,
-      executable: {
-        command: shellConfig.executable.command,
-        args: [...shellConfig.executable.args]
-      }
+      type: shellConfig.type
     };
 
     if (shellConfig.overrides) {
-      shellInfo.overrides = {};
       if (shellConfig.overrides.security) {
-        shellInfo.overrides.security = { ...shellConfig.overrides.security };
+        shellInfo.security = { ...shellConfig.overrides.security };
       }
-      if (shellConfig.overrides.restrictions) {
-        shellInfo.overrides.restrictions = {
-          blockedCommands: shellConfig.overrides.restrictions.blockedCommands ?
-            [...shellConfig.overrides.restrictions.blockedCommands] : undefined,
-          blockedArguments: shellConfig.overrides.restrictions.blockedArguments ?
-            [...shellConfig.overrides.restrictions.blockedArguments] : undefined,
-          blockedOperators: shellConfig.overrides.restrictions.blockedOperators ?
-            [...shellConfig.overrides.restrictions.blockedOperators] : undefined
-        };
+
+      const r = shellConfig.overrides.restrictions;
+      if (r && (r.blockedCommands || r.blockedArguments || r.blockedOperators)) {
+        shellInfo.restrictions = {};
+        if (r.blockedCommands) shellInfo.restrictions.blockedCommands = [...r.blockedCommands];
+        if (r.blockedArguments) shellInfo.restrictions.blockedArguments = [...r.blockedArguments];
+        if (r.blockedOperators) shellInfo.restrictions.blockedOperators = [...r.blockedOperators];
       }
-      if (shellConfig.overrides.paths) {
-        shellInfo.overrides.paths = {
-          allowedPaths: shellConfig.overrides.paths.allowedPaths ?
-            [...shellConfig.overrides.paths.allowedPaths] : undefined,
-          initialDir: shellConfig.overrides.paths.initialDir
-        };
+
+      const p = shellConfig.overrides.paths;
+      if (p && (p.allowedPaths || p.initialDir !== undefined)) {
+        shellInfo.paths = {};
+        if (p.allowedPaths) shellInfo.paths.allowedPaths = [...p.allowedPaths];
+        if (p.initialDir !== undefined) shellInfo.paths.initialDir = p.initialDir;
       }
     }
 

--- a/src/utils/toolDescription.ts
+++ b/src/utils/toolDescription.ts
@@ -229,15 +229,14 @@ export function buildValidateDirectoriesDescription(
  */
 export function buildGetConfigDescription(): string {
   const lines: string[] = [];
-  
+
   lines.push('Get the windows CLI server configuration');
   lines.push('');
   lines.push('**Returns:**');
-  lines.push('- `configuration`: The server configuration with global and shell-specific settings');
-  lines.push('- `resolvedShells`: Effective configuration for each enabled shell after merging');
+  lines.push('- `global`: Default settings applied to all shells');
+  lines.push('- `shells`: Enabled shells with any overrides applied');
   lines.push('');
-  lines.push('The resolved configuration shows what settings are actually used for each shell,');
-  lines.push('including inherited global settings and shell-specific overrides.');
-  
+  lines.push('Only enabled shells are included and technical fields like executables are omitted.');
+
   return lines.join('\n');
 }

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -104,31 +104,25 @@ describe('get_config tool', () => {
     
     // Check shells configuration
     if (testConfig.shells.powershell) {
-      expect(safeConfig.shells.powershell.enabled).toBe(testConfig.shells.powershell.enabled);
-      expect(safeConfig.shells.powershell.executable.command).toBe(testConfig.shells.powershell.executable?.command);
-      expect(safeConfig.shells.powershell.executable.args).toEqual(testConfig.shells.powershell.executable?.args || []);
-      expect(safeConfig.shells.powershell.overrides?.restrictions?.blockedOperators)
-        .toEqual(testConfig.shells.powershell.overrides?.restrictions?.blockedOperators || []);
+      expect(safeConfig.shells.powershell.type).toBe('powershell');
+      expect(safeConfig.shells.powershell.restrictions?.blockedOperators)
+        .toEqual(testConfig.shells.powershell.overrides?.restrictions?.blockedOperators || undefined);
     }
-    
+
     if (testConfig.shells.cmd) {
-      expect(safeConfig.shells.cmd.enabled).toBe(testConfig.shells.cmd.enabled);
+      expect(safeConfig.shells.cmd.type).toBe('cmd');
     }
-    
+
     if (testConfig.shells.gitbash) {
       expect(safeConfig.shells.gitbash).toBeUndefined();
     }
-    
-    // Verify that function properties are not included in the serializable config
-    // We now look for overrides.validatePath property which shouldn't be included in serialized output
+
+    // Verify that executable information is not included
     if (safeConfig.shells.powershell) {
-      expect(safeConfig.shells.powershell.validatePath).toBeUndefined();
+      expect((safeConfig.shells.powershell as any).executable).toBeUndefined();
     }
     if (safeConfig.shells.cmd) {
-      expect(safeConfig.shells.cmd.validatePath).toBeUndefined();
-    }
-    if (safeConfig.shells.gitbash) {
-      expect(safeConfig.shells.gitbash.validatePath).toBeUndefined();
+      expect((safeConfig.shells.cmd as any).executable).toBeUndefined();
     }
 
   });
@@ -158,13 +152,7 @@ describe('get_config tool', () => {
       const shell = testConfig.shells[shellName as keyof typeof testConfig.shells];
       if (shell && shell.enabled) {
         expect(safeConfig.shells).toHaveProperty(shellName);
-        expect(safeConfig.shells[shellName]).toHaveProperty('enabled');
-        expect(safeConfig.shells[shellName]).toHaveProperty('executable');
-        expect(safeConfig.shells[shellName].executable).toHaveProperty('command');
-        expect(safeConfig.shells[shellName].executable).toHaveProperty('args');
-        if (safeConfig.shells[shellName].overrides && safeConfig.shells[shellName].overrides.restrictions) {
-          expect(safeConfig.shells[shellName].overrides.restrictions).toHaveProperty('blockedOperators');
-        }
+        expect(safeConfig.shells[shellName]).toHaveProperty('type');
       }
     });
 

--- a/tests/integration/mcpProtocol.test.ts
+++ b/tests/integration/mcpProtocol.test.ts
@@ -10,10 +10,9 @@ describe('MCP Protocol Interactions', () => {
     const result = await server.callTool('get_config', {});
     const text = result.content[0]?.text ?? '';
     const cfg = JSON.parse(text);
-    expect(cfg).toHaveProperty('configuration');
-    expect(cfg.configuration).toHaveProperty('global');
-    expect(cfg.configuration.global).toHaveProperty('security');
-    expect(cfg).toHaveProperty('resolvedShells');
+    expect(cfg).toHaveProperty('global');
+    expect(cfg.global).toHaveProperty('security');
+    expect(cfg).toHaveProperty('shells');
   });
 
   test('should validate directories correctly', async () => {

--- a/tests/server/toolHandlers.test.ts
+++ b/tests/server/toolHandlers.test.ts
@@ -6,7 +6,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 describe('Tool Handlers', () => {
   describe('get_config tool', () => {
-    test('returns both configuration and resolved settings', async () => {
+    test('returns configuration summary', async () => {
       const config = buildTestConfig({
         global: {
           security: { commandTimeout: 30 },
@@ -29,11 +29,10 @@ describe('Tool Handlers', () => {
 
       const configData = JSON.parse(result.content[0].text as string);
 
-      expect(configData.configuration.global.security.commandTimeout).toBe(30);
-      expect(configData.configuration.shells.cmd.overrides.security.commandTimeout).toBe(60);
-      expect(configData.resolvedShells.cmd.effectiveSettings.security.commandTimeout).toBe(60);
-      expect(configData.resolvedShells.cmd.effectiveSettings.restrictions.blockedCommands)
-        .toEqual(['global-blocked', 'cmd-specific']);
+      expect(configData.global.security.commandTimeout).toBe(30);
+      expect(configData.shells.cmd.security.commandTimeout).toBe(60);
+      expect(configData.shells.cmd.restrictions.blockedCommands)
+        .toEqual(['cmd-specific']);
     });
   });
 

--- a/tests/toolDescription.details.test.ts
+++ b/tests/toolDescription.details.test.ts
@@ -67,7 +67,7 @@ describe('Detailed Tool Descriptions', () => {
   test('buildGetConfigDescription outlines return fields', () => {
     const result = buildGetConfigDescription();
     expect(result).toContain('Get the windows CLI server configuration');
-    expect(result).toContain('`configuration`');
-    expect(result).toContain('`resolvedShells`');
+    expect(result).toContain('`global`');
+    expect(result).toContain('`shells`');
   });
 });


### PR DESCRIPTION
## Summary
- refactor `createSerializableConfig` to omit executable info and merge overrides directly
- update server to return only the simplified config in `get_config`
- revise get_config description text
- adjust unit and integration tests for new format
- update docs to describe the simplified configuration structure

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a27299f248320ba1129ede7727a8b