### PR TITLE
Respect empty restriction arrays in mergeConfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,8 +475,11 @@ The inheritance system works as follows:
 1. **Global defaults** are applied to all shells
 2. **Shell-specific overrides** replace or extend global settings
 3. **Array settings** (like `blockedCommands`) are merged, not replaced
-4. **Object settings** are deep-merged
-5. **Primitive settings** are replaced
+4. **Empty arrays disable defaults** – specifying an empty array for a field
+   such as `blockedCommands`, `blockedArguments`, or `blockedOperators`
+   results in no defaults being applied for that setting
+5. **Object settings** are deep-merged
+6. **Primitive settings** are replaced
 
 Example of inheritance in action:
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,23 @@ The inheritance system works as follows:
 5. **Object settings** are deep-merged
 6. **Primitive settings** are replaced
 
+For instance, you can disable the default command, argument, and operator
+restrictions by providing empty arrays:
+
+```json
+{
+  "global": {
+    "restrictions": {
+      "blockedCommands": [],
+      "blockedArguments": [],
+      "blockedOperators": []
+    }
+  }
+}
+```
+
+With these arrays defined as empty, no defaults will apply for those fields.
+
 Example of inheritance in action:
 
 ```json

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -200,15 +200,14 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
         ...(userConfig.global?.security || {})
       },
       restrictions: {
-        // Merge arrays properly - only use user config arrays if they have content,
-        // otherwise keep defaults
-        blockedCommands: (userConfig.global?.restrictions?.blockedCommands && userConfig.global.restrictions.blockedCommands.length > 0) 
-          ? userConfig.global.restrictions.blockedCommands 
+        // Use user-provided arrays whenever defined, even if empty
+        blockedCommands: (userConfig.global?.restrictions?.blockedCommands !== undefined)
+          ? userConfig.global.restrictions.blockedCommands
           : defaultConfig.global.restrictions.blockedCommands,
-        blockedArguments: (userConfig.global?.restrictions?.blockedArguments && userConfig.global.restrictions.blockedArguments.length > 0)
+        blockedArguments: (userConfig.global?.restrictions?.blockedArguments !== undefined)
           ? userConfig.global.restrictions.blockedArguments
           : defaultConfig.global.restrictions.blockedArguments,
-        blockedOperators: (userConfig.global?.restrictions?.blockedOperators && userConfig.global.restrictions.blockedOperators.length > 0)
+        blockedOperators: (userConfig.global?.restrictions?.blockedOperators !== undefined)
           ? userConfig.global.restrictions.blockedOperators
           : defaultConfig.global.restrictions.blockedOperators
       },

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -83,8 +83,10 @@ describe('Config Normalization', () => {
     expect(cfg.global.security.maxCommandLength).toBe(500);
     expect(cfg.global.paths.allowedPaths).toContain('c:\\custom\\path');
 
-    // Check that there are some blockedCommands (we don't need to check exact values)
-    expect(cfg.global.restrictions.blockedCommands.length).toBeGreaterThan(0);
+    // Empty arrays in user config should override defaults
+    expect(cfg.global.restrictions.blockedCommands).toEqual([]);
+    expect(cfg.global.restrictions.blockedArguments).toEqual([]);
+    expect(cfg.global.restrictions.blockedOperators).toEqual([]);
     expect(cfg.global.security.commandTimeout).toBe(DEFAULT_CONFIG.global.security.commandTimeout);
     expect(cfg.global.security.enableInjectionProtection).toBe(DEFAULT_CONFIG.global.security.enableInjectionProtection);
 


### PR DESCRIPTION
## Summary
- allow empty arrays for blockedCommands, blockedArguments, and blockedOperators
- document disabling defaults by passing empty arrays
- test that user-provided empty arrays override defaults

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ae62db63083208d9f177c199c188b