### PR TITLE
Hide inactive restrictions from get_config

### DIFF
--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -183,6 +183,23 @@ describe('get_config tool', () => {
     expect(safeConfig.shells).toBeDefined();
     expect(Object.keys(safeConfig.shells)).toHaveLength(0);
   });
+
+  test('createSerializableConfig omits restrictions when injection protection disabled', () => {
+    const disabledConfig: ServerConfig = {
+      ...testConfig,
+      global: {
+        ...testConfig.global,
+        security: {
+          ...testConfig.global.security,
+          enableInjectionProtection: false
+        }
+      }
+    };
+
+    const safeConfig = createSerializableConfig(disabledConfig);
+
+    expect(safeConfig.global.restrictions).toBeUndefined();
+  });
   
   test('get_config tool response format', () => {
     // Call the utility function directly with our test config


### PR DESCRIPTION
## Summary
- hide global restrictions when injection protection is off
- skip shell restriction serialization when injection protection isn't enabled
- test omission of restrictions when injection protection disabled

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6a6d77988320a1daa000ccc24dad