### PR TITLE
Fix GitBash path regex

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -333,7 +333,8 @@ export function normalizeWindowsPath(inputPath: string): string {
     let tempPath = inputPath.trim();
 
     // Priority 1: Git Bash paths like /c/foo -> C:\foo
-    const gitBashMatch = tempPath.match(/^\/([a-zA-Z])(\/.*)?$/);
+    // Match Git Bash drive paths like /c/foo or /d
+    const gitBashMatch = tempPath.match(/^\/([a-zA-Z])(?:\/(.*))?$/);
     if (gitBashMatch) {
         const drive = gitBashMatch[1].toUpperCase();
         const pathPart = gitBashMatch[2] || '';

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -263,6 +263,7 @@ describe('Path Normalization', () => {
     ['/mnt/d/', '/mnt/d/'],
     ['/home/user/documents', '/home/user/documents'],
     ['/usr/local/bin', '/usr/local/bin'],
+    ['/workspaces/wcli0/dist/index.js', '/workspaces/wcli0/dist/index.js'],
     ['/', '/'],
 
     // Redundant separators


### PR DESCRIPTION
## Summary
- avoid misclassifying paths like `/workspaces/...` as GitBash drive paths
- test GitBash detection on workspace path

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a3f7488688320b62d750d596e9996