### PR TITLE
test: add WSL2 integration tests, fix path case preservation, and clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .env
+.mcp.json
 .DS_Store
 *.log
 tests/config*.json
@@ -11,6 +12,9 @@ performance-results.json
 
 # VS Code
 .vscode/
+
+# Claude Code
+.claude/
 coverage/
 
 # Private documentation

--- a/docs/tasks/wsl_integration_tests/analysis_1_preserve_root_path.md
+++ b/docs/tasks/wsl_integration_tests/analysis_1_preserve_root_path.md
@@ -1,0 +1,9 @@
+# Analysis 1 - Preserve Root Path
+
+## Decision: Valid — fix applied
+
+The concern is correct: `currentPath.replace(trailingSep, '')` at `src/utils/validation.ts:443` turns `/` into `''`. This empty string is then pushed into `processedPaths`. In `isPathAllowed`, an empty `normalizedAllowedPath` matches every path (since every string starts with `''`), making it silently allow all paths — a security issue. The fix guards the trailing-separator removal so that `/` (Unix root) is preserved as-is, matching the existing pattern used for `C:\` and UNC share roots at lines 411-418.
+
+**Why:** The root path `/` is a valid Unix path that should be explicitly allowed. Stripping it to `''` is both semantically wrong and a security risk. The fix follows the same pattern already established for Windows drive roots.
+
+**Commit:** 5c966c1 — fix(validation): address review feedback for PR #82

--- a/docs/tasks/wsl_integration_tests/analysis_2_wsl_cwd_without_exe_suffix.md
+++ b/docs/tasks/wsl_integration_tests/analysis_2_wsl_cwd_without_exe_suffix.md
@@ -1,0 +1,7 @@
+# Analysis 2 - WSL cwd without .exe suffix
+
+## Decision: Rejected — theoretical edge case, intentional design
+
+The `.exe` suffix check at `src/index.ts:403` is intentionally designed to differentiate between two runtime scenarios: (1) Windows-native Node.js spawning `wsl.exe` where `spawn` needs a Windows cwd, and (2) WSL2 Linux Node.js spawning `wsl.exe` via Windows interop where `spawn` needs a Linux cwd. Switching to `process.platform` would break scenario (2) because WSL2 reports `process.platform === 'linux'` despite having access to `wsl.exe`. The default configuration uses `wsl.exe`, and alternative executables (`wsl` without `.exe`, `.cmd` wrappers) are not standard WSL launchers.
+
+**Why:** The `.exe` suffix is the correct heuristic for distinguishing Windows-native spawn from Linux spawn in the dual-platform WSL scenario. Users who change the executable away from the documented default of `wsl.exe` accept responsibility for the configuration. Using `process.platform` would cause real regressions for the WSL2-from-WSL use case.

--- a/docs/tasks/wsl_integration_tests/analysis_3_skip_git_bash_tests.md
+++ b/docs/tasks/wsl_integration_tests/analysis_3_skip_git_bash_tests.md
@@ -1,0 +1,9 @@
+# Analysis 3 - Skip Git Bash tests
+
+## Decision: Valid — fix applied
+
+The tests use `if (!server) return` guards which cause Jest to report them as passing with zero assertions, creating a false sense of coverage. The fix replaces the `beforeEach` early-return pattern with a `describe.skip` wrapper that checks for Git Bash availability once, making skipped tests visible in the Jest output. This follows the same pattern already used by `describeOnWindows` at line 9 which skips the entire suite on non-Windows platforms.
+
+**Why:** Test transparency matters — silently passing tests that never ran hides missing prerequisites. Using `describe.skip` produces accurate coverage reporting and makes it immediately obvious when Git Bash is not installed.
+
+**Commit:** 5c966c1 — fix(validation): address review feedback for PR #82

--- a/docs/tasks/wsl_integration_tests/analysis_4_wsl_extensionless_launcher.md
+++ b/docs/tasks/wsl_integration_tests/analysis_4_wsl_extensionless_launcher.md
@@ -1,0 +1,9 @@
+# Analysis 4 - Convert WSL cwd for extensionless Windows launcher
+
+## Decision: Valid — fix applied
+
+On native Windows, both `wsl` and `wsl.exe` resolve to the same Windows binary, so the cwd must be converted regardless of the executable suffix. On WSL2 (Linux), only `.exe`-suffixed commands are Windows interop binaries that need Windows paths. The fix uses `process.platform === 'win32' || .exe` to cover both platforms correctly.
+
+**Why:** The `.exe` suffix check was intentionally narrow for the WSL2 (Linux Node) scenario, but it incorrectly skips conversion on native Windows where `wsl` without `.exe` is still a Windows binary. Using `process.platform` distinguishes the two scenarios cleanly.
+
+**Commit:** 8d7c451 — fix(validation): address review feedback round 2 for PR #82

--- a/docs/tasks/wsl_integration_tests/analysis_5_unix_path_case_global.md
+++ b/docs/tasks/wsl_integration_tests/analysis_5_unix_path_case_global.md
@@ -1,0 +1,9 @@
+# Analysis 5 - Preserve Unix path case in global allow checks
+
+## Decision: Valid — fix applied
+
+`isPathAllowed` unconditionally lowercases both the test path and the allowed path, which defeats the case-preservation work in `normalizeAllowedPaths` for Unix paths. Since Unix filesystems are case-sensitive, `/tmp/MyApp` and `/tmp/myapp` are different directories. The fix skips `.toLowerCase()` for paths that start with `/` (Unix-style), making global allow checks case-sensitive for Unix paths while remaining case-insensitive for Windows paths.
+
+**Why:** The `normalizeAllowedPaths` function already preserves case for Unix paths (see `src/utils/validation.ts:428-429`), but `isPathAllowed` lowercases everything, making the preservation useless for global checks like startup CWD validation and `set_current_directory`.
+
+**Commit:** 8d7c451 — fix(validation): address review feedback round 2 for PR #82

--- a/docs/tasks/wsl_integration_tests/analysis_6_unc_test_determinism.md
+++ b/docs/tasks/wsl_integration_tests/analysis_6_unc_test_determinism.md
@@ -1,0 +1,9 @@
+# Analysis 6 - Avoid OS-dependent UNC rejection in Windows tests
+
+## Decision: Valid — fix applied
+
+Changed the UNC tests to pass `allowedPaths` so `restrictWorkingDirectory` is enabled and the validation layer rejects UNC paths deterministically, instead of relying on Node's spawn to fail on a non-existent network path. The error matcher now checks for "allowed paths" to confirm the rejection comes from validation.
+
+**Why:** Without `allowedPaths`, the test exercised spawn failure rather than path validation, making it fragile and environment-dependent. With deterministic validation, the test verifies the intended security behavior regardless of host network configuration.
+
+**Commit:** 8d7c451 — fix(validation): address review feedback round 2 for PR #82

--- a/docs/tasks/wsl_integration_tests/comment_1_preserve_root_path.md
+++ b/docs/tasks/wsl_integration_tests/comment_1_preserve_root_path.md
@@ -1,0 +1,3 @@
+# P1 - Preserve '/' when normalizing Unix allowed paths
+
+When a user configures `/` as an allowed path for a Unix-style shell, the replacement at `src/utils/validation.ts:443` turns it into the empty string because `/` matches the trailing-separator regex. The normalized value no longer starts with `/`, so `validateUnixPath` rejects every absolute working directory even though root was explicitly allowed; the root path `/` should be preserved when trimming trailing separators.

--- a/docs/tasks/wsl_integration_tests/comment_2_wsl_cwd_without_exe_suffix.md
+++ b/docs/tasks/wsl_integration_tests/comment_2_wsl_cwd_without_exe_suffix.md
@@ -1,0 +1,3 @@
+# P2 - Convert WSL cwd for Windows commands without .exe suffix
+
+When the server is running on Windows and the WSL shell executable is configured as `wsl` (or a wrapper such as `.cmd`) instead of the default `wsl.exe`, the check at `src/index.ts:403` leaves `/mnt/c/...` as the process `cwd`; Windows `spawn` cannot use that Linux-style cwd, so commands with a mounted-drive workingDir fail before reaching WSL. The conversion should be based on the host/platform or all Windows-resolved WSL launchers, not only a literal `.exe` suffix.

--- a/docs/tasks/wsl_integration_tests/comment_3_skip_git_bash_tests.md
+++ b/docs/tasks/wsl_integration_tests/comment_3_skip_git_bash_tests.md
@@ -1,0 +1,3 @@
+# P3 - Skip Git Bash tests instead of returning early
+
+On Windows machines where Git Bash is not installed at exactly `C:\Program Files\Git\bin\bash.exe`, the `beforeEach` in `tests/windows/shellExecution.test.ts:243` leaves `server` unset and each test returns before making any assertions, so Jest reports the Git Bash coverage as passing even though nothing ran. This should use an explicit skipped/conditional suite or assert the prerequisite so missing Git Bash is visible rather than a false pass.

--- a/docs/tasks/wsl_integration_tests/comment_4_wsl_extensionless_launcher.md
+++ b/docs/tasks/wsl_integration_tests/comment_4_wsl_extensionless_launcher.md
@@ -1,0 +1,3 @@
+# P4 - Convert WSL cwd for extensionless Windows launcher
+
+When the server runs on native Windows and the WSL executable is configured as `wsl` instead of the default `wsl.exe`, the `.exe` suffix check at `src/index.ts:403` leaves `/mnt/c/...` working directory unchanged. Windows `spawn` receives a Linux-style `cwd` and fails before WSL starts, whereas the previous behavior converted mounted paths for all WSL launchers. The conversion should be based on the host platform or recognized Windows WSL launchers rather than only a literal `.exe` suffix.

--- a/docs/tasks/wsl_integration_tests/comment_5_unix_path_case_global.md
+++ b/docs/tasks/wsl_integration_tests/comment_5_unix_path_case_global.md
@@ -1,0 +1,3 @@
+# P5 - Preserve Unix path case in global allow checks
+
+`normalizeAllowedPaths` preserves case for Unix paths, but global callers such as startup CWD validation and `set_current_directory` go through `isPathAllowed` (`src/utils/validation.ts:270`), which lowercases both the candidate and allowed path before comparing. An allowed `/tmp/MyApp` still accepts `/tmp/myapp` on Unix, so the case-preservation fix does not protect non-shell-specific permission checks. Unix paths need case-sensitive comparison in `isPathAllowed`.

--- a/docs/tasks/wsl_integration_tests/comment_6_unc_test_determinism.md
+++ b/docs/tasks/wsl_integration_tests/comment_6_unc_test_determinism.md
@@ -1,0 +1,3 @@
+# P6 - Avoid OS-dependent UNC rejection in Windows tests
+
+In the UNC tests at `tests/windows/pathHandling.test.ts:134-156`, `buildWindowsConfig('cmd')` is called without `allowedPaths`, so `restrictWorkingDirectory` is false and `_executeTool` skips working-directory validation entirely. The test only passes if Windows/Node fails spawning with `\\server\share` as `cwd` (ENOENT when `cwd` does not exist). It can fail or hang in environments where the UNC name resolves differently. Use a deterministic validation setup instead of relying on host network path lookup.

--- a/docs/tasks/wsl_integration_tests/progress.md
+++ b/docs/tasks/wsl_integration_tests/progress.md
@@ -5,3 +5,9 @@
 - [x] P1: Preserve Unix root `/` in `normalizeAllowedPaths` (fixed — guard against stripping `/` to `''`; fix nesting/child detection for root path)
 - [-] P2: WSL cwd conversion without `.exe` suffix (rejected — `.exe` check is intentional for dual-platform WSL scenario)
 - [x] P3: Skip Git Bash tests when unavailable (fixed — replaced `if (!server) return` with `describe.skip`; removed early-return guards)
+
+## Review Feedback Round 2 (PR #82)
+
+- [x] P4: WSL cwd conversion for extensionless Windows launcher (fixed — use `process.platform === 'win32'` OR `.exe` suffix check)
+- [x] P5: Preserve Unix path case in global `isPathAllowed` checks (fixed — skip `.toLowerCase()` for Unix paths in `isPathAllowed`)
+- [x] P6: Avoid OS-dependent UNC rejection in Windows tests (fixed — pass `allowedPaths` so validation rejects UNC deterministically)

--- a/docs/tasks/wsl_integration_tests/progress.md
+++ b/docs/tasks/wsl_integration_tests/progress.md
@@ -1,0 +1,7 @@
+# WSL2 Integration Tests — Progress
+
+## Review Feedback (PR #82)
+
+- [x] P1: Preserve Unix root `/` in `normalizeAllowedPaths` (fixed — guard against stripping `/` to `''`; fix nesting/child detection for root path)
+- [-] P2: WSL cwd conversion without `.exe` suffix (rejected — `.exe` check is intentional for dual-platform WSL scenario)
+- [x] P3: Skip Git Bash tests when unavailable (fixed — replaced `if (!server) return` with `describe.skip`; removed early-return guards)

--- a/docs/tasks/wsl_integration_tests/task.md
+++ b/docs/tasks/wsl_integration_tests/task.md
@@ -1,0 +1,132 @@
+# WSL2 Real-Environment Integration Tests (bash shell)
+
+## Goal
+
+Create a test suite that runs the same scenarios as `tests/wsl.test.ts` (emulator-based) but targets **real `bash` shell** inside WSL2 instead of the `wsl-emulator.js` mock. This allows side-by-side comparison of emulator vs real bash behavior.
+
+## Context
+
+- `tests/wsl.test.ts` runs all commands through `scripts/wsl-emulator.js` — a Node.js script that simulates a Linux-like shell on Windows.
+- The `bash` shell config uses `bash -c` as the executable (`src/utils/config.ts:105`). When the MCP server runs inside WSL2, `bash` resolves to the native Linux bash — no nesting or emulation.
+- The `wsl` shell type uses `wsl.exe -e`, which is designed for Windows-to-WSL bridging. Inside WSL2, calling `wsl.exe` would nest WSL — the `bash` shell is the correct choice for in-WSL testing.
+- These tests are the logical counterpart to `tests/windows/shellExecution.test.ts` (which tests cmd/powershell/gitbash on native Windows).
+
+## Why bash, not wsl
+
+Inside WSL2 the Node process is already running on Linux. The available shells differ:
+
+| Shell | Executable | Works inside WSL2? |
+|-------|-----------|-------------------|
+| bash | `bash -c` | Yes — native Linux bash |
+| wsl | `wsl.exe -e` | Redundant — nests WSL inside WSL |
+| cmd | `cmd.exe /c` | Available via `/mnt/c/Windows/...`interop |
+| powershell | `powershell.exe ...` | Available via interop |
+| gitbash | `bash.exe -c` | Windows binary, available via interop |
+
+Testing `bash` exercises the primary use case: an MCP server running natively inside WSL2, executing commands through the native Linux shell.
+
+## File Location
+
+`tests/wsl/bashExecution.test.ts`
+
+## Guard
+
+Tests must only run when inside WSL2. Detect WSL2 by checking for `/proc/version` containing `microsoft`:
+
+```ts
+import fs from 'fs';
+
+function isRunningInWsl2(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    const version = fs.readFileSync('/proc/version', 'utf8');
+    return version.toLowerCase().includes('microsoft');
+  } catch {
+    return false;
+  }
+}
+
+const describeBash = isRunningInWsl2() ? describe : describe.skip;
+```
+
+This avoids the need to shell out to `wsl.exe` and correctly identifies the WSL2 Linux environment.
+
+## Test Matrix
+
+Mirror every test from `tests/wsl.test.ts`. Each test uses the **bash shell** (`bash -c`) instead of the emulator.
+
+### Group 1: Basic Command Execution
+
+| Test ID | Emulator Test | Real Bash Test | Description |
+|---------|---------------|---------------|-------------|
+| R1 | Test 1: echo | `echo hello bash in wsl2` | Basic command execution, check stdout, exit code 0 |
+| R2 | Test 2: exit code | `exit 42` | Non-zero exit code reported correctly |
+| R3 | Test 3: stderr | `ls /nonexistent_directory_for_bash_test_xyz` | stderr captured in output, non-zero exit code |
+| R4 | Test 4: injection | `echo bad ; ls` | Semicolon blocked by injection protection |
+
+### Group 2: Extended Command Execution
+
+| Test ID | Emulator Test | Real Bash Test | Description |
+|---------|---------------|---------------|-------------|
+| R4.1 | Test 4.1: uname | `uname -a` | Verify output contains `Linux` (not `Msys` like the emulator) |
+| R4.2 | Test 4.2: ls args | `ls -la /tmp` | Multi-argument command, check `total N` and `.`/`..` entries |
+| R4.3 | Test 4.3: bad path | `ls /no/such/path/at/all` | Non-existent path, `No such file or directory` in output |
+
+### Group 3: Working Directory Validation
+
+| Test ID | Emulator Test | Real Bash Test | Description |
+|---------|---------------|---------------|-------------|
+| R5.1 | Test 5.1: valid cwd (sub) | `pwd` in `/tmp/bash-test-<rand>/sub` | Create temp dir under `/tmp`, verify `pwd` matches |
+| R5.1.1 | Test 5.1.1: valid cwd (/tmp) | `pwd` in `/tmp` | Standard Linux path works as working directory |
+| R5.2 | Test 5.2: invalid cwd | `pwd` in `/opt/forbidden_dir` | Rejected — not in allowedPaths |
+| R5.3 | Test 5.3: invalid cwd (prefix) | `pwd` in `/tmp/bash-test-suffix` | Rejected — prefix match is not containment |
+| R5.4 | Test 5.4: invalid cwd (pure Linux) | `pwd` in `/usr/local` | Rejected — not in allowedPaths |
+
+## Configuration
+
+Each test configures the bash shell with native `bash -c`, not the emulator:
+
+```ts
+testConfig.shells.bash = {
+  type: 'bash',
+  enabled: true,
+  executable: {
+    command: 'bash',
+    args: ['-c']
+  },
+  overrides: {
+    restrictions: {
+      blockedOperators: ['&', '|', ';', '`']
+    }
+  }
+};
+```
+
+All other shells (cmd, powershell, gitbash, wsl) are disabled.
+
+## Key Differences from Emulator Tests
+
+1. **uname output**: Emulator returns `Msys`; real bash in WSL2 returns `Linux` — test must match `Linux` only.
+2. **Path handling**: Native Linux paths (`/tmp`, `/home/...`) work directly. No `/mnt/` conversion involved since `bash` is not a Windows `.exe` — the spawn cwd guard in `src/index.ts` leaves paths unchanged.
+3. **Temp directories**: Use `/tmp/bash-test-<random>` inside the Linux filesystem. No Windows `os.tmpdir()` needed.
+4. **Timing**: Real bash spawning is slower than the emulator (but faster than `wsl.exe` since there is no VM boundary). Increase timeouts if needed.
+5. **Cleanup**: Temp directories created in `/tmp` must be removed in `afterEach`.
+6. **Shell type**: Tests use `shell: 'bash'` in arguments, not `shell: 'wsl'`. The `validatePath` function for bash accepts `/` and relative paths — no `/mnt/` prefix required.
+
+## Implementation Steps
+
+1. Create `tests/wsl/bashExecution.test.ts` with the WSL2 detection guard.
+2. Implement Group 1 (R1-R4) — basic execution and injection protection.
+3. Implement Group 2 (R4.1-R4.3) — extended commands with real Linux output.
+4. Implement Group 3 (R5.1-R5.4) — working directory validation with real Linux paths.
+5. Verify all tests pass inside WSL2.
+6. Verify all tests are skipped on native Linux, macOS, and Windows.
+
+## Acceptance Criteria
+
+- [x] Test file exists at `tests/wsl/bashExecution.test.ts`
+- [x] Every test from `tests/wsl.test.ts` has a corresponding real-bash test
+- [x] Tests are skipped outside WSL2 (checked via `/proc/version`)
+- [x] Tests pass inside WSL2 with `bash -c`
+- [x] No modification to existing emulator tests
+- [x] Test naming follows the R1, R2, ... convention for easy cross-reference

--- a/docs/tasks/wsl_tests/plan.md
+++ b/docs/tasks/wsl_tests/plan.md
@@ -1,0 +1,76 @@
+# MCP Testing in WSL2 — Plan
+
+## Current State
+
+**Environment**: WSL2 (kernel 5.15.167.4), Node v22.12.0 (via nvm), `wsl.exe` available.
+
+**Test results**: 769/806 pass, 27 fail across 4 test suites:
+- `tests/wsl.test.ts` — 6 failures
+- `tests/asyncOperations.test.ts` — failures
+- `tests/integration/perCommandOutputLimit.test.ts` — failures
+- `tests/unit/perCommandOutputLimit.test.ts` — failures
+
+**Root cause**: All failures show `spawn node ENOENT`. The `TestCLIServer` spawns `node` as a bare command (`TestCLIServer.ts:34`), but WSL2+nvm doesn't put `node` on the default `spawn` PATH. `spawn('node', ...)` without `{ shell: true }` fails to resolve it.
+
+---
+
+## Phase 1 — Fix the known `spawn node ENOENT` issue
+
+| # | Task | Why |
+|---|------|-----|
+| 1.1 | In `TestCLIServer.ts:34`, resolve the full `node` path via `process.execPath` instead of bare `'node'` | Fixes all 27 failures that block the rest of testing |
+| 1.2 | Run full suite and verify 0 failures | Confirms no regressions |
+
+---
+
+## Phase 2 — MCP stdio transport in WSL2
+
+| # | Task | Why |
+|---|------|-----|
+| 2.1 | Build the project (`npm run build`) and test `node dist/index.js` as an MCP stdio server | Validates the actual MCP server starts and responds via stdio |
+| 2.2 | Send JSON-RPC `initialize` + `tools/list` requests via stdin, parse stdout | Confirms the MCP protocol handshake works end-to-end in WSL2 |
+| 2.3 | Send `tools/call` for `execute_command` with `bash` shell | Validates command execution through MCP in WSL2 |
+
+---
+
+## Phase 3 — WSL shell behavior
+
+| # | Task | Why |
+|---|------|-----|
+| 3.1 | Test `execute_command` with shell=`bash` running real commands (`echo`, `pwd`, `uname -a`) | Native bash is the primary shell in WSL2 |
+| 3.2 | Test `execute_command` with shell=`wsl` calling `wsl.exe -e` from inside WSL2 | Nested WSL-in-WSL — validates the wsl shell type works when server runs in WSL2 |
+| 3.3 | Verify `wsl.exe` path conversion: `/mnt/c/...` stays as Linux path when spawning from WSL2 (not converted to `C:\...`) | The spawn cwd fix from Phase 1 prevents ENOENT for non-.exe executables |
+| 3.4 | Test `execute_command` with shell=`cmd` calling `cmd.exe /c echo hello` | **DONE** — `tests/windows/shellExecution.test.ts` (Phase 3.4 describe block) |
+| 3.5 | Test `execute_command` with shell=`powershell` calling `powershell.exe -Command "echo hello"` | **DONE** — `tests/windows/shellExecution.test.ts` (Phase 3.5 describe block) |
+
+---
+
+## Phase 4 — Path handling across WSL2 boundaries
+
+| # | Task | Why |
+|---|------|-----|
+| 4.1 | Test `/mnt/c/...` to `C:\...` conversion when server runs in WSL2 — verify it's skipped for Linux executables | The server does WSL-to-Windows path conversion for `spawn` cwd; must not apply when spawning Linux binaries |
+| 4.2 | Test `set_current_directory` with WSL paths (`/tmp`, `/mnt/d/...`) and verify round-trip | Mixed path formats in a WSL2 environment |
+| 4.3 | Test `validate_directories` with cross-boundary paths (`/mnt/c/...`, `/home/...`) | Security validation across mount points |
+
+---
+
+## Phase 5 — WSL emulator accuracy validation
+
+| # | Task | Why |
+|---|------|-----|
+| 5.1 | Compare `wsl-emulator.js` behavior with real `wsl.exe -e` output for basic commands | The emulator may drift from real WSL behavior |
+| 5.2 | Test the full WSL test suite (`npm run test:wsl`) with `wsl.exe` instead of the emulator | Validates tests would pass against real WSL, not just the mock |
+
+---
+
+## Phase 6 — Windows shell testing (implemented on native Windows)
+
+Tests are in `tests/windows/` and gated on `process.platform === 'win32'` (skipped on non-Windows).
+
+| # | Task | Status |
+|---|------|--------|
+| 6.1 | Test `execute_command` with shell=`cmd` running real commands | **DONE** — `tests/windows/shellExecution.test.ts` (Phase 6.1) |
+| 6.2 | Test `execute_command` with shell=`powershell` running real commands | **DONE** — `tests/windows/shellExecution.test.ts` (Phase 6.2) |
+| 6.3 | Test `execute_command` with shell=`gitbash` running real commands | **DONE** — `tests/windows/shellExecution.test.ts` (Phase 6.3) |
+| 6.4 | Test Windows path handling: `C:\...` paths, `\\server\share` UNC paths | **DONE** — `tests/windows/pathHandling.test.ts` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,18 +397,21 @@ class CLIServer {
         let spawnCwd = workingDir;
         let envVars = { ...process.env };
         if (shellConfig.type === 'wsl') {
-          if (workingDir.startsWith('/mnt/')) {
-            // Convert /mnt/c/path to C:\path
-            const match = workingDir.match(/^\/mnt\/([a-z])\/(.*)$/i);
-            if (match) {
-              const drive = match[1].toUpperCase();
-              const pathPart = match[2].replace(/\//g, '\\');
-              spawnCwd = `${drive}:\\${pathPart}`;
+          // Only convert paths when the executable is a Windows binary (.exe).
+          // When running inside WSL2 with the emulator (spawned via Linux node),
+          // Linux spawn needs Linux paths — conversion would cause ENOENT.
+          const isWindowsExe = shellConfig.executable.command.toLowerCase().endsWith('.exe');
+          if (isWindowsExe) {
+            if (workingDir.startsWith('/mnt/')) {
+              const match = workingDir.match(/^\/mnt\/([a-z])\/(.*)$/i);
+              if (match) {
+                const drive = match[1].toUpperCase();
+                const pathPart = match[2].replace(/\//g, '\\');
+                spawnCwd = `${drive}:\\${pathPart}`;
+              }
+            } else if (workingDir.startsWith('/')) {
+              spawnCwd = process.cwd();
             }
-          } else if (workingDir.startsWith('/')) {
-            // Pure Linux paths like /tmp - use current directory for spawn
-            // and let emulator handle the path emulation
-            spawnCwd = process.cwd();
           }
           // Pass original WSL path to emulator via environment variable
           envVars.WSL_ORIGINAL_PATH = workingDir;

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,10 +397,11 @@ class CLIServer {
         let spawnCwd = workingDir;
         let envVars = { ...process.env };
         if (shellConfig.type === 'wsl') {
-          // Only convert paths when the executable is a Windows binary (.exe).
-          // When running inside WSL2 with the emulator (spawned via Linux node),
-          // Linux spawn needs Linux paths — conversion would cause ENOENT.
-          const isWindowsExe = shellConfig.executable.command.toLowerCase().endsWith('.exe');
+          // Convert paths when on native Windows or when the executable is a
+          // Windows binary (.exe). On WSL2 (Linux Node), only .exe-suffixed
+          // commands are Windows interop binaries; other launchers need Linux paths.
+          const isWindowsExe = process.platform === 'win32' ||
+            shellConfig.executable.command.toLowerCase().endsWith('.exe');
           if (isWindowsExe) {
             if (workingDir.startsWith('/mnt/')) {
               const match = workingDir.match(/^\/mnt\/([a-z])\/(.*)$/i);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -440,7 +440,9 @@ export function normalizeAllowedPaths(paths: string[]): string[] {
         const sep = isUnix ? '/' : '\\';
 
         // a. Create a version of currentPath without a trailing separator
-        const comparableCurrentPath = currentPath.replace(trailingSep, '');
+        //    Preserve Unix root '/' — stripping it to '' would match everything.
+        const isUnixRoot = isUnix && currentPath === '/';
+        const comparableCurrentPath = isUnixRoot ? '/' : currentPath.replace(trailingSep, '');
 
         // b. Check for Duplicates
         if (processedPaths.some(existingPath => existingPath.replace(trailingSep, '') === comparableCurrentPath)) {
@@ -450,6 +452,10 @@ export function normalizeAllowedPaths(paths: string[]): string[] {
         // c. Check for Nesting (currentPath is child of an existing path)
         if (processedPaths.some(existingPath => {
             const comparableExistingPath = existingPath.replace(trailingSep, '');
+            // Unix root '/' is parent of all other Unix paths
+            if (comparableExistingPath === '/' && comparableCurrentPath !== '/') {
+                return comparableCurrentPath.startsWith('/');
+            }
             return comparableCurrentPath.startsWith(comparableExistingPath + sep);
         })) {
             continue;
@@ -458,7 +464,11 @@ export function normalizeAllowedPaths(paths: string[]): string[] {
         // d. Remove Existing Nested Children (existing path is child of currentPath)
         for (let i = processedPaths.length - 1; i >= 0; i--) {
             const comparableExistingPath = processedPaths[i].replace(trailingSep, '');
-            if (comparableExistingPath.startsWith(comparableCurrentPath + sep)) {
+            // For Unix root '/', all other Unix paths are children
+            const isChild = isUnixRoot
+                ? comparableExistingPath.startsWith('/') && comparableExistingPath !== '/'
+                : comparableExistingPath.startsWith(comparableCurrentPath + sep);
+            if (isChild) {
                 processedPaths.splice(i, 1);
             }
         }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -422,37 +422,48 @@ export function normalizeWindowsPath(inputPath: string): string {
 export function normalizeAllowedPaths(paths: string[]): string[] {
     // Step 1: Initial Normalization
     // For each path, normalize it with its own fresh history for normalizeWindowsPath
-    const normalizedInputPaths = paths.map(p => normalizeWindowsPath(p).toLowerCase());
+    const normalizedInputPaths = paths.map(p => {
+        const normalized = normalizeWindowsPath(p);
+        // Preserve case for Unix/WSL paths (case-sensitive filesystems)
+        if (normalized.startsWith('/')) {
+            return normalized;
+        }
+        return normalized.toLowerCase();
+    });
 
     // Step 2: Processing and Filtering
     const processedPaths: string[] = [];
 
     for (const currentPath of normalizedInputPaths) {
-        // a. Create a version of currentPath without a trailing backslash
-        const comparableCurrentPath = currentPath.replace(/\\$/, '');
+        const isUnix = currentPath.startsWith('/');
+        const trailingSep = isUnix ? /\/$/ : /\\$/;
+        const sep = isUnix ? '/' : '\\';
+
+        // a. Create a version of currentPath without a trailing separator
+        const comparableCurrentPath = currentPath.replace(trailingSep, '');
 
         // b. Check for Duplicates
-        if (processedPaths.some(existingPath => existingPath.replace(/\\$/, '') === comparableCurrentPath)) {
+        if (processedPaths.some(existingPath => existingPath.replace(trailingSep, '') === comparableCurrentPath)) {
             continue;
         }
 
         // c. Check for Nesting (currentPath is child of an existing path)
         if (processedPaths.some(existingPath => {
-            const comparableExistingPath = existingPath.replace(/\\$/, '');
-            return comparableCurrentPath.startsWith(comparableExistingPath + '\\');
+            const comparableExistingPath = existingPath.replace(trailingSep, '');
+            return comparableCurrentPath.startsWith(comparableExistingPath + sep);
         })) {
             continue;
         }
 
         // d. Remove Existing Nested Children (existing path is child of currentPath)
         for (let i = processedPaths.length - 1; i >= 0; i--) {
-            const comparableExistingPath = processedPaths[i].replace(/\\$/, '');
-            if (comparableExistingPath.startsWith(comparableCurrentPath + '\\')) {
+            const comparableExistingPath = processedPaths[i].replace(trailingSep, '');
+            if (comparableExistingPath.startsWith(comparableCurrentPath + sep)) {
                 processedPaths.splice(i, 1);
             }
         }
-        
-        // e. Add comparableCurrentPath (the version without the trailing slash)
+
+        // e. Add comparableCurrentPath (the version without the trailing separator)
         processedPaths.push(comparableCurrentPath);
     }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -269,13 +269,22 @@ export function validateWslWorkingDirectory(dir: string, allowedPaths: string[])
 
 export function isPathAllowed(testPath: string, allowedPaths: string[]): boolean {
     // Step 1: Normalize testPath
-    let normalizedTestPath = normalizeWindowsPath(testPath).toLowerCase();
+    let normalizedTestPath = normalizeWindowsPath(testPath);
+    // Unix paths are case-sensitive — preserve case; Windows paths are case-insensitive
+    const isUnixPath = normalizedTestPath.startsWith('/');
+    if (!isUnixPath) {
+        normalizedTestPath = normalizedTestPath.toLowerCase();
+    }
     normalizedTestPath = normalizedTestPath.replace(/[/\\]+$/, ''); // Remove ALL trailing slashes
 
     // Step 2: Iterate through allowedPaths
     return allowedPaths.some(allowedPath => {
         // Step 2a: Normalize current allowedPath
-        let normalizedAllowedPath = normalizeWindowsPath(allowedPath).toLowerCase();
+        let normalizedAllowedPath = normalizeWindowsPath(allowedPath);
+        const isAllowedUnixPath = normalizedAllowedPath.startsWith('/');
+        if (!isAllowedUnixPath) {
+            normalizedAllowedPath = normalizedAllowedPath.toLowerCase();
+        }
         normalizedAllowedPath = normalizedAllowedPath.replace(/[/\\]+$/, ''); // Remove ALL trailing slashes
 
         let comparisonResult = false;

--- a/tests/asyncOperations.test.ts
+++ b/tests/asyncOperations.test.ts
@@ -65,7 +65,7 @@ describe('Async Command Execution', () => {
       type: 'wsl',
       enabled: true,
       executable: {
-        command: 'node',
+        command: process.execPath,
         args: [wslEmulatorPath, '-e']
       },
       overrides: {

--- a/tests/configNormalization.test.ts
+++ b/tests/configNormalization.test.ts
@@ -15,7 +15,7 @@ describe('Config Normalization', () => {
   test.each([
     [
       ['C:\\SomeFolder\\Test', '/c/other/PATH', 'C:/Another/Folder', '/mnt/d/Incorrect/Path'],
-      ['c:\\somefolder\\test', 'c:\\other\\path', 'c:\\another\\folder', '/mnt/d/incorrect/path']
+      ['c:\\somefolder\\test', 'c:\\other\\path', 'c:\\another\\folder', '/mnt/d/Incorrect/Path']
     ],
     [
       ['D:\\Work\\Project', '\\\\server\\share', '/e/temp'],
@@ -119,7 +119,7 @@ describe('Config Normalization', () => {
         },
         powershell: { enabled: false, executable: { command: 'powershell.exe', args: [] } },
         cmd: { enabled: false, executable: { command: 'cmd.exe', args: ['/c'] } },
-        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } },
+        wsl: { enabled: false, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } },
         bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } }
       }
     };
@@ -160,7 +160,7 @@ describe('Config Normalization', () => {
         cmd: { enabled: false, executable: { command: 'cmd.exe', args: ['/c'] } },
         gitbash: { enabled: false, executable: { command: 'bash.exe', args: ['-c'] } },
         bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } },
-        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: false, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     });
 
@@ -209,7 +209,7 @@ describe('Config Normalization', () => {
         },
         gitbash: { enabled: false, executable: { command: 'bash.exe', args: ['-c'] } },
         bash: { enabled: false, executable: { command: 'bash', args: ['-c'] } },
-        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: false, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     };
 
@@ -250,7 +250,7 @@ describe('Config Normalization', () => {
         }
       },
       shells: {
-        wsl: { enabled: false, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: false, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     });
 
@@ -387,7 +387,7 @@ describe('Shell Config Resolution', () => {
           type: 'wsl',
           enabled: true,
           executable: {
-            command: 'node',
+            command: process.execPath,
             args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e']
           },
           wslConfig: {

--- a/tests/handlers/resourceHandler.test.ts
+++ b/tests/handlers/resourceHandler.test.ts
@@ -11,7 +11,7 @@ describe('Resource Handler', () => {
       const config = buildTestConfig({
         shells: {
           cmd: { enabled: true, executable: { command: 'cmd.exe', args: ['/c'] } },
-          wsl: { enabled: true, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+          wsl: { enabled: true, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
         }
       });
 
@@ -95,7 +95,7 @@ describe('Resource Handler', () => {
         shells: {
           wsl: {
             enabled: true,
-            executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+            executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
             overrides: {
               security: { commandTimeout: 120 },
               restrictions: { blockedCommands: ['wsl-cmd'] }

--- a/tests/handlers/toolListHandler.test.ts
+++ b/tests/handlers/toolListHandler.test.ts
@@ -11,7 +11,7 @@ describe('ListTools Handler', () => {
       shells: {
         cmd: { enabled: true, executable: { command: 'cmd.exe', args: ['/c'] } },
         powershell: { enabled: false, executable: { command: 'powershell.exe', args: [] } },
-        wsl: { enabled: true, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: true, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     });
 
@@ -54,7 +54,7 @@ describe('ListTools Handler', () => {
     const config = buildTestConfig({
       shells: {
         cmd: { enabled: true, executable: { command: 'cmd.exe', args: ['/c'] } },
-        wsl: { enabled: true, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } },
+        wsl: { enabled: true, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } },
         gitbash: { enabled: true, executable: { command: 'bash.exe', args: ['-c'] } }
       }
     });
@@ -75,7 +75,7 @@ describe('ListTools Handler', () => {
         security: { restrictWorkingDirectory: true }
       },
       shells: {
-        wsl: { enabled: true, executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
+        wsl: { enabled: true, executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] } }
       }
     });
 

--- a/tests/helpers/TestCLIServer.ts
+++ b/tests/helpers/TestCLIServer.ts
@@ -31,7 +31,7 @@ export class TestCLIServer {
       type: 'wsl',
       enabled: true,
       executable: {
-        command: 'node',
+        command: process.execPath,
         args: [wslEmulatorPath, '-e']
       },
       overrides: {

--- a/tests/helpers/testUtils.ts
+++ b/tests/helpers/testUtils.ts
@@ -90,7 +90,7 @@ export function createWslEmulatorConfig(overrides: Partial<WslShellConfig> = {})
     type: 'wsl',
     enabled: true,
     executable: {
-      command: 'node',
+      command: process.execPath,
       args: [wslEmulatorPath, '-e']
     },
     wslConfig: {

--- a/tests/initialDirConfig.test.ts
+++ b/tests/initialDirConfig.test.ts
@@ -60,7 +60,9 @@ describe('loadConfig initialDir handling', () => {
     const cfg = loadConfig(configPath);
     const normalized = normalizeWindowsPath(dir);
     expect(cfg.global.paths.initialDir).toBe(normalized);
-    expect(cfg.global.paths.allowedPaths).toContain(normalized.toLowerCase());
+    // Unix paths preserve case through normalizeAllowedPaths
+    const expectedInAllowed = normalized.startsWith('/') ? normalized : normalized.toLowerCase();
+    expect(cfg.global.paths.allowedPaths).toContain(expectedInAllowed);
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -71,7 +73,9 @@ describe('loadConfig initialDir handling', () => {
     const cfg = loadConfig(configPath);
     const normalized = normalizeWindowsPath(dir);
     expect(cfg.global.paths.initialDir).toBe(normalized);
-    expect(cfg.global.paths.allowedPaths).not.toContain(normalized.toLowerCase());
+    // Unix paths preserve case through normalizeAllowedPaths
+    const expectedNotInAllowed = normalized.startsWith('/') ? normalized : normalized.toLowerCase();
+    expect(cfg.global.paths.allowedPaths).not.toContain(expectedNotInAllowed);
     fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
     fs.rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/integration/folderPropagation.test.ts
+++ b/tests/integration/folderPropagation.test.ts
@@ -27,7 +27,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {
@@ -81,7 +81,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {
@@ -129,7 +129,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {
@@ -193,7 +193,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {
@@ -240,7 +240,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {
@@ -298,7 +298,7 @@ describe('Integration: Folder Propagation in get_config Tool', () => {
             type: 'wsl',
             enabled: true,
             executable: {
-              command: 'node',
+              command: process.execPath,
               args: ['scripts/wsl-emulator.js', '-e']
             },
             wslConfig: {

--- a/tests/pathCasePreservation.test.ts
+++ b/tests/pathCasePreservation.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from '@jest/globals';
+import { normalizeAllowedPaths, normalizeWindowsPath } from '../src/utils/validation.js';
+
+/**
+ * Unix/WSL paths must preserve their original casing through normalization.
+ * On case-sensitive filesystems (Linux, WSL2 mounts),
+ * "my.TypeScript" and "my.typescript" are different directories.
+ */
+describe('Path case preservation', () => {
+
+  describe('normalizeAllowedPaths', () => {
+    test('preserves mixed-case segments in WSL mount paths', () => {
+      const input = ['/mnt/d/dev/my.TypeScript/project'];
+      const result = normalizeAllowedPaths(input);
+      expect(result[0]).toBe('/mnt/d/dev/my.TypeScript/project');
+    });
+
+    test('preserves mixed-case segments in /home paths', () => {
+      const input = ['/home/JohnDoe/Projects/myApp'];
+      const result = normalizeAllowedPaths(input);
+      expect(result[0]).toBe('/home/JohnDoe/Projects/myApp');
+    });
+
+    test('preserves case for multiple Unix paths while normalizing Windows paths', () => {
+      const input = [
+        'C:\\Users\\Admin\\Project',
+        '/mnt/d/dev/my.TypeScript/project',
+        '/home/User Name/workspace',
+      ];
+      const result = normalizeAllowedPaths(input);
+
+      // Windows path: case-insensitive, lowercase is fine
+      expect(result[0]).toBe('c:\\users\\admin\\project');
+      // Unix paths: case must be preserved
+      expect(result[1]).toBe('/mnt/d/dev/my.TypeScript/project');
+      expect(result[2]).toBe('/home/User Name/workspace');
+    });
+
+    test('preserves case for /tmp paths with mixed-case directories', () => {
+      const input = ['/tmp/BuildOutput/x86'];
+      const result = normalizeAllowedPaths(input);
+      expect(result[0]).toBe('/tmp/BuildOutput/x86');
+    });
+
+    test('does not lowercase path segment that happens to look like a drive letter', () => {
+      const input = ['/mnt/c/MyFolder'];
+      const result = normalizeAllowedPaths(input);
+      expect(result[0]).toBe('/mnt/c/MyFolder');
+    });
+
+    test('preserves case for deeply nested WSL paths', () => {
+      const input = ['/mnt/d/repos/OrgName/my.TypeScript/project/src/utils'];
+      const result = normalizeAllowedPaths(input);
+      expect(result[0]).toBe('/mnt/d/repos/OrgName/my.TypeScript/project/src/utils');
+    });
+  });
+
+  describe('normalizeWindowsPath (used inside normalizeAllowedPaths)', () => {
+    test('preserves case for WSL paths (no lowercasing in this function)', () => {
+      const result = normalizeWindowsPath('/mnt/d/dev/my.TypeScript/project');
+      expect(result).toBe('/mnt/d/dev/my.TypeScript/project');
+    });
+
+    test('preserves case for /home paths', () => {
+      const result = normalizeWindowsPath('/home/JohnDoe/Projects');
+      expect(result).toBe('/home/JohnDoe/Projects');
+    });
+  });
+
+  describe('dedup still works with case-preserved paths', () => {
+    test('deduplicates exact duplicates while preserving case', () => {
+      const input = [
+        '/mnt/d/dev/my.TypeScript/project',
+        '/mnt/d/dev/my.TypeScript/project', // exact duplicate
+      ];
+      const result = normalizeAllowedPaths(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe('/mnt/d/dev/my.TypeScript/project');
+    });
+
+    test('does not deduplicate paths that differ only by case on Unix', () => {
+      // On case-sensitive filesystems, these are different directories
+      const input = [
+        '/mnt/d/dev/my.TypeScript/project',
+        '/mnt/d/dev/my.typescript/project',
+      ];
+      const result = normalizeAllowedPaths(input);
+      expect(result).toHaveLength(2);
+      expect(result).toContain('/mnt/d/dev/my.TypeScript/project');
+      expect(result).toContain('/mnt/d/dev/my.typescript/project');
+    });
+  });
+});

--- a/tests/server/toolHandlers.test.ts
+++ b/tests/server/toolHandlers.test.ts
@@ -46,7 +46,7 @@ describe('Tool Handlers', () => {
         shells: {
           wsl: {
             enabled: true,
-            executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+            executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
             overrides: { paths: { allowedPaths: ['/home/user', '/tmp'] } }
           }
         }

--- a/tests/types/configTypes.test.ts
+++ b/tests/types/configTypes.test.ts
@@ -8,7 +8,7 @@ describe('Config Type Guards', () => {
     test('identifies WSL shell config', () => {
       const wslShell: WslShellConfig = {
         enabled: true,
-        executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+        executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
         wslConfig: {
           mountPoint: '/mnt/',
           inheritGlobalPaths: true

--- a/tests/utils/configMerger.test.ts
+++ b/tests/utils/configMerger.test.ts
@@ -116,7 +116,7 @@ describe('Config Merger', () => {
     test('includes WSL config for WSL shells', () => {
       const shell: WslShellConfig = {
         enabled: true,
-        executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+        executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
         wslConfig: {
           mountPoint: '/mnt/',
           inheritGlobalPaths: true
@@ -135,7 +135,7 @@ describe('Config Merger', () => {
     test('converts and merges Windows paths for WSL', () => {
       const resolved: ResolvedShellConfig = {
         enabled: true,
-        executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+        executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
         security: mockGlobal.security,
         restrictions: mockGlobal.restrictions,
         paths: {
@@ -159,7 +159,7 @@ describe('Config Merger', () => {
     test('does not convert paths when inheritance disabled', () => {
       const resolved: ResolvedShellConfig = {
         enabled: true,
-        executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+        executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
         security: mockGlobal.security,
         restrictions: mockGlobal.restrictions,
         paths: {
@@ -183,7 +183,7 @@ describe('Config Merger', () => {
     test('uses specified mount point', () => {
       const resolved: ResolvedShellConfig = {
         enabled: true,
-        executable: { command: 'node', args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
+        executable: { command: process.execPath, args: [path.resolve(process.cwd(), 'scripts/wsl-emulator.js'), '-e'] },
         security: mockGlobal.security,
         restrictions: mockGlobal.restrictions,
         paths: {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -301,6 +301,21 @@ describe('Allowed Paths Normalization', () => {
     const paths = ['/c/Users', '/d/Projects'];
     expect(normalizeAllowedPaths(paths)).toEqual(['c:\\users', 'd:\\projects']);
   });
+  // P1: Root path '/' must be preserved, not stripped to empty string
+  test('preserves Unix root path "/" as-is (P1)', () => {
+    expect(normalizeAllowedPaths(['/'])).toEqual(['/']);
+  });
+  test('preserves Unix root "/" alongside other paths (P1)', () => {
+    const result = normalizeAllowedPaths(['/home/user', '/']);
+    // Root absorbs all other paths as children
+    expect(result).toEqual(['/']);
+  });
+  test('Unix root "/" allows any absolute path via isPathAllowed (P1)', () => {
+    const allowed = normalizeAllowedPaths(['/']);
+    expect(isPathAllowed('/home/user/docs', allowed)).toBe(true);
+    expect(isPathAllowed('/tmp', allowed)).toBe(true);
+    expect(isPathAllowed('/etc/passwd', allowed)).toBe(true);
+  });
 });
 
 describe('Path Validation', () => {

--- a/tests/windows/pathHandling.test.ts
+++ b/tests/windows/pathHandling.test.ts
@@ -133,25 +133,25 @@ describeOnWindows('Phase 6.4: Windows path handling (C:\... paths)', () => {
 
   describe('UNC path validation', () => {
     test('cmd shell rejects UNC path', async () => {
-      const server = new CLIServer(buildWindowsConfig('cmd'));
+      const server = new CLIServer(buildWindowsConfig('cmd', ['C:\\safe']));
 
       await expect(
         server._executeTool({
           name: 'execute_command',
           arguments: { shell: 'cmd', command: 'echo unc', workingDir: '\\\\server\\share' },
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(/allowed paths/i);
     });
 
     test('powershell shell rejects UNC path', async () => {
-      const server = new CLIServer(buildWindowsConfig('powershell'));
+      const server = new CLIServer(buildWindowsConfig('powershell', ['C:\\safe']));
 
       await expect(
         server._executeTool({
           name: 'execute_command',
           arguments: { shell: 'powershell', command: 'echo unc', workingDir: '\\\\server\\share' },
         })
-      ).rejects.toThrow();
+      ).rejects.toThrow(/allowed paths/i);
     });
   });
 });

--- a/tests/windows/pathHandling.test.ts
+++ b/tests/windows/pathHandling.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, beforeEach, expect } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import os from 'os';
+import path from 'path';
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+function buildWindowsConfig(
+  activeShell: 'cmd' | 'powershell' | 'gitbash',
+  allowedPaths: string[] = [],
+): ServerConfig {
+  const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+
+  if (config.shells) {
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.bash) config.shells.bash.enabled = false;
+    if (config.shells.wsl) config.shells.wsl.enabled = false;
+
+    if (config.shells[activeShell]) {
+      config.shells[activeShell]!.enabled = true;
+    }
+  }
+
+  if (config.global) {
+    config.global.security.restrictWorkingDirectory = allowedPaths.length > 0;
+    config.global.paths.allowedPaths = allowedPaths;
+  }
+
+  return config;
+}
+
+// --- Phase 6.4: Windows path handling ---
+describeOnWindows('Phase 6.4: Windows path handling (C:\... paths)', () => {
+  const tmpDir = os.tmpdir();
+  // Normalize to a real Windows path (forward slashes to backslashes)
+  const winTmpDir = path.resolve(tmpDir);
+
+  describe('cmd shell path handling', () => {
+    let server: CLIServer;
+
+    beforeEach(() => {
+      server = new CLIServer(buildWindowsConfig('cmd', [winTmpDir]));
+    });
+
+    test('C:\... path accepted as working directory', async () => {
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'cd', workingDir: winTmpDir },
+      }) as any;
+
+      expect(result.isError).toBe(false);
+      expect(result.metadata.workingDirectory).toBe(winTmpDir);
+    });
+
+    test('forward-slash path normalized to backslash for cmd', async () => {
+      const forwardSlashPath = winTmpDir.replace(/\\/g, '/');
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo ok', workingDir: forwardSlashPath },
+      }) as any;
+
+      expect(result.isError).toBe(false);
+      expect(result.metadata.exitCode).toBe(0);
+    });
+
+    test('lowercase drive letter path accepted', async () => {
+      const lowerDrive = winTmpDir.replace(/^[A-Z]:/, (m) => m.toLowerCase());
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'cmd', command: 'echo ok', workingDir: lowerDrive },
+      }) as any;
+
+      expect(result.isError).toBe(false);
+      expect(result.metadata.exitCode).toBe(0);
+    });
+  });
+
+  describe('powershell shell path handling', () => {
+    let server: CLIServer;
+
+    beforeEach(() => {
+      server = new CLIServer(buildWindowsConfig('powershell', [winTmpDir]));
+    });
+
+    test('C:\... path accepted as working directory', async () => {
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'powershell', command: 'Get-Location', workingDir: winTmpDir },
+      }) as any;
+
+      expect(result.isError).toBe(false);
+      expect(result.metadata.workingDirectory).toBe(winTmpDir);
+    });
+
+    test('path with spaces works', async () => {
+      // Use a path segment that is likely to contain spaces, e.g. AppData\Local\Temp
+      const result = await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'powershell', command: 'echo ok', workingDir: winTmpDir },
+      }) as any;
+
+      expect(result.isError).toBe(false);
+    });
+  });
+
+  describe('path validation for disallowed directories', () => {
+    test('cmd rejects path outside allowedPaths', async () => {
+      const server = new CLIServer(buildWindowsConfig('cmd', [winTmpDir]));
+
+      await expect(
+        server._executeTool({
+          name: 'execute_command',
+          arguments: { shell: 'cmd', command: 'echo fail', workingDir: 'C:\\Windows\\System32' },
+        })
+      ).rejects.toThrow(/allowed paths/i);
+    });
+
+    test('powershell rejects path outside allowedPaths', async () => {
+      const server = new CLIServer(buildWindowsConfig('powershell', [winTmpDir]));
+
+      await expect(
+        server._executeTool({
+          name: 'execute_command',
+          arguments: { shell: 'powershell', command: 'echo fail', workingDir: 'C:\\Windows\\System32' },
+        })
+      ).rejects.toThrow(/allowed paths/i);
+    });
+  });
+
+  describe('UNC path validation', () => {
+    test('cmd shell rejects UNC path', async () => {
+      const server = new CLIServer(buildWindowsConfig('cmd'));
+
+      await expect(
+        server._executeTool({
+          name: 'execute_command',
+          arguments: { shell: 'cmd', command: 'echo unc', workingDir: '\\\\server\\share' },
+        })
+      ).rejects.toThrow();
+    });
+
+    test('powershell shell rejects UNC path', async () => {
+      const server = new CLIServer(buildWindowsConfig('powershell'));
+
+      await expect(
+        server._executeTool({
+          name: 'execute_command',
+          arguments: { shell: 'powershell', command: 'echo unc', workingDir: '\\\\server\\share' },
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/tests/windows/shellExecution.test.ts
+++ b/tests/windows/shellExecution.test.ts
@@ -227,20 +227,18 @@ describeOnWindows('Phase 6.2: powershell shell real commands', () => {
 });
 
 // --- Phase 6.3: gitbash shell comprehensive tests ---
-describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
+const gitBashAvailable = process.platform === 'win32'
+  && fs.existsSync('C:\\Program Files\\Git\\bin\\bash.exe');
+const describeWithGitBash = gitBashAvailable ? describe : describe.skip;
+
+describeWithGitBash('Phase 6.3: gitbash shell real commands', () => {
   let server: CLIServer;
 
   beforeEach(() => {
-    const gitBashPath = 'C:\\Program Files\\Git\\bin\\bash.exe';
-    // Skip if git bash is not available at the default location
-    if (!fs.existsSync(gitBashPath)) {
-      return;
-    }
     server = new CLIServer(buildWindowsTestConfig('gitbash'));
   });
 
   test('echo command', async () => {
-    if (!server) return;
     const result = await server._executeTool({
       name: 'execute_command',
       arguments: { shell: 'gitbash', command: 'echo hello from gitbash' },
@@ -252,7 +250,6 @@ describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
   });
 
   test('pwd returns a path', async () => {
-    if (!server) return;
     const result = await server._executeTool({
       name: 'execute_command',
       arguments: { shell: 'gitbash', command: 'pwd' },
@@ -264,7 +261,6 @@ describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
   });
 
   test('uname returns output', async () => {
-    if (!server) return;
     const result = await server._executeTool({
       name: 'execute_command',
       arguments: { shell: 'gitbash', command: 'uname -a' },
@@ -277,7 +273,6 @@ describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
   });
 
   test('exit code propagation', async () => {
-    if (!server) return;
     const result = await server._executeTool({
       name: 'execute_command',
       arguments: { shell: 'gitbash', command: 'exit 55' },
@@ -288,7 +283,6 @@ describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
   });
 
   test('ls on temp directory', async () => {
-    if (!server) return;
     const tmpDir = os.tmpdir();
     const result = await server._executeTool({
       name: 'execute_command',

--- a/tests/windows/shellExecution.test.ts
+++ b/tests/windows/shellExecution.test.ts
@@ -1,0 +1,301 @@
+import { describe, test, beforeEach, expect } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+function buildWindowsTestConfig(
+  activeShell: 'cmd' | 'powershell' | 'gitbash',
+  extraOverrides?: Partial<ServerConfig>
+): ServerConfig {
+  const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+
+  if (config.shells) {
+    // Disable all shells first
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.bash) config.shells.bash.enabled = false;
+    if (config.shells.wsl) config.shells.wsl.enabled = false;
+
+    // Enable only the target shell
+    if (config.shells[activeShell]) {
+      config.shells[activeShell]!.enabled = true;
+    }
+  }
+
+  if (config.global) {
+    config.global.security.restrictWorkingDirectory = false;
+    config.global.security.enableInjectionProtection = true;
+  }
+
+  if (extraOverrides) {
+    if (extraOverrides.global) {
+      config.global = {
+        ...config.global,
+        security: { ...config.global.security, ...extraOverrides.global.security },
+        restrictions: { ...config.global.restrictions, ...extraOverrides.global.restrictions },
+        paths: { ...config.global.paths, ...extraOverrides.global.paths },
+      };
+    }
+    if (extraOverrides.shells) {
+      for (const [name, shell] of Object.entries(extraOverrides.shells)) {
+        if (shell) {
+          (config.shells as any)[name] = {
+            ...(config.shells as any)[name],
+            ...shell,
+          };
+        }
+      }
+    }
+  }
+
+  return config;
+}
+
+// --- Phase 3.4: cmd shell basic test ---
+describeOnWindows('Phase 3.4: cmd shell on native Windows', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildWindowsTestConfig('cmd'));
+  });
+
+  test('cmd.exe /c echo hello', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'echo hello' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('hello');
+    expect(result.metadata.exitCode).toBe(0);
+  });
+});
+
+// --- Phase 3.5: powershell shell basic test ---
+describeOnWindows('Phase 3.5: powershell shell on native Windows', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildWindowsTestConfig('powershell'));
+  });
+
+  test('powershell.exe -Command "echo hello"', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'echo hello' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('hello');
+    expect(result.metadata.exitCode).toBe(0);
+  });
+});
+
+// --- Phase 6.1: cmd shell comprehensive tests ---
+describeOnWindows('Phase 6.1: cmd shell real commands', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildWindowsTestConfig('cmd'));
+  });
+
+  test('echo with multiple words', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'echo hello world from cmd' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('hello world from cmd');
+    expect(result.metadata.exitCode).toBe(0);
+  });
+
+  test('echo with special characters', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'echo test-value_123' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('test-value_123');
+    expect(result.metadata.exitCode).toBe(0);
+  });
+
+  test('cd to temp directory', async () => {
+    const tmpDir = os.tmpdir();
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'cd', workingDir: tmpDir },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+    // cmd cd outputs the current directory
+    const output = result.content[0].text;
+    expect(output.toLowerCase()).toContain('temp');
+  });
+
+  test('exit code propagation', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'exit /b 42' },
+    }) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.metadata.exitCode).toBe(42);
+  });
+
+  test('dir command on temp directory', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'cmd', command: 'dir /b', workingDir: os.tmpdir() },
+    }) as any;
+
+    // dir may return exit code 0 even with empty output, or non-zero if the path has issues
+    expect(result.metadata.exitCode).toBeDefined();
+    expect(result.content[0].text).toBeDefined();
+  });
+});
+
+// --- Phase 6.2: powershell shell comprehensive tests ---
+describeOnWindows('Phase 6.2: powershell shell real commands', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildWindowsTestConfig('powershell'));
+  });
+
+  test('Get-Date returns output', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'Get-Date -Format "yyyy-MM-dd"' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+    // Should contain a date pattern
+    expect(result.content[0].text).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  test('$env:TEMP variable accessible', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'echo $env:TEMP' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+    expect(result.content[0].text.length).toBeGreaterThan(0);
+  });
+
+  test('working directory is respected', async () => {
+    const tmpDir = os.tmpdir();
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'Get-Location', workingDir: tmpDir },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.workingDirectory).toBe(tmpDir);
+  });
+
+  test('exit code propagation', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'exit 7' },
+    }) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.metadata.exitCode).toBe(7);
+  });
+
+  test('non-existent command produces error', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'powershell', command: 'Get-NonExistentCmdlet_XYZ' },
+    }) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.metadata.exitCode).not.toBe(0);
+  });
+});
+
+// --- Phase 6.3: gitbash shell comprehensive tests ---
+describeOnWindows('Phase 6.3: gitbash shell real commands', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    const gitBashPath = 'C:\\Program Files\\Git\\bin\\bash.exe';
+    // Skip if git bash is not available at the default location
+    if (!fs.existsSync(gitBashPath)) {
+      return;
+    }
+    server = new CLIServer(buildWindowsTestConfig('gitbash'));
+  });
+
+  test('echo command', async () => {
+    if (!server) return;
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'gitbash', command: 'echo hello from gitbash' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('hello from gitbash');
+    expect(result.metadata.exitCode).toBe(0);
+  });
+
+  test('pwd returns a path', async () => {
+    if (!server) return;
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'gitbash', command: 'pwd' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+    expect(result.content[0].text.length).toBeGreaterThan(0);
+  });
+
+  test('uname returns output', async () => {
+    if (!server) return;
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'gitbash', command: 'uname -a' },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+    // Git Bash uname reports MINGW or MSYS
+    expect(result.content[0].text).toMatch(/MINGW|MSYS|Windows/i);
+  });
+
+  test('exit code propagation', async () => {
+    if (!server) return;
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'gitbash', command: 'exit 55' },
+    }) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.metadata.exitCode).toBe(55);
+  });
+
+  test('ls on temp directory', async () => {
+    if (!server) return;
+    const tmpDir = os.tmpdir();
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'gitbash', command: 'ls', workingDir: tmpDir },
+    }) as any;
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata.exitCode).toBe(0);
+  });
+});

--- a/tests/wsl.test.ts
+++ b/tests/wsl.test.ts
@@ -28,7 +28,7 @@ describe('WSL Shell Execution via Emulator (Tests 1-4)', () => {
         type: 'wsl',
         enabled: true,
         executable: {
-          command: 'node',
+          command: process.execPath,
           args: [wslEmulatorPath, '-e']
         },
         overrides: {
@@ -138,11 +138,11 @@ describe('WSL Shell Execution via Emulator (Tests 1-4)', () => {
     expect(result.content[0].text).toContain('..'); // parent directory
   });
 
-  test('Test 4.3: Command with non-existent path argument (ls /mnt/c)', async () => {
-    // The emulator runs in `/app` and does not have `/mnt/c`. This command should fail.
+  test('Test 4.3: Command with non-existent path argument', async () => {
+    // Use a path that truly doesn't exist on any system (not /mnt/c which exists in WSL2)
     const result = await serverInstance._executeTool({
       name: 'execute_command',
-      arguments: { shell: 'wsl', command: 'ls /mnt/c' }
+      arguments: { shell: 'wsl', command: 'ls /no/such/path/at/all' }
     }) as CallToolResult;
     expect(result.isError).toBe(true); // Expect an error
     expect((result.metadata as any)?.exitCode).not.toBe(0); // Expect non-zero exit code
@@ -166,7 +166,7 @@ describe('WSL Working Directory Validation (Test 5)', () => { // Removed .only
         type: 'wsl',
         enabled: true,
         executable: {
-          command: 'node',
+          command: process.execPath,
           args: [wslEmulatorPath, '-e']
         },
         overrides: {

--- a/tests/wsl/bashExecution.test.ts
+++ b/tests/wsl/bashExecution.test.ts
@@ -1,0 +1,345 @@
+import { describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import { McpError, ErrorCode, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import fs from 'fs';
+import crypto from 'crypto';
+
+// --- WSL2 detection guard ---
+function isRunningInWsl2(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    const version = fs.readFileSync('/proc/version', 'utf8');
+    return version.toLowerCase().includes('microsoft');
+  } catch {
+    return false;
+  }
+}
+
+const describeBash = isRunningInWsl2() ? describe : describe.skip;
+
+// --- Helpers ---
+
+function buildBashTestConfig(extraOverrides?: Partial<ServerConfig>): ServerConfig {
+  const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+
+  if (config.shells) {
+    // Disable all shells first
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.wsl) config.shells.wsl.enabled = false;
+
+    // Enable bash with native executable
+    config.shells.bash = {
+      type: 'bash',
+      enabled: true,
+      executable: {
+        command: 'bash',
+        args: ['-c'],
+      },
+      overrides: {
+        restrictions: {
+          blockedOperators: ['&', '|', ';', '`'],
+        },
+      },
+    };
+  }
+
+  if (config.global) {
+    config.global.security.restrictWorkingDirectory = false;
+    config.global.security.enableInjectionProtection = true;
+  }
+
+  if (extraOverrides) {
+    if (extraOverrides.global) {
+      config.global = {
+        ...config.global,
+        security: { ...config.global.security, ...extraOverrides.global.security },
+        restrictions: { ...config.global.restrictions, ...extraOverrides.global.restrictions },
+        paths: { ...config.global.paths, ...extraOverrides.global.paths },
+      };
+    }
+    if (extraOverrides.shells) {
+      for (const [name, shell] of Object.entries(extraOverrides.shells)) {
+        if (shell) {
+          (config.shells as Record<string, unknown>)[name] = {
+            ...(config.shells as Record<string, unknown>)[name],
+            ...shell,
+          };
+        }
+      }
+    }
+  }
+
+  return config;
+}
+
+function buildBashCwdTestConfig(allowedPaths: string[]): ServerConfig {
+  const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+
+  if (config.shells) {
+    // Disable all shells
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.wsl) config.shells.wsl.enabled = false;
+
+    config.shells.bash = {
+      type: 'bash',
+      enabled: true,
+      executable: {
+        command: 'bash',
+        args: ['-c'],
+      },
+      overrides: {
+        restrictions: {
+          blockedOperators: ['&', '|', ';', '`'],
+        },
+      },
+    };
+  }
+
+  if (config.global) {
+    config.global.security.restrictWorkingDirectory = true;
+    config.global.security.enableInjectionProtection = false;
+    config.global.paths.allowedPaths = allowedPaths;
+  }
+
+  return config;
+}
+
+// --- Group 1: Basic Command Execution ---
+
+describeBash('R1-R4: Real bash in WSL2 - Basic Command Execution', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildBashTestConfig());
+  });
+
+  test('R1: Basic command execution (echo)', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'echo hello bash in wsl2' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('hello bash in wsl2');
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(0);
+  });
+
+  test('R2: Command with a specific error exit code', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'exit 42' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(42);
+    expect(result.content[0].text).toContain('Command failed with exit code 42');
+  });
+
+  test('R3: Command producing stderr output', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'ls /nonexistent_directory_for_bash_test_xyz' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect([1, 2]).toContain((result.metadata as Record<string, unknown>)?.exitCode);
+    expect(result.content[0].text).toMatch(/No such file or directory|cannot access/i);
+    expect(result.content[0].text).toContain('Error output:');
+  });
+
+  test('R4: Injection protection (semicolon)', async () => {
+    try {
+      await server._executeTool({
+        name: 'execute_command',
+        arguments: { shell: 'bash', command: 'echo bad ; ls' },
+      });
+      throw new Error('Test failed: Command with semicolon should have been rejected');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(McpError);
+      const mcpError = e as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+      expect(mcpError.message).toContain('Command contains blocked operator for bash: ;');
+    }
+  });
+});
+
+// --- Group 2: Extended Command Execution ---
+
+describeBash('R4.1-R4.3: Real bash in WSL2 - Extended Command Execution', () => {
+  let server: CLIServer;
+
+  beforeEach(() => {
+    server = new CLIServer(buildBashTestConfig());
+  });
+
+  test('R4.1: uname -a execution', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'uname -a' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(false);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(0);
+    // Real bash in WSL2 reports Linux, not Msys
+    expect(result.content[0].text).toContain('Linux');
+  });
+
+  test('R4.2: Command with multiple arguments (ls -la /tmp)', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'ls -la /tmp' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(false);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(0);
+    expect(result.content[0].text).toMatch(/total\s\d+/);
+    expect(result.content[0].text).toContain('.');
+    expect(result.content[0].text).toContain('..');
+  });
+
+  test('R4.3: Command with non-existent path argument', async () => {
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: { shell: 'bash', command: 'ls /no/such/path/at/all' },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).not.toBe(0);
+    expect(result.content[0].text).toMatch(/No such file or directory|cannot access/i);
+  });
+});
+
+// --- Group 3: Working Directory Validation ---
+
+describeBash('R5.1-R5.4: Real bash in WSL2 - Working Directory Validation', () => {
+  let server: CLIServer;
+  let allowedBase: string;
+  let createdDirs: string[] = [];
+
+  beforeEach(() => {
+    allowedBase = `/tmp/bash-test-${crypto.randomBytes(4).toString('hex')}`;
+    fs.mkdirSync(allowedBase, { recursive: true });
+    createdDirs.push(allowedBase);
+
+    server = new CLIServer(buildBashCwdTestConfig([allowedBase]));
+  });
+
+  afterEach(() => {
+    for (const dir of createdDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    createdDirs = [];
+  });
+
+  test('R5.1: Valid working directory (subdirectory under allowed path)', async () => {
+    const subDir = `${allowedBase}/sub`;
+    fs.mkdirSync(subDir, { recursive: true });
+
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: {
+        shell: 'bash',
+        command: 'pwd',
+        workingDir: subDir,
+      },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(false);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(0);
+    expect(result.content[0].text.trim()).toBe(subDir);
+    expect((result.metadata as Record<string, unknown>)?.workingDirectory).toBe(subDir);
+  });
+
+  test('R5.1.1: Valid working directory (/tmp)', async () => {
+    const tmpConfig = buildBashCwdTestConfig(['/tmp']);
+    server = new CLIServer(tmpConfig);
+
+    const result = await server._executeTool({
+      name: 'execute_command',
+      arguments: {
+        shell: 'bash',
+        command: 'pwd',
+        workingDir: '/tmp',
+      },
+    }) as CallToolResult;
+
+    expect(result.isError).toBe(false);
+    expect((result.metadata as Record<string, unknown>)?.exitCode).toBe(0);
+    expect(result.content[0].text.trim()).toBe('/tmp');
+    expect((result.metadata as Record<string, unknown>)?.workingDirectory).toBe('/tmp');
+  });
+
+  test('R5.2: Invalid working directory (not in allowedPaths)', async () => {
+    try {
+      await server._executeTool({
+        name: 'execute_command',
+        arguments: {
+          shell: 'bash',
+          command: 'pwd',
+          workingDir: '/opt/forbidden_dir',
+        },
+      });
+      throw new Error('Test failed: Command with invalid CWD should have been rejected');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(McpError);
+      const mcpError = e as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+      expect(mcpError.message).toContain('Working directory validation failed');
+      expect(mcpError.message).toContain('must be within allowed paths');
+    }
+  });
+
+  test('R5.3: Invalid working directory (prefix match, not containment)', async () => {
+    // allowedBase is /tmp/bash-test-<rand>, so /tmp/bash-test-<rand>-suffix
+    // is NOT contained within it (prefix match is not directory containment)
+    const suffixDir = `${allowedBase}-suffix`;
+
+    try {
+      await server._executeTool({
+        name: 'execute_command',
+        arguments: {
+          shell: 'bash',
+          command: 'pwd',
+          workingDir: suffixDir,
+        },
+      });
+      throw new Error('Test failed: Command with prefix-match CWD should have been rejected');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(McpError);
+      const mcpError = e as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+      expect(mcpError.message).toContain('Working directory validation failed');
+      expect(mcpError.message).toContain('must be within allowed paths');
+    }
+  });
+
+  test('R5.4: Invalid working directory (pure Linux path not in allowedPaths)', async () => {
+    try {
+      await server._executeTool({
+        name: 'execute_command',
+        arguments: {
+          shell: 'bash',
+          command: 'pwd',
+          workingDir: '/usr/local',
+        },
+      });
+      throw new Error('Test failed: Command with pure Linux path not in allowedPaths should have been rejected');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(McpError);
+      const mcpError = e as McpError;
+      expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+      expect(mcpError.message).toContain('Working directory validation failed');
+      expect(mcpError.message).toContain('must be within allowed paths');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Single squashed commit combining WSL2 testing work:

- **WSL2 integration tests** (12 tests in `tests/wsl/bashExecution.test.ts`) — mirrors the emulator test suite using real `bash -c` instead of the wsl-emulator. Gated on WSL2 detection via `/proc/version`.
- **Windows shell tests** (`tests/windows/shellExecution.test.ts`, `tests/windows/pathHandling.test.ts`) — cmd, powershell, gitbash tests gated on `process.platform === 'win32'`.
- **Fix: preserve case for Unix/WSL paths** in `normalizeAllowedPaths` — stops lowercasing paths on case-sensitive filesystems.
- **Fix: WSL path conversion gated on .exe** — only converts `/mnt/c/` to `C:\` when spawning a Windows binary.
- **Fix: spawn ENOENT** — replaced bare `'node'` with `process.execPath` in test helpers.
- **Gitignore cleanup** — added `.mcp.json` and `.claude/`.

## Test plan

- [x] All existing tests pass with `process.execPath` fix
- [x] New WSL2 bash tests pass inside WSL2, skipped outside WSL2
- [x] Windows tests gated on `win32` platform
- [x] Path case preservation verified with unit tests
