### PR TITLE
Fix Jest warning by preventing CLI auto start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, bu
 import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig } from './types/config.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname } from 'path';
 import { setDebugLogging, debugLog, debugWarn, errorLog } from './utils/log.js';
 
@@ -938,8 +938,10 @@ const main = async () => {
   }
 };
 
-// For ES modules, always run main() when this file is executed directly
-// The module is only imported when used as a library, not when run as a binary
-main();
+// For ES modules, run main() only when executed directly via Node
+// This avoids starting the server when the module is imported in tests
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
 
 export { CLIServer, main };


### PR DESCRIPTION
## Summary
- avoid automatically running the CLI when `src/index.ts` is imported
- run CLI only when the module is executed directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a45fb173c8320a5d71c049f3acd6c