### PR TITLE
Mitigate Jest shutdown warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "lint": "tsc --noEmit",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "test:validation": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests/validation.test.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,6 +377,7 @@ class CLIServer {
           `Command execution timed out after ${shellConfig.security.commandTimeout} seconds in ${shellName}`
         ));
       }, shellConfig.security.commandTimeout * 1000);
+      timeout.unref();
     });
   }
 

--- a/tests/testCleanup.test.ts
+++ b/tests/testCleanup.test.ts
@@ -11,6 +11,9 @@ describe('Test Suite Cleanup Verification', () => {
     if (global.gc) {
       global.gc();
     }
-    return new Promise(resolve => setTimeout(resolve, 100));
+    return new Promise(resolve => {
+      const t = setTimeout(resolve, 100);
+      t.unref();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- unref command timeout timer
- unref cleanup timer in tests
- run Jest in single-worker mode to avoid open handle warning

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a45fb173c8320a5d71c049f3acd6c