### PR TITLE
Add resource template handler

### DIFF
--- a/docs/unit_tests/handlers/resourceHandler.md
+++ b/docs/unit_tests/handlers/resourceHandler.md
@@ -8,3 +8,4 @@
 - **returns security information summary** – tests that `cli://info/security` summarizes enabled shells and key security settings.
 - **returns error for unknown resource** – ensures an unknown URI is rejected with an error.
 - **returns error for disabled shell resource** – verifies that requesting configuration for a disabled shell produces an error.
+- **returns no resource templates by default** – checks that listing resource templates yields an empty array.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
   CallToolResult, // Changed from CallToolResultPayload
   ErrorCode,
@@ -452,6 +453,11 @@ class CLIServer {
       });
 
       return { resources };
+    });
+
+    // Provide an empty list of resource templates for now
+    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+      return { resourceTemplates: [] };
     });
 
     // Read resource content

--- a/tests/handlers/resourceTemplatesHandler.test.ts
+++ b/tests/handlers/resourceTemplatesHandler.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import { buildTestConfig } from '../helpers/testUtils.js';
+import { executeListResourceTemplates } from '../helpers/testServerUtils.js';
+
+describe('ListResourceTemplates Handler', () => {
+  test('returns empty template list', async () => {
+    const config = buildTestConfig();
+    const server = new CLIServer(config);
+    const result = await executeListResourceTemplates(server);
+    expect(result.resourceTemplates).toEqual([]);
+  });
+});

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -365,6 +365,14 @@ export class TestCLIServer {
   }
 
   /**
+   * Implementation of the list resource templates handler for testing
+   * @returns An empty array of resource templates
+   */
+  async listResourceTemplates(): Promise<{ resourceTemplates: any[] }> {
+    return { resourceTemplates: [] };
+  }
+
+  /**
    * Implementation of the read resource handler for testing
    * @param uri The resource URI to read
    * @returns The content of the requested resource

--- a/tests/helpers/testServerUtils.ts
+++ b/tests/helpers/testServerUtils.ts
@@ -98,6 +98,20 @@ export async function executeListResources(server: CLIServer): Promise<any> {
 }
 
 /**
+ * Execute the list resource templates request handler
+ * @param server - The server to use
+ * @returns The list of resource templates
+ */
+export async function executeListResourceTemplates(server: CLIServer): Promise<any> {
+  if (server instanceof TestCLIServer) {
+    return (server as TestCLIServer).listResourceTemplates();
+  }
+
+  const testServer = new TestCLIServer((server as any).config);
+  return await testServer.listResourceTemplates();
+}
+
+/**
  * Execute the read resource request handler
  * @param server - The server to use
  * @param uri - The resource URI


### PR DESCRIPTION
## Summary
- import `ListResourceTemplatesRequestSchema`
- handle `ListResourceTemplates` in `setupHandlers`
- expose helper in `TestCLIServer` and `testServerUtils`
- test empty template list
- document the new handler test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e85a331e48320b18322777313342c