### PR TITLE
Fix allowed paths merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,7 @@ If no configuration file is found, the server will use a default (restricted) co
       "blockedOperators": ["&", "|", ";", "`"]
     },
     "paths": {
-      "allowedPaths": ["~", "."],
-      "initialDir": null,
-      "restrictWorkingDirectory": true
+      "initialDir": null
     }
   },
   "shells": {
@@ -381,6 +379,11 @@ Global settings provide defaults that apply to all shells unless overridden.
   }
 }
 ```
+
+If the `allowedPaths` array is omitted from your configuration file, no default
+directories are automatically allowed. When `restrictWorkingDirectory` is
+enabled, only the `initialDir` (if specified) will be added to the allowed paths
+list.
 
 #### Shell Configuration
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,17 @@ To get started with configuration:
 
    For WSL shells, you can specify a custom mount location:
 
-   ```bash
-   npx wcli0 --shell wsl \
-     --wslMountPoint /windows/
-   ```
+  ```bash
+  npx wcli0 --shell wsl \
+    --wslMountPoint /windows/
+  ```
+
+  To disable directory restrictions entirely when no allowed paths are
+  configured, start the server with:
+
+  ```bash
+  npx wcli0 --allowAllDirs
+  ```
 
    When started this way, `restrictWorkingDirectory` is forced on and
    `enableInjectionProtection` is disabled to ensure the allowed paths apply
@@ -384,6 +391,8 @@ If the `allowedPaths` array is omitted from your configuration file, no default
 directories are automatically allowed. When `restrictWorkingDirectory` is
 enabled, only the `initialDir` (if specified) will be added to the allowed paths
 list.
+Use the `--allowAllDirs` flag when launching the server to automatically
+disable `restrictWorkingDirectory` if no allowed paths or `initialDir` are set.
 
 #### Shell Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,11 @@ const parseArgs = async () => {
       type: 'string',
       description: 'Mount point for Windows drives in WSL (default: /mnt/)'
     })
+    .option('allowAllDirs', {
+      type: 'boolean',
+      default: false,
+      description: 'Disable working directory restriction when no allowed paths are configured'
+    })
     .option('debug', {
       type: 'boolean',
       default: false,
@@ -919,7 +924,7 @@ const main = async () => {
     }
 
     // Load configuration
-    const config = loadConfig(args.config);
+    const config = loadConfig(args.config, Boolean(args.allowAllDirs));
 
     // Apply command line override for initialDir
     applyCliInitialDir(config, args.initialDir as string | undefined);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -101,7 +101,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   }
 };
 
-export function loadConfig(configPath?: string): ServerConfig {
+export function loadConfig(configPath?: string, disableIfEmpty = false): ServerConfig {
   // If no config path provided, look in default locations
   const configLocations = [
     configPath,
@@ -134,6 +134,15 @@ export function loadConfig(configPath?: string): ServerConfig {
 
   if (!config.global.paths.allowedPaths) {
     config.global.paths.allowedPaths = [];
+  }
+
+  if (
+    disableIfEmpty &&
+    config.global.security.restrictWorkingDirectory &&
+    config.global.paths.allowedPaths.length === 0 &&
+    !config.global.paths.initialDir
+  ) {
+    config.global.security.restrictWorkingDirectory = false;
   }
   
   // Validate and process initialDir if provided

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -30,10 +30,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
       blockedOperators: ['&', '|', ';', '`']
     },
     paths: {
-      allowedPaths: [
-        os.homedir(),
-        process.cwd()
-      ],
+      allowedPaths: [],
       initialDir: undefined
     }
   },
@@ -129,9 +126,15 @@ export function loadConfig(configPath?: string): ServerConfig {
   }
 
   // Use defaults if no config was loaded or merge with loaded config
-  const config = Object.keys(loadedConfig).length > 0
+  const userProvidedConfig = Object.keys(loadedConfig).length > 0;
+
+  const config = userProvidedConfig
     ? mergeConfigs(DEFAULT_CONFIG, loadedConfig)
     : { ...DEFAULT_CONFIG };
+
+  if (!config.global.paths.allowedPaths) {
+    config.global.paths.allowedPaths = [];
+  }
   
   // Validate and process initialDir if provided
   if (config.global.paths.initialDir) {

--- a/tests/errorHandling.test.ts
+++ b/tests/errorHandling.test.ts
@@ -26,6 +26,7 @@ describe('Error Handling', () => {
 
   test('should recover from shell crashes', async () => {
     const crashConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    crashConfig.global.paths.allowedPaths = [process.cwd()];
     if (crashConfig.shells && crashConfig.shells.cmd) {
       // Update the shell configuration to use the new structure
       crashConfig.shells.cmd.executable = {

--- a/tests/integration/mcpProtocol.test.ts
+++ b/tests/integration/mcpProtocol.test.ts
@@ -2,7 +2,10 @@ import { describe, test, expect } from '@jest/globals';
 import { TestCLIServer } from '../helpers/TestCLIServer.js';
 
 const server = new TestCLIServer({
-  security: { restrictWorkingDirectory: true, allowedPaths: [process.cwd()] }
+  global: {
+    security: { restrictWorkingDirectory: true },
+    paths: { allowedPaths: [process.cwd()] }
+  }
 });
 
 describe('MCP Protocol Interactions', () => {

--- a/tests/integration/shellExecution.test.ts
+++ b/tests/integration/shellExecution.test.ts
@@ -4,7 +4,9 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 describe('Shell Execution Security', () => {
   test('should reject commands with blocked operators', async () => {
-    const server = new TestCLIServer();
+    const server = new TestCLIServer({
+      global: { paths: { allowedPaths: [process.cwd()] } }
+    });
     await expect(
       server.executeCommand({ shell: 'wsl', command: 'echo hi ; ls' })
     ).rejects.toBeInstanceOf(McpError);


### PR DESCRIPTION
## Summary
- avoid automatically adding home or working directory in defaults
- update default configuration docs
- ensure tests specify allowedPaths when needed

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686aba447cd083209aafddd21983336a