### PR TITLE
Remove unused pathMapping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,7 @@ The server uses an inheritance-based configuration system where global defaults 
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       }
     }
   }
@@ -444,11 +440,7 @@ WSL shells have additional configuration options for path mapping:
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       }
     }
   }

--- a/config.examples/config.development.json
+++ b/config.examples/config.development.json
@@ -68,11 +68,7 @@
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       }
     },
     "wsl": {
@@ -84,11 +80,7 @@
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       }
     }
   }

--- a/config.examples/development.json
+++ b/config.examples/development.json
@@ -39,11 +39,7 @@
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       },
       "overrides": {
         "security": {

--- a/docs/CONFIGURATION_EXAMPLES.md
+++ b/docs/CONFIGURATION_EXAMPLES.md
@@ -252,11 +252,7 @@ Configuration optimized for WSL development:
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       },
       "overrides": {
         "security": {
@@ -350,11 +346,7 @@ Configuration supporting different environments with shell-specific overrides:
       },
       "wslConfig": {
         "mountPoint": "/mnt/",
-        "inheritGlobalPaths": true,
-        "pathMapping": {
-          "enabled": true,
-          "windowsToWsl": true
-        }
+        "inheritGlobalPaths": true
       }
     }
   }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -138,7 +138,6 @@ A: When enabled, it limits command execution to directories listed in `allowedPa
 A: WSL configuration includes special options:
 - `inheritGlobalPaths`: Convert Windows paths to WSL format
 - `mountPoint`: Where Windows drives are mounted (default: `/mnt/`)
-- `pathMapping`: Enable automatic path conversion
 
 Example:
 ```json
@@ -146,11 +145,7 @@ Example:
   "wsl": {
     "wslConfig": {
       "mountPoint": "/mnt/",
-      "inheritGlobalPaths": true,
-      "pathMapping": {
-        "enabled": true,
-        "windowsToWsl": true
-      }
+      "inheritGlobalPaths": true
     }
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -149,21 +149,6 @@ export interface WslSpecificConfig {
    * Whether to inherit global path settings and convert to WSL format
    */
   inheritGlobalPaths?: boolean;
-  
-  /**
-   * Path mapping settings between Windows and WSL
-   */
-  pathMapping?: {
-    /**
-     * Whether path mapping is enabled
-     */
-    enabled: boolean;
-    
-    /**
-     * Whether to convert Windows paths to WSL format
-     */
-    windowsToWsl: boolean;
-  };
 }
 
 /**

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -66,11 +66,7 @@ export function createSerializableConfig(config: ServerConfig): any {
       const wc = (shellConfig as any).wslConfig;
       shellInfo.wslConfig = {
         mountPoint: wc.mountPoint,
-        inheritGlobalPaths: wc.inheritGlobalPaths,
-        pathMapping: wc.pathMapping ? {
-          enabled: wc.pathMapping.enabled,
-          windowsToWsl: wc.pathMapping.windowsToWsl
-        } : undefined
+        inheritGlobalPaths: wc.inheritGlobalPaths
       };
     }
 

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -41,11 +41,7 @@ export class TestCLIServer {
       },
       wslConfig: {
         mountPoint: '/mnt/',
-        inheritGlobalPaths: true,
-        pathMapping: {
-          enabled: true,
-          windowsToWsl: true
-        }
+        inheritGlobalPaths: true
       }
     };
     

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -94,11 +94,7 @@ export function createWslEmulatorConfig(overrides: Partial<WslShellConfig> = {})
     },
     wslConfig: {
       mountPoint: '/mnt/',
-      inheritGlobalPaths: true,
-      pathMapping: {
-        enabled: true,
-        windowsToWsl: true
-      }
+      inheritGlobalPaths: true
     },
     ...overrides
   };

--- a/tests/wsl.test.ts
+++ b/tests/wsl.test.ts
@@ -38,11 +38,7 @@ describe('WSL Shell Execution via Emulator (Tests 1-4)', () => {
         },
         wslConfig: {
           mountPoint: '/mnt/',
-          inheritGlobalPaths: true,
-          pathMapping: {
-            enabled: true,
-            windowsToWsl: true
-          }
+          inheritGlobalPaths: true
         }
       };
       
@@ -180,11 +176,7 @@ describe('WSL Working Directory Validation (Test 5)', () => { // Removed .only
         },
         wslConfig: {
           mountPoint: '/mnt/',
-          inheritGlobalPaths: true,
-          pathMapping: {
-            enabled: true,
-            windowsToWsl: true
-          }
+          inheritGlobalPaths: true
         }
       };
       


### PR DESCRIPTION
## Summary
- drop `pathMapping` from WSL config types and utilities
- update docs and example configs
- clean tests and helpers of `pathMapping`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a807b542083209c6a76b84dd069ac