### PR TITLE
Update CLI override docs

### DIFF
--- a/docs/unit_tests/TEST_DESCRIPTIONS.md
+++ b/docs/unit_tests/TEST_DESCRIPTIONS.md
@@ -72,6 +72,20 @@ This document summarizes the purpose of each unit test in the project.
 - **overrides config initialDir and updates allowedPaths** – applying the CLI option replaces the configured `initialDir` with the provided path and appends it to `allowedPaths`.
 - **invalid directory logs warning and does not override** – supplying a nonexistent directory causes a warning and the original configuration remains unchanged.
 
+## tests/shellCliOverride.test.ts
+
+- **enables only selected shell and sets allowed directories** – activating the CLI flag disables other shells, updates global and shell-specific `allowedPaths`, and enforces working directory restriction.
+
+## tests/securityCliOverride.test.ts
+
+- **overrides security values with valid numbers** – valid `maxCommandLength` and `commandTimeout` values update the configuration when provided via CLI.
+- **logs warning and ignores invalid values** – zero or negative numbers trigger a warning and leave the original security settings intact.
+
+## tests/wslMountPointCliOverride.test.ts
+
+- **overrides mount point for WSL and Bash shells** – applying the CLI option changes the `mountPoint` for both WSL and Bash shell configurations.
+- **ignores when mount point is undefined** – omitting the value leaves existing mount points unchanged.
+
 ## tests/serverCwdInitialization.test.ts
 
 - **launch outside allowed paths leaves cwd undefined** – starting the server in a disallowed directory results in no active working directory.

--- a/docs/unit_tests/securityCliOverride.md
+++ b/docs/unit_tests/securityCliOverride.md
@@ -1,0 +1,4 @@
+# securityCliOverride
+
+- **overrides security values with valid numbers** – valid `maxCommandLength` and `commandTimeout` values update the configuration when provided via CLI.
+- **logs warning and ignores invalid values** – zero or negative numbers trigger a warning and leave the original security settings intact.

--- a/docs/unit_tests/shellCliOverride.md
+++ b/docs/unit_tests/shellCliOverride.md
@@ -1,0 +1,3 @@
+# shellCliOverride
+
+- **enables only selected shell and sets allowed directories** – activating the CLI flag disables other shells, updates global and shell-specific `allowedPaths`, and enforces working directory restriction.

--- a/docs/unit_tests/wslMountPointCliOverride.md
+++ b/docs/unit_tests/wslMountPointCliOverride.md
@@ -1,0 +1,4 @@
+# wslMountPointCliOverride
+
+- **overrides mount point for WSL and Bash shells** – applying the CLI option changes the `mountPoint` for both WSL and Bash shell configurations.
+- **ignores when mount point is undefined** – omitting the value leaves existing mount points unchanged.


### PR DESCRIPTION
## Summary
- add CLI override summaries for new test coverage
- document security, shell and wsl mount point overrides in `TEST_DESCRIPTIONS`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_686a9706a3c88320a17d7bb3c53ca7d3