### PR TITLE
Bump version and document new handler tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+## [1.0.7] - 2025-07-09
+
+### Added
+- CLI restriction override flags
+- WSL mount point flag
+- Option to disable default directory restriction
+- Bash shell support
+- Resource templates handler
+
+### Changed
+- Simplified `get_config` output with enabled shells
+- Improved configuration merging behavior
+
+### Fixed
+- Resolved script execution via symlink
+- Corrected extra allowed path handling
+- Improved Git Bash path detection
+- CLI no longer auto-starts when imported
+
 
 ## [1.0.6] - 2025-07-04
 

--- a/docs/unit_tests/TEST_DESCRIPTIONS.md
+++ b/docs/unit_tests/TEST_DESCRIPTIONS.md
@@ -250,3 +250,7 @@ The tests also cover the correct normalization and validation of WSL paths (e.g.
 - **should reject commands with blocked operators** – executing a command containing `;` results in an `McpError`.
 - **should enforce working directory restrictions** – commands fail when executed from disallowed directories.
 - **should execute when working directory allowed** – succeeds when the directory is permitted by the configuration.
+
+## tests/handlers/resourceTemplatesHandler.test.ts
+
+- **returns empty template list** – verifies that the ListResourceTemplates handler responds with an empty array.

--- a/docs/unit_tests/handlers/resourceTemplatesHandler.md
+++ b/docs/unit_tests/handlers/resourceTemplatesHandler.md
@@ -1,0 +1,3 @@
+# handlers/resourceTemplatesHandler
+
+- **returns empty template list** – verifies that the handler responds with an empty `resourceTemplates` array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wcli0",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wcli0",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wcli0",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Enhanced MCP server for Windows CLI interactions with advanced configuration and security features",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- document `resourceTemplates` unit tests
- bump to 1.0.7
- update changelog with changes since 1.0.6

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e93c328e083208f140e8b4a023397