### PR TITLE
Add jest global teardown

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,11 +21,13 @@ export default {
   },
   testTimeout: 10000,
   verbose: true,
+  forceExit: true,
   testPathIgnorePatterns: [
     '/node_modules/',
     '/dist/',
     '/scripts/wsl.sh'
   ],
+  globalTeardown: './tests/jest/globalTeardown.js',
   resolver: undefined,
   globals: {}
 };

--- a/tests/jest/globalTeardown.js
+++ b/tests/jest/globalTeardown.js
@@ -1,0 +1,7 @@
+export default async function globalTeardown() {
+  process.stdin.removeAllListeners('data');
+  process.stdin.removeAllListeners('error');
+  process.stdout.removeAllListeners('drain');
+  process.stdout.removeAllListeners('error');
+}
+console.log('global teardown executed');


### PR DESCRIPTION
## Summary
- add a small `globalTeardown` script to remove stdin/stdout listeners
- enable `forceExit` and configure the teardown script in `jest.config.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a45fb173c8320a5d71c049f3acd6c