### PR TITLE
Fix lingering timers in tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,6 +377,7 @@ class CLIServer {
           `Command execution timed out after ${shellConfig.security.commandTimeout} seconds in ${shellName}`
         ));
       }, shellConfig.security.commandTimeout * 1000);
+      timeout.unref();
     });
   }
 

--- a/tests/testCleanup.test.ts
+++ b/tests/testCleanup.test.ts
@@ -11,6 +11,9 @@ describe('Test Suite Cleanup Verification', () => {
     if (global.gc) {
       global.gc();
     }
-    return new Promise(resolve => setTimeout(resolve, 100));
+    return new Promise(resolve => {
+      const timer = setTimeout(resolve, 100);
+      timer.unref();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- unref command timeout timer in CLIServer
- unref cleanup timer in test suite

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a45fb173c8320a5d71c049f3acd6c