### PR TITLE
Add WSL mount point CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ To get started with configuration:
      --allowedDir C:\safe --allowedDir D:\projects
    ```
 
+   For WSL shells, you can specify a custom mount location:
+
+   ```bash
+   npx wcli0 --shell wsl \
+     --wslMountPoint /windows/
+   ```
+
    When started this way, `restrictWorkingDirectory` is forced on and
    `enableInjectionProtection` is disabled to ensure the allowed paths apply
    without shell injection checks.
@@ -446,6 +453,8 @@ WSL shells have additional configuration options for path mapping:
   }
 }
 ```
+
+You can override the mount point at startup using the `--wslMountPoint` CLI flag.
 
 ### Configuration Inheritance
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -138,6 +138,7 @@ A: When enabled, it limits command execution to directories listed in `allowedPa
 A: WSL configuration includes special options:
 - `inheritGlobalPaths`: Convert Windows paths to WSL format
 - `mountPoint`: Where Windows drives are mounted (default: `/mnt/`)
+  You can override the mount point on startup with the `--wslMountPoint` flag.
 
 Example:
 ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import path from 'path';
 import { buildToolDescription } from './utils/toolDescription.js';
 import { buildExecuteCommandSchema, buildValidateDirectoriesSchema } from './utils/toolSchemas.js';
 import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, buildGetConfigDescription } from './utils/toolDescription.js';
-import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides } from './utils/config.js';
+import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides, applyCliWslMountPoint } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig } from './types/config.js';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -90,6 +90,10 @@ const parseArgs = async () => {
     .option('commandTimeout', {
       type: 'number',
       description: 'Command timeout in seconds'
+    })
+    .option('wslMountPoint', {
+      type: 'string',
+      description: 'Mount point for Windows drives in WSL (default: /mnt/)'
     })
     .option('debug', {
       type: 'boolean',
@@ -929,6 +933,7 @@ const main = async () => {
       args.maxCommandLength as number | undefined,
       args.commandTimeout as number | undefined
     );
+    applyCliWslMountPoint(config, args.wslMountPoint as string | undefined);
 
     const server = new CLIServer(config);
     await server.run();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -462,3 +462,21 @@ export function applyCliSecurityOverrides(
     debugWarn(`WARN: Invalid commandTimeout '${commandTimeout}', ignoring.`);
   }
 }
+
+export function applyCliWslMountPoint(
+  config: ServerConfig,
+  mountPoint?: string
+): void {
+  if (!mountPoint) return;
+
+  const normalized = mountPoint.endsWith('/') ? mountPoint : mountPoint + '/';
+  const shells: (keyof ServerConfig['shells'])[] = ['wsl', 'bash'];
+
+  for (const name of shells) {
+    const shell = config.shells[name] as WslShellConfig | undefined;
+    if (shell) {
+      shell.wslConfig = shell.wslConfig || {};
+      shell.wslConfig.mountPoint = normalized;
+    }
+  }
+}

--- a/tests/wslMountPointCliOverride.test.ts
+++ b/tests/wslMountPointCliOverride.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from '@jest/globals';
+import { applyCliWslMountPoint } from '../src/utils/config.js';
+import { buildTestConfig } from './helpers/testUtils.js';
+
+describe('applyCliWslMountPoint', () => {
+  test('overrides mount point for WSL and Bash shells', () => {
+    const config = buildTestConfig({
+      shells: {
+        wsl: {
+          type: 'wsl',
+          enabled: true,
+          executable: { command: 'wsl.exe', args: ['-e'] },
+          wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true }
+        },
+        bash: {
+          type: 'bash',
+          enabled: true,
+          executable: { command: 'bash', args: ['-c'] },
+          wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true }
+        }
+      }
+    });
+
+    applyCliWslMountPoint(config, '/windows/');
+
+    expect(config.shells.wsl?.wslConfig?.mountPoint).toBe('/windows/');
+    expect(config.shells.bash?.wslConfig?.mountPoint).toBe('/windows/');
+  });
+
+  test('ignores when mount point is undefined', () => {
+    const config = buildTestConfig({
+      shells: {
+        wsl: {
+          type: 'wsl',
+          enabled: true,
+          executable: { command: 'wsl.exe', args: ['-e'] },
+          wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true }
+        }
+      }
+    });
+
+    applyCliWslMountPoint(config, undefined);
+
+    expect(config.shells.wsl?.wslConfig?.mountPoint).toBe('/mnt/');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `applyCliWslMountPoint` util
- support `--wslMountPoint` CLI argument
- document the new option in README and FAQ
- test CLI mount point override

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a915fdff483208e8246c0323c3c70