### PR TITLE
feat(transport): add HTTP/SSE transport for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,8 @@ To get started with configuration:
   # Start with SSE transport on default host/port (127.0.0.1:9444)
   npx wcli0 --transport sse
 
-  # Custom host and port
-  npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000
+  # Custom port, still bound to localhost
+  npx wcli0 --transport sse --sse-host 127.0.0.1 --sse-port 3000
   ```
 
   | Option | Type | Default | Description |
@@ -503,7 +503,17 @@ To get started with configuration:
 
   When SSE mode is active, clients connect via `GET /sse` to open an SSE
   stream and send messages via `POST /messages?sessionId=<id>`. The server
-  logs the bind address and port on startup.
+  logs the bind address and port on startup. To mitigate DNS-rebinding
+  attacks, the server validates the request `Origin` header: requests whose
+  `Origin` is not a loopback host or the configured bind host are rejected with
+  `403 Forbidden`, while non-browser clients that send no `Origin` are allowed.
+
+  > **Security:** This transport has no built-in authentication and exposes
+  > command-execution tools. Keep it bound to `127.0.0.1` (the default) for
+  > local use. Binding to `0.0.0.0` or any non-loopback address exposes those
+  > tools to every host that can reach the port; only do so behind an
+  > authenticated reverse proxy or equivalent access control. Origin validation
+  > alone does not authenticate non-browser clients.
 
 1. **Update your Claude Desktop configuration** to use your config file:
 

--- a/README.md
+++ b/README.md
@@ -483,6 +483,28 @@ To get started with configuration:
   fully unsafe mode disables those restrictions as well. These two flags are
   mutually exclusive; using both at once will fail.
 
+  You can start the server with HTTP/SSE transport instead of the default
+  stdio transport. This allows remote and web-based MCP clients to connect
+  over HTTP:
+
+  ```bash
+  # Start with SSE transport on default host/port (127.0.0.1:9444)
+  npx wcli0 --transport sse
+
+  # Custom host and port
+  npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000
+  ```
+
+  | Option | Type | Default | Description |
+  |--------|------|---------|-------------|
+  | `--transport` | string | stdio | Transport protocol: `stdio` or `sse` |
+  | `--sse-host` | string | 127.0.0.1 | Host address for SSE transport |
+  | `--sse-port` | number | 9444 | Port for SSE transport |
+
+  When SSE mode is active, clients connect via `GET /sse` to open an SSE
+  stream and send messages via `POST /messages?sessionId=<id>`. The server
+  logs the bind address and port on startup.
+
 1. **Update your Claude Desktop configuration** to use your config file:
 
    ```json
@@ -784,6 +806,20 @@ WSL shells have additional configuration options for path mapping:
 You can override the mount point at startup using the `--wslMountPoint` CLI flag.
 
 ### Configuration Inheritance
+
+The transport section can also be set in the config file:
+
+```json
+{
+  "transport": {
+    "mode": "sse",
+    "sseHost": "127.0.0.1",
+    "ssePort": 9444
+  }
+}
+```
+
+CLI flags (`--transport`, `--sse-host`, `--sse-port`) override config file values.
 
 The inheritance system works as follows:
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ INCLUDED_SHELLS=gitbash,powershell npm run build:custom
 ### Bundle Size Comparison
 
 | Build | Size Reduction | Shells Included |
-|-------|---------------|-----------------|
+| ----- | -------------- | --------------- |
 | Full | Baseline | All 5 shells |
 | Windows | ~40% smaller | PowerShell, CMD, Git Bash |
 | Git Bash Only | ~60% smaller | Git Bash |
@@ -241,7 +241,7 @@ Configure Claude Desktop to use wcli0 on macOS:
 When running on Unix systems, use these CLI options:
 
 | Option | Type | Description |
-|--------|------|-------------|
+| ------ | ---- | ----------- |
 | `--shell` | string | Shell to use (use `bash` or `bash_auto` on Unix) |
 | `--allowedDir` | string | Add an allowed directory (can be used multiple times) |
 | `--config` | string | Path to configuration file |
@@ -414,7 +414,7 @@ To get started with configuration:
     ```
 
    | Option | Type | Default | Description |
-   |--------|------|---------|-------------|
+   | ------ | ---- | ------- | ----------- |
    | `--maxOutputLines` | number | 20 | Maximum output lines before truncation |
    | `--enableTruncation` | boolean | true | Enable output truncation |
    | `--enableLogResources` | boolean | true | Enable log resources for `get_command_output` |
@@ -496,7 +496,7 @@ To get started with configuration:
   ```
 
   | Option | Type | Default | Description |
-  |--------|------|---------|-------------|
+  | ------ | ---- | ------- | ----------- |
   | `--transport` | string | stdio | Transport protocol: `stdio` or `sse` |
   | `--sse-host` | string | 127.0.0.1 | Host address for SSE transport |
   | `--sse-port` | number | 9444 | Port for SSE transport |

--- a/README.md
+++ b/README.md
@@ -500,13 +500,15 @@ To get started with configuration:
   | `--transport` | string | stdio | Transport protocol: `stdio` or `sse` |
   | `--sse-host` | string | 127.0.0.1 | Host address for SSE transport |
   | `--sse-port` | number | 9444 | Port for SSE transport |
+  | `--sse-allowed-origins` | string | (none) | Comma-separated browser origins allowed in addition to loopback hosts and the bind host (e.g. `https://app.example.com,192.168.1.10`). Only the host component is compared. Required for browser clients on a wildcard (`0.0.0.0`) bind. |
 
   When SSE mode is active, clients connect via `GET /sse` to open an SSE
   stream and send messages via `POST /messages?sessionId=<id>`. The server
   logs the bind address and port on startup. To mitigate DNS-rebinding
   attacks, the server validates the request `Origin` header: requests whose
-  `Origin` is not a loopback host or the configured bind host are rejected with
-  `403 Forbidden`, while non-browser clients that send no `Origin` are allowed.
+  `Origin` is not a loopback host, the configured bind host, or one of the
+  configured `--sse-allowed-origins` are rejected with `403 Forbidden`, while
+  non-browser clients that send no `Origin` are allowed.
 
   > **Security:** This transport has no built-in authentication and exposes
   > command-execution tools. Keep it bound to `127.0.0.1` (the default) for
@@ -514,6 +516,14 @@ To get started with configuration:
   > tools to every host that can reach the port; only do so behind an
   > authenticated reverse proxy or equivalent access control. Origin validation
   > alone does not authenticate non-browser clients.
+  >
+  > **Wildcard binds and browser origins:** When binding to a wildcard address
+  > (`0.0.0.0` / `::`), the bind host is not a usable origin to compare against,
+  > so browser clients reaching the server through its real LAN address (or a
+  > reverse proxy whose public hostname differs from the bind host) are rejected
+  > unless their origin is listed in `--sse-allowed-origins` (or the
+  > `transport.sseAllowedOrigins` config array). Non-browser clients are
+  > unaffected, since they send no `Origin`.
 
 1. **Update your Claude Desktop configuration** to use your config file:
 
@@ -824,12 +834,17 @@ The transport section can also be set in the config file:
   "transport": {
     "mode": "sse",
     "sseHost": "127.0.0.1",
-    "ssePort": 9444
+    "ssePort": 9444,
+    "sseAllowedOrigins": ["https://app.example.com", "192.168.1.10"]
   }
 }
 ```
 
-CLI flags (`--transport`, `--sse-host`, `--sse-port`) override config file values.
+`sseAllowedOrigins` is optional and defaults to an empty list. Each entry is an
+origin URL or a bare host; only the host component is compared (case-insensitively).
+
+CLI flags (`--transport`, `--sse-host`, `--sse-port`, `--sse-allowed-origins`)
+override config file values.
 
 The inheritance system works as follows:
 

--- a/docs/tasks/http_sse_transport/PRD.md
+++ b/docs/tasks/http_sse_transport/PRD.md
@@ -1,0 +1,80 @@
+# PRD: HTTP/SSE Transport for MCP Server
+
+## Objective
+
+Add HTTP/SSE transport protocol support to the wcli0 MCP server, enabling remote and browser-based clients to connect via HTTP, in addition to the existing stdio transport. The server will default to stdio but can be switched to HTTP/SSE mode via CLI flags with configurable host and port.
+
+## Background
+
+The wcli0 MCP server currently supports only stdio transport (`StdioServerTransport`), which limits usage to local CLI integrations (e.g., `npx wcli0`). Some MCP clients (web-based tools, remote orchestrators) require HTTP/SSE transport to connect over a network. The MCP SDK v1.0.1 already includes `SSEServerTransport` in `@modelcontextprotocol/sdk/server/sse.js`, which handles the SSE + HTTP POST pattern for bidirectional JSON-RPC communication.
+
+## Requirements
+
+### REQ-1: Transport Mode Selection
+
+The server must accept a `--transport` CLI flag that selects between `stdio` (default) and `sse` transport modes. When `--transport sse` is specified, the server starts an HTTP server with SSE transport instead of stdio.
+
+### REQ-2: SSE Host Configuration
+
+The server must accept a `--sse-host` CLI flag to configure the bind address for the HTTP server. Default value: `127.0.0.1`. Only applies when `--transport sse` is used.
+
+### REQ-3: SSE Port Configuration
+
+The server must accept a `--sse-port` CLI flag to configure the listening port for the HTTP server. Default value: `9444`. Only applies when `--transport sse` is used.
+
+### REQ-4: HTTP Server Lifecycle
+
+When running in SSE mode, the server must:
+- Create an `http.createServer` instance
+- Handle GET requests on `/sse` to establish SSE connections via `SSEServerTransport`
+- Handle POST requests on `/messages` to receive client messages, routing them by session ID
+- Log the listening address and port on startup
+- Gracefully shut down the HTTP server on SIGINT/SIGTERM
+
+### REQ-5: Configuration File Support
+
+The `transport`, `sseHost`, and `ssePort` settings must also be configurable via the JSON config file (`win-cli-mcp.config.json`) under a top-level `transport` key, with CLI flags taking precedence.
+
+### REQ-6: Backward Compatibility
+
+All existing stdio behavior must remain unchanged. When no `--transport` flag is provided, the server must behave exactly as before. The `CLIServer` class must export its interface so both transports can be tested without starting the actual server.
+
+### REQ-7: Tests
+
+All new transport code must be covered by unit and integration tests:
+- Unit tests for transport selection logic (stdio vs SSE based on config/CLI args)
+- Unit tests for CLI argument parsing of `--transport`, `--sse-host`, `--sse-port`
+- Integration tests verifying SSE transport starts, accepts connections, and processes requests
+- Integration tests verifying stdio transport is unaffected
+
+## Non-Requirements
+
+- Streamable HTTP transport (the newer protocol variant) is out of scope; only classic SSE is implemented.
+- Authentication or TLS/SSL for the HTTP server is out of scope.
+- Multi-client session management beyond what `SSEServerTransport` provides out of the box.
+- Docker or deployment configuration changes.
+
+## Acceptance Criteria
+
+1. Running `npx wcli0` without flags starts the server in stdio mode (existing behavior unchanged).
+2. Running `npx wcli0 --transport sse` starts an HTTP server on `127.0.0.1:9444`.
+3. Running `npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000` binds to `0.0.0.0:3000`.
+4. An MCP client can connect to the SSE endpoint (`GET /sse`), receive the endpoint URI, and send messages (`POST /messages`).
+5. The `transport` config section in JSON config is respected when no CLI override is given.
+6. CLI flags override config file values for transport settings.
+7. The server logs the bind address and port when SSE mode starts.
+8. SIGINT/SIGTERM gracefully shuts down the HTTP server in SSE mode.
+9. All new and existing tests pass.
+10. `npm run lint` passes with no new errors.
+
+## Deliverables
+
+| Deliverable | Type |
+| ----------- | ---- |
+| `src/index.ts` | Update - transport selection in `CLIServer.run()` and `parseArgs()` |
+| `src/utils/transport.ts` | Create - SSE transport factory and HTTP server setup |
+| `src/types/config.ts` | Update - add transport config type |
+| `src/utils/config.ts` | Update - load transport config from file, apply CLI overrides |
+| `tests/unit/transport.test.ts` | Create - unit tests for transport selection logic |
+| `tests/integration/sse-transport.test.ts` | Create - integration tests for SSE transport |
+| `README.md` | Update - document new CLI flags and config options |

--- a/docs/tasks/http_sse_transport/PRD.md
+++ b/docs/tasks/http_sse_transport/PRD.md
@@ -25,6 +25,7 @@ The server must accept a `--sse-port` CLI flag to configure the listening port f
 ### REQ-4: HTTP Server Lifecycle
 
 When running in SSE mode, the server must:
+
 - Create an `http.createServer` instance
 - Handle GET requests on `/sse` to establish SSE connections via `SSEServerTransport`
 - Handle POST requests on `/messages` to receive client messages, routing them by session ID
@@ -42,6 +43,7 @@ All existing stdio behavior must remain unchanged. When no `--transport` flag is
 ### REQ-7: Tests
 
 All new transport code must be covered by unit and integration tests:
+
 - Unit tests for transport selection logic (stdio vs SSE based on config/CLI args)
 - Unit tests for CLI argument parsing of `--transport`, `--sse-host`, `--sse-port`
 - Integration tests verifying SSE transport starts, accepts connections, and processes requests

--- a/docs/tasks/http_sse_transport/analysis.md
+++ b/docs/tasks/http_sse_transport/analysis.md
@@ -41,6 +41,7 @@ No breaking changes to existing code paths.
 ### Recommended: Extract transport logic into a dedicated module
 
 Create `src/utils/transport.ts` that exports:
+
 - `createSseServer(mcpServer, host, port)` - sets up HTTP server with SSE routing
 - `TransportConfig` type for host/port/mode
 
@@ -74,12 +75,14 @@ The `CLIServer.run()` method selects transport based on config and delegates.
 ## Test Strategy
 
 ### Unit Tests (`tests/unit/transport.test.ts`)
+
 - Transport selection logic: given config with transport mode, verify correct transport is created.
 - CLI argument parsing: verify `--transport`, `--sse-host`, `--sse-port` are parsed correctly.
 - Config override precedence: CLI > config file > default.
 - Default values: verify stdio when no transport config, `127.0.0.1:9444` when SSE defaults.
 
 ### Integration Tests (`tests/integration/sse-transport.test.ts`)
+
 - Start server in SSE mode on port 0 (ephemeral).
 - Connect via HTTP GET to `/sse`, verify SSE stream opens.
 - Send a JSON-RPC `initialize` message via POST `/messages`.

--- a/docs/tasks/http_sse_transport/analysis.md
+++ b/docs/tasks/http_sse_transport/analysis.md
@@ -1,0 +1,88 @@
+# Analysis: HTTP/SSE Transport for MCP Server
+
+## Goal
+
+Enable the wcli0 MCP server to accept connections over HTTP/SSE in addition to the existing stdio transport, allowing remote and web-based MCP clients to use the server.
+
+## Current Behavior
+
+The server's transport is hard-coded in `src/index.ts:1352-1363`:
+
+```typescript
+async run(): Promise<void> {
+  const transport = new StdioServerTransport();
+  // ...
+  await this.server.connect(transport);
+  debugLog("Windows CLI MCP Server running on stdio");
+}
+```
+
+- `CLIServer` class (line ~70-1460 in `src/index.ts`) owns the MCP `Server` instance and calls `run()` to connect.
+- `parseArgs()` (line 70-164) uses yargs to define all CLI options. No transport-related flags exist.
+- Configuration loading (`src/utils/config.ts`) handles file-based config and CLI overrides. No transport config exists.
+- The `ServerConfig` type (`src/types/config.ts`) has no transport fields.
+- The MCP SDK v1.0.1 provides `SSEServerTransport` at `@modelcontextprotocol/sdk/server/sse.js` which requires:
+  - An endpoint path string (e.g., `/messages`)
+  - A `ServerResponse` object for the initial SSE connection
+  - The caller to manage `http.createServer` routing
+
+## Feasibility
+
+Straightforward. The MCP SDK already provides `SSEServerTransport` with the full SSE+POST protocol. The server already has a clean separation between config loading, server construction, and transport connection. Adding an alternative transport path is a matter of:
+
+1. Detecting the desired transport mode from config/CLI.
+2. If SSE: creating an HTTP server, handling GET `/sse` and POST `/messages`, and using `SSEServerTransport`.
+3. If stdio: keeping existing behavior.
+
+No breaking changes to existing code paths.
+
+## Approach
+
+### Recommended: Extract transport logic into a dedicated module
+
+Create `src/utils/transport.ts` that exports:
+- `createSseServer(mcpServer, host, port)` - sets up HTTP server with SSE routing
+- `TransportConfig` type for host/port/mode
+
+The `CLIServer.run()` method selects transport based on config and delegates.
+
+| Advantages | Disadvantages |
+| ---------- | ------------- |
+| Clean separation of concerns | One new file to maintain |
+| Easy to test transport logic in isolation | Slightly more indirection |
+| stdio path remains untouched | |
+| Future transports (WebSocket, streamable HTTP) fit the same pattern | |
+
+## Implementation Notes
+
+- `SSEServerTransport` constructor takes `(endpoint: string, res: ServerResponse)`. The server must hold a map of session ID to transport for routing POST requests.
+- The MCP SDK's `SSEServerTransport` sets `res` headers and begins streaming. The HTTP server must call `transport.start()` after creating the transport with the response.
+- POST `/messages` handling: parse the session ID from the URL query parameter (the SDK sends `?sessionId=...`), look up the transport, and call `transport.handlePostMessage(req, res)`.
+- The HTTP server should use Node.js built-in `http` module (already a dependency via `@types/node`). No additional npm dependencies needed.
+- `yargs` already validates CLI input, so `--transport` can use `choices: ['stdio', 'sse']` for validation.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| SSE transport session management edge cases | Follow MCP SDK patterns exactly; test multi-request flows |
+| Port conflicts on CI runners | Use port 0 (OS-assigned) in tests, not the default 9444 |
+| SIGINT handler needs to close HTTP server | Extend existing cleanup handler to close HTTP server if running |
+| Config file migration for users with existing configs | Transport config is optional with sensible defaults; absent config means stdio |
+| `SSEServerTransport` API assumptions may differ from our usage | Read SDK source carefully; write integration test first as a spike |
+
+## Test Strategy
+
+### Unit Tests (`tests/unit/transport.test.ts`)
+- Transport selection logic: given config with transport mode, verify correct transport is created.
+- CLI argument parsing: verify `--transport`, `--sse-host`, `--sse-port` are parsed correctly.
+- Config override precedence: CLI > config file > default.
+- Default values: verify stdio when no transport config, `127.0.0.1:9444` when SSE defaults.
+
+### Integration Tests (`tests/integration/sse-transport.test.ts`)
+- Start server in SSE mode on port 0 (ephemeral).
+- Connect via HTTP GET to `/sse`, verify SSE stream opens.
+- Send a JSON-RPC `initialize` message via POST `/messages`.
+- Verify response is received on the SSE stream.
+- Test graceful shutdown.
+- Verify stdio mode still works (regression).

--- a/docs/tasks/http_sse_transport/analysis_10_serialize_transport_config.md
+++ b/docs/tasks/http_sse_transport/analysis_10_serialize_transport_config.md
@@ -1,0 +1,20 @@
+# Analysis 10 - Include transport in serialized config
+
+## Decision: Valid -- fix applied
+
+`createSerializableConfig()` builds the object returned by the `get_config` tool
+and the `cli://config` resource, but it only copied `global` and `shells`. The
+new `transport` section added to `ServerConfig` was therefore invisible to
+clients, so a server running in SSE mode or bound to a custom host/port still
+reported nothing about its actual connection settings. The fix appends
+`config.transport` to the serializable object (mode, sseHost, ssePort) when it is
+present, so the advertised configuration reflects the live transport.
+
+**Why:** These handlers exist to expose the complete, safe view of the server
+configuration. Omitting transport contradicts that contract and hides
+operationally relevant data (especially a non-default bind address). The
+transport section contains no secrets, so it is safe to serialize directly. The
+copy is guarded by a presence check so stdio-only configs without a transport
+section serialize unchanged.
+
+**Commit:** 0c15707 -- fix(transport): address third-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_11_per_session_relative_dir.md
+++ b/docs/tasks/http_sse_transport/analysis_11_per_session_relative_dir.md
@@ -27,4 +27,4 @@ followed by a relative path) and, because resolution happens before the
 `restrictWorkingDirectory` validation, the resolved path is still checked
 against the allowed paths, so security is unchanged.
 
-**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83
+**Commit:** 16d7070 -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_11_per_session_relative_dir.md
+++ b/docs/tasks/http_sse_transport/analysis_11_per_session_relative_dir.md
@@ -1,0 +1,30 @@
+# Analysis 11 - Anchor relative working directories to the calling session
+
+## Decision: Valid -- fix applied
+
+The previous round isolated `session.activeCwd` but kept the process-global
+`process.chdir()` in `set_current_directory`, reasoning that command execution
+always spawns with an explicit cwd. That holds for the no-`workingDir` path
+(which uses the already-absolute `session.activeCwd`) and for Windows/Git Bash
+shells (whose paths are absolutized by `normalizeWindowsPath`), but not for a
+relative `workingDir` on a unix-format shell (WSL/bash) when restrictions are
+disabled: that path reached `spawn({ cwd })` verbatim and resolved against the
+shared process cwd, which another session had mutated via `process.chdir()`. The
+fix adds `CLIServer.resolveWorkingDirForSession()`, called in the
+`execute_command` handler right after `normalizePathForShell`, which resolves a
+relative `workingDir` against `session.activeCwd` (POSIX semantics for
+`/`-rooted bases, Windows otherwise) and leaves absolute paths and the
+no-active-directory case untouched. New tests in `sessionIsolation.test.ts`
+prove the same relative input resolves to each session's own directory and that
+absolute paths are passed through unchanged.
+
+**Why:** The user-selected approach keeps `process.chdir()` so stdio behavior
+and the existing `setCurrentDirectory.test.ts` suite (which asserts `chdir` is
+called) remain valid, while closing the cross-session leak at the exact point it
+occurs -- the spawn cwd. Anchoring relative paths to the session's active
+directory is also the intuitively correct behavior (equivalent to a shell `cd`
+followed by a relative path) and, because resolution happens before the
+`restrictWorkingDirectory` validation, the resolved path is still checked
+against the allowed paths, so security is unchanged.
+
+**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_12_wildcard_sse_allowed_origins.md
+++ b/docs/tasks/http_sse_transport/analysis_12_wildcard_sse_allowed_origins.md
@@ -26,4 +26,4 @@ disallowed origin is still rejected with `403` before any work) while the
 documented remote-binding use case becomes possible. The empty default keeps the
 prior loopback-only behavior unchanged for existing deployments.
 
-**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83
+**Commit:** 16d7070 -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_12_wildcard_sse_allowed_origins.md
+++ b/docs/tasks/http_sse_transport/analysis_12_wildcard_sse_allowed_origins.md
@@ -1,0 +1,29 @@
+# Analysis 12 - Add an allowed-origins configuration for wildcard binds
+
+## Decision: Valid -- fix applied
+
+On a wildcard bind (`--sse-host 0.0.0.0` / `::`) the bind host is not a usable
+origin to compare against, so `isOriginAllowed` rejected every real browser
+client reaching the server through its LAN address or a reverse proxy whose
+public hostname differs from the bind host. The fix introduces an explicit
+allowed-origin list: a new optional `transport.sseAllowedOrigins: string[]`
+config field and a `--sse-allowed-origins` CLI flag (comma-separated, parsed by
+`applyCliTransport`). `isOriginAllowed` now also accepts any origin whose host
+matches an entry in that list, in addition to loopback and the bind host;
+entries may be full origin URLs or bare hosts, and only the host component is
+compared (case-insensitively, matching the existing bind-host comparison).
+`validateTransportConfig` rejects a non-array value or empty-string entries, the
+list defaults to empty, and `createSseServer`/`run()` thread it through to the
+request handler. README and config examples document the new parameter. New
+unit tests cover the wildcard-rejection default, full-origin and bare-host
+matches, case-insensitivity, the still-rejected unrelated origin, CLI parsing,
+and config validation.
+
+**Why:** An explicit allowlist is the option Codex recommended and the correct
+security posture: it does not auto-trust arbitrary origins simply because the
+server is bound to `0.0.0.0`, so the DNS-rebinding defense is preserved (a
+disallowed origin is still rejected with `403` before any work) while the
+documented remote-binding use case becomes possible. The empty default keeps the
+prior loopback-only behavior unchanged for existing deployments.
+
+**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_13_sse_cleanup_before_connect.md
+++ b/docs/tasks/http_sse_transport/analysis_13_sse_cleanup_before_connect.md
@@ -1,0 +1,29 @@
+# Analysis 13 - Register SSE session cleanup before connect()
+
+## Decision: Valid -- fix applied
+
+The prior code added the session to the `sessions` map, awaited
+`sessionServer.connect(transport)`, and only then overwrote `transport.onclose`
+to delete the map entry. `connect()` calls `transport.start()`, which writes the
+SSE headers and attaches the SDK's own `res` `close` listener while `connect()`
+is still awaiting; a client that opens `/sse` and disconnects during that window
+fires the close event before the after-the-fact `onclose` handler is installed,
+so the SDK handler runs alone and the map entry is never removed. The dead
+session then leaks, and later POSTs route into `handlePostMessage()` (returning
+`500` instead of `404`). The fix registers the cleanup directly on the response
+(`res.on('close', ...)`) before calling `connect()`, so the listener is in place
+before the response can close -- eliminating the race. The SDK transport still
+runs its own `onclose` for protocol teardown (it is no longer overwritten), and
+this listener only removes the routing entry. New integration tests exercise an
+immediate disconnect right after the endpoint event and rapid
+connect/immediate-disconnect cycles, asserting later POSTs return `404` and no
+session leaks.
+
+**Why:** Listening on the response object is race-free because, unlike
+overwriting `transport.onclose` after `connect()` resolves, the listener is
+attached synchronously before the SSE stream starts and therefore before the
+client can disconnect. It also avoids depending on the SDK's internal ordering
+of `onclose` assignment versus `start()`, which the previous approach implicitly
+relied on.
+
+**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_13_sse_cleanup_before_connect.md
+++ b/docs/tasks/http_sse_transport/analysis_13_sse_cleanup_before_connect.md
@@ -26,4 +26,4 @@ client can disconnect. It also avoids depending on the SDK's internal ordering
 of `onclose` assignment versus `start()`, which the previous approach implicitly
 relied on.
 
-**Commit:** e8cfa0f -- fix(transport): address fourth-round Codex review feedback for PR #83
+**Commit:** 16d7070 -- fix(transport): address fourth-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_1_per_session_server.md
+++ b/docs/tasks/http_sse_transport/analysis_1_per_session_server.md
@@ -1,0 +1,25 @@
+# Analysis 1 - Create a fresh MCP server per SSE session
+
+## Decision: Valid -- fix applied
+
+The shared-`Server` design is a genuine concurrency bug. The pinned SDK
+(`@modelcontextprotocol/sdk@1.0.1`) implements `Protocol.connect(transport)` as
+`this._transport = transport`, unconditionally replacing any previously connected
+transport and its callbacks. Two concurrent SSE sessions on one `CLIServer`
+therefore share a single protocol whose `_transport` points only at the most
+recent stream, so the earlier session's responses are misrouted. The fix turns
+`createSseServer()` into a per-connection factory: it now accepts a
+`() => Server` callback and constructs a fresh, fully-wired `Server` for each
+`GET /sse`. `CLIServer` exposes `createServerInstance()` (extracted from the
+constructor) and `setupHandlers(server)` was parameterized so the same handler
+set can be registered on any server instance. The shared `this.server` is still
+used for stdio mode and shutdown.
+
+**Why:** This mirrors the SDK's own legacy SSE example, which builds one server
+per connection. It is the minimal change that gives each session an isolated
+protocol/transport pair without duplicating handler logic. The existing
+integration test "multiple concurrent SSE sessions" only spun up separate
+`CLIServer` processes, so it never exercised two sessions sharing one server;
+new tests cover that path directly.
+
+**Commit:** 57358aa -- fix(transport): address Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_2_origin_validation.md
+++ b/docs/tasks/http_sse_transport/analysis_2_origin_validation.md
@@ -1,0 +1,23 @@
+# Analysis 2 - Reject untrusted Origin headers on HTTP transport
+
+## Decision: Valid -- fix applied
+
+DNS-rebinding against a localhost listener is a documented MCP threat, and the
+transport performed no `Origin` checking. The fix adds an origin allowlist in
+`src/utils/transport.ts`: requests with no `Origin` header (native MCP clients,
+curl) are still accepted, but a present `Origin` must resolve to a loopback host
+(`localhost`, `127.0.0.1`, `::1`) or to the configured bind host. Disallowed or
+malformed origins -- including the literal `null` origin used by sandboxed
+iframes and `file://` pages -- are rejected with `403 Forbidden` on both
+`GET /sse` and `POST /messages`, before any session is created or message is
+routed.
+
+**Why:** The `Origin` header reflects the page the request originated from, not
+the rebound IP, so allowlisting trusted origins defeats DNS rebinding even when
+the attacker's domain resolves to `127.0.0.1`. Allowing the no-`Origin` case
+keeps non-browser clients (and the existing integration tests, which use bare
+`http.get`/`http.request`) working, matching the SDK's own
+`enableDnsRebindingProtection` posture of validating only when the header is
+present.
+
+**Commit:** 57358aa -- fix(transport): address Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_3_doc_bind_all_interfaces.md
+++ b/docs/tasks/http_sse_transport/analysis_3_doc_bind_all_interfaces.md
@@ -1,0 +1,19 @@
+# Analysis 3 - Avoid advertising unauthenticated bind-all-interfaces example
+
+## Decision: Valid -- fix applied
+
+The README's "custom host and port" snippet used `--sse-host 0.0.0.0`, which a
+reader can copy onto an untrusted network and unwittingly expose the
+command-execution tools with no authentication. The fix changes the documented
+example to bind `127.0.0.1` on a custom port and adds a prominent security
+callout warning that binding to `0.0.0.0` (or any non-loopback address) exposes
+the tools to every host that can reach the port and must be fronted by
+authenticated access control. The callout also notes the new `Origin` validation
+so readers understand the built-in mitigation and its limits.
+
+**Why:** Documentation that demonstrates an insecure default is itself a security
+defect because copy-paste usage is the norm. Keeping the happy-path example on
+localhost and gating the bind-all guidance behind an explicit warning aligns the
+docs with the transport's intended local-first threat model.
+
+**Commit:** 57358aa -- fix(transport): address Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_4_validate_transport_config.md
+++ b/docs/tasks/http_sse_transport/analysis_4_validate_transport_config.md
@@ -1,0 +1,21 @@
+# Analysis 4 - Validate transport config before use
+
+## Decision: Valid -- fix applied
+
+`validateConfig()` checked security, shells, timeout, and logging but never the
+`transport` section, so file-supplied values flowed straight into `run()`. A
+string `ssePort` (for example `"3000"`) silently becomes a named-pipe path in
+`httpServer.listen()` while startup still logs `http://host:3000`, breaking SSE
+clients with no error. The fix adds `validateTransportConfig()` and calls it from
+`validateConfig()`: `mode` must be `stdio` or `sse`, `sseHost` must be a
+non-empty string, and `ssePort` must be an integer in `1..65535`. Because
+`loadConfig()` runs `validateConfig()` after the merge, a malformed config now
+fails fast at startup.
+
+**Why:** The CLI path already validated these values in `applyCliTransport()`, so
+config-file values were the only unguarded entry point -- exactly the gap the
+reviewer flagged. Reusing the existing `validateConfig()` chokepoint keeps the
+validation in one place and catches typos before the listener is created. The
+port range mirrors the `1..65535` bound already enforced for `--sse-port`.
+
+**Commit:** 57358aa -- fix(transport): address Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_5_malformed_host_header.md
+++ b/docs/tasks/http_sse_transport/analysis_5_malformed_host_header.md
@@ -1,0 +1,23 @@
+# Analysis 5 - Handle malformed Host headers
+
+## Decision: Valid -- fix applied
+
+The HTTP request callback built the request URL from `req.url` and
+`req.headers.host` via `new URL()` as its very first statement. A client can
+send an unparseable `Host` (for example `%%%%`), which
+makes `new URL()` throw `ERR_INVALID_URL`. Because the callback is `async`, the
+throw escaped as an unhandled promise rejection, and under Node's default
+`--unhandled-rejections=throw` policy that terminates the process -- so a single
+unauthenticated request could take the SSE server down. The fix wraps the URL
+construction in a `try/catch` that returns a 400 `Bad Request` (and falls back to
+`localhost` as the base host when the header is absent), keeping the listener
+alive. A new integration test sends `Host: %%%%`, asserts the 400, and then
+confirms a subsequent normal request still succeeds (the process did not crash).
+
+**Why:** Returning 400 is the correct semantic for a malformed request line and
+is strictly safer than letting the exception propagate. Parsing defensively at
+the single entry point covers every route at once, and validating before the
+origin check keeps the crash surface minimal. The behavior matches the existing
+defensive style already used for malformed Origin headers.
+
+**Commit:** 3365e3f -- fix(transport): address second-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_6_track_sockets_shutdown.md
+++ b/docs/tasks/http_sse_transport/analysis_6_track_sockets_shutdown.md
@@ -1,0 +1,25 @@
+# Analysis 6 - Track sockets instead of relying on closeAllConnections
+
+## Decision: Valid -- fix applied
+
+`closeSseServer()` forced lingering sockets closed only through
+`server.closeAllConnections()`, which Node added in 18.2. The package's
+`engines.node` is `>=18.0.0`, so on 18.0/18.1 the method is `undefined` and the
+old guard (`typeof closeAll === 'function'`) silently skipped it. With an active
+long-lived `/sse` stream, `server.close()` then waited for the client to
+disconnect on its own, so `cleanup()`/SIGINT could hang indefinitely. The fix
+tracks every accepted socket in a per-server `Set` (populated from the
+`connection` event and pruned on each socket's `close`), keyed weakly by server
+in a module-level `WeakMap`. `closeSseServer()` still prefers
+`closeAllConnections()` when present, but now falls back to destroying the
+tracked sockets, guaranteeing close completes on every supported runtime. A new
+test stubs `closeAllConnections` to `undefined`, opens a live SSE stream, and
+asserts `closeSseServer()` still tears the server down.
+
+**Why:** Tracking sockets removes the version dependency entirely instead of
+masking it, and is preferable to raising the minimum Node version because it
+keeps the advertised `>=18.0.0` support contract intact. The `WeakMap` keying
+avoids leaking server references and needs no changes to the `closeSseServer`
+signature, which several tests and `cleanup()` already depend on.
+
+**Commit:** 3365e3f -- fix(transport): address second-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_7_per_session_active_directory.md
+++ b/docs/tasks/http_sse_transport/analysis_7_per_session_active_directory.md
@@ -1,0 +1,31 @@
+# Analysis 7 - Isolate active directories per SSE session
+
+## Decision: Valid -- fix applied
+
+Each SSE connection already received its own MCP `Server`, but every handler
+closed over the same `CLIServer` and read/wrote the single
+`this.serverActiveCwd` field. `set_current_directory` in one client therefore
+changed the directory that `execute_command` (with no `workingDir`) used for
+every other concurrent SSE client. The fix introduces a `SessionState`
+(`{ activeCwd }`) object: `createServerInstance(session)` and
+`setupHandlers(server, session)` now thread a per-instance state through, the
+`CallToolRequestSchema` handler passes it to `_executeTool(params, session)`, and
+the `execute_command` / `get_current_directory` / `set_current_directory` cases
+read and write `session.activeCwd` instead of the shared field. `run()` seeds
+each SSE connection with a fresh `SessionState` copied from the primary session's
+initial cwd. `serverActiveCwd` is kept as a getter/setter that proxies to a
+`primarySession` object, so stdio mode, `initializeWorkingDirectory()`, and the
+many tests that read or assign `serverActiveCwd` are unchanged. New unit tests
+prove two sessions keep independent directories while the primary session stays
+untouched.
+
+**Why:** A per-session state object is the minimal change that isolates the
+mutable cwd without duplicating handler logic or altering the public
+`_executeTool` contract (the `session` parameter defaults to the primary
+session). `process.chdir()` remains a process-global call, but command execution
+always spawns with an explicit cwd resolved from `session.activeCwd`, so routing
+is now correctly per-session -- which is exactly the leak the reviewer flagged.
+The getter/setter shim preserves backward compatibility with existing tests that
+treat `serverActiveCwd` as a field.
+
+**Commit:** 3365e3f -- fix(transport): address second-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_8_cors_allowed_origins.md
+++ b/docs/tasks/http_sse_transport/analysis_8_cors_allowed_origins.md
@@ -1,0 +1,29 @@
+# Analysis 8 - Return CORS headers for allowed browser origins
+
+## Decision: Valid -- fix applied
+
+The origin allowlist accepted a browser request but the responses carried no
+`Access-Control-Allow-Origin`, and a cross-origin `POST /messages` with
+`application/json` triggers an `OPTIONS` preflight that fell through to the 404
+branch. A page served from an allowed loopback origin on a different port could
+therefore pass the origin check yet still have the browser block the response
+before the MCP handshake completed. The fix, applied after the origin check
+passes, echoes the request's `Origin` (plus `Vary: Origin`) on the SSE response,
+the `POST /messages` response, and the error responses, and answers `OPTIONS`
+preflight requests with `204` and
+`Access-Control-Allow-Methods: GET, POST, OPTIONS` /
+`Access-Control-Allow-Headers: Content-Type`. CORS headers are added through
+`res.setHeader()` before the SDK transport writes its own headers (which
+`writeHead()` merges), so the echoed origin survives onto the `200`/`202`
+responses. Non-browser clients send no `Origin` and receive no CORS headers, so
+their behavior is unchanged. New tests cover the preflight, the echoed header on
+`GET /sse`, the disallowed-origin 403 without CORS, and the no-Origin case.
+
+**Why:** Echoing only the already-allowlisted origin keeps the DNS-rebinding
+defense intact -- a disallowed origin is rejected with 403 before any CORS header
+is emitted, so the allowlist still governs access. Handling preflight is required
+for the documented web-based MCP clients to connect at all, and reflecting the
+specific origin (rather than `*`) is the correct, narrow choice for a
+credential-free localhost transport.
+
+**Commit:** 3365e3f -- fix(transport): address second-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/analysis_9_cli_fractional_sse_port.md
+++ b/docs/tasks/http_sse_transport/analysis_9_cli_fractional_sse_port.md
@@ -1,0 +1,22 @@
+# Analysis 9 - Reject fractional SSE ports from the CLI
+
+## Decision: Valid -- fix applied
+
+`validateTransportConfig()` rejects non-integer ports, but it only runs inside
+`validateConfig()` during `loadConfig()` -- which executes before
+`applyCliTransport()` in `index.ts`. The CLI override path had its own guard
+(`ssePort > 0 && ssePort <= 65535`) that omitted an integer check, so
+`--transport sse --sse-port 9444.5` passed and was assigned. Node's
+`httpServer.listen()` then throws `ERR_SOCKET_BAD_PORT` for a fractional port,
+crashing startup instead of warning and falling back to the default. The fix
+adds `Number.isInteger(ssePort)` to the guard in `applyCliTransport()` so a
+fractional port is rejected and ignored with the existing warning, leaving the
+default port in place.
+
+**Why:** The reviewer correctly identified that yargs `number` options accept
+decimals and that CLI overrides bypass the centralized validation. Mirroring the
+`Number.isInteger` rule already enforced in `validateTransportConfig()` keeps the
+two entry points consistent and converts a hard crash into the same
+warn-and-ignore behavior used for out-of-range ports.
+
+**Commit:** 0c15707 -- fix(transport): address third-round Codex review feedback for PR #83

--- a/docs/tasks/http_sse_transport/comment_10_serialize_transport_config.md
+++ b/docs/tasks/http_sse_transport/comment_10_serialize_transport_config.md
@@ -1,0 +1,9 @@
+# P10 - Include transport in serialized config
+
+Adding `transport` to `ServerConfig` (`src/types/config.ts:271`) did not update
+`createSerializableConfig()`, which still serializes only `global` and `shells`.
+Consequently `get_config` and `cli://config` omit the active transport
+mode/host/port even when the server runs with SSE or a custom bind address.
+Since these handlers advertise the complete server configuration, include
+`config.transport` in the serializable object so clients can inspect the actual
+connection settings.

--- a/docs/tasks/http_sse_transport/comment_11_per_session_relative_dir.md
+++ b/docs/tasks/http_sse_transport/comment_11_per_session_relative_dir.md
@@ -1,0 +1,3 @@
+# P11 - Avoid changing global cwd for per-session SSE directories
+
+In SSE mode `set_current_directory` (`src/index.ts:1105`) stores `activeCwd` per session but still calls the process-wide `process.chdir()`. When directory restrictions are disabled, a relative `workingDir` passed to `execute_command` is handed to `spawn({ cwd })` without being made absolute, so it resolves against the shared process-global cwd that another session most recently set. A second SSE client can therefore make another client's relative command run in the wrong directory even though `session.activeCwd` itself stays isolated.

--- a/docs/tasks/http_sse_transport/comment_12_wildcard_sse_allowed_origins.md
+++ b/docs/tasks/http_sse_transport/comment_12_wildcard_sse_allowed_origins.md
@@ -1,0 +1,3 @@
+# P12 - Allow origins for wildcard SSE binds
+
+When the server is started with the documented remote binding `--sse-host 0.0.0.0`, browser clients reaching it through the machine's real address send an origin such as `http://192.168.1.10:9444`, but the comparison in `isOriginAllowed` (`src/utils/transport.ts:48`) only accepts the literal configured bind host (`0.0.0.0`) or loopback, so those web clients are rejected with `403`. The same problem occurs behind a reverse proxy unless `sseHost` is set to the public hostname, so wildcard binds need an allowed-origin configuration instead of comparing the origin host directly to `0.0.0.0`.

--- a/docs/tasks/http_sse_transport/comment_13_sse_cleanup_before_connect.md
+++ b/docs/tasks/http_sse_transport/comment_13_sse_cleanup_before_connect.md
@@ -1,0 +1,3 @@
+# P13 - Register SSE cleanup before the connection can close
+
+The transport is inserted into `sessions` before the cleanup callback is installed, and `await sessionServer.connect(transport)` (`src/utils/transport.ts:140`) starts the SSE response and attaches the SDK close listener first. If a client opens `/sse` and immediately disconnects before execution resumes to replace `transport.onclose`, only the SDK close handler runs, so the map entry is never deleted; later POSTs to that dead session can hit `handlePostMessage()` and return `500` instead of `404`, and repeated rapid connects leak session entries.

--- a/docs/tasks/http_sse_transport/comment_1_per_session_server.md
+++ b/docs/tasks/http_sse_transport/comment_1_per_session_server.md
@@ -1,0 +1,13 @@
+# P1 - Create a fresh MCP server per SSE session
+
+`createSseServer()` reuses the single shared `Server` instance for every SSE
+connection (`src/utils/transport.ts:21`), but the MCP `Protocol` object owns one
+transport at a time: `connect()` overwrites `this._transport`, and its own
+docstring states it "assumes ownership of the Transport ... and expects that it
+is the only user of the Transport instance going forward." When a second client
+opens `/sse` while the first stream is still connected, the second `connect()`
+rebinds the protocol to the new transport, so responses for the first session can
+be routed to the wrong stream (newer SDKs throw outright). The SDK's legacy SSE
+example avoids this by constructing a new MCP server per SSE connection; this
+server needs the same per-session protocol instance rather than sharing
+`this.server` across sessions.

--- a/docs/tasks/http_sse_transport/comment_2_origin_validation.md
+++ b/docs/tasks/http_sse_transport/comment_2_origin_validation.md
@@ -1,0 +1,10 @@
+# P2 - Reject untrusted Origin headers on HTTP transport
+
+The SSE endpoints accept every `GET /sse` and `POST /messages` without checking
+the `Origin` header (`src/utils/transport.ts:14`). For the default localhost
+listener, a malicious web page can use DNS rebinding to reach `127.0.0.1:9444`
+with its own origin and drive the MCP command-execution tools over SSE/POST. The
+MCP HTTP transport security guidance requires validating `Origin` to prevent
+exactly this class of attack. Add an allowlist for local origins/hosts and reject
+disallowed origins before creating sessions or handling messages, while still
+permitting non-browser clients that send no `Origin` header.

--- a/docs/tasks/http_sse_transport/comment_3_doc_bind_all_interfaces.md
+++ b/docs/tasks/http_sse_transport/comment_3_doc_bind_all_interfaces.md
@@ -1,0 +1,8 @@
+# P3 - Avoid advertising unauthenticated bind-all-interfaces example
+
+The README documents a `--sse-host 0.0.0.0` example (`README.md:495`). When users
+copy this onto a shared or untrusted network, the HTTP transport exposes the MCP
+server's command-execution tools to any host that can reach the port, and the
+implementation adds no authentication. Keep the documented example bound to
+localhost and include a prominent security requirement to place authenticated
+access control in front of the server before binding to all interfaces.

--- a/docs/tasks/http_sse_transport/comment_4_validate_transport_config.md
+++ b/docs/tasks/http_sse_transport/comment_4_validate_transport_config.md
@@ -1,0 +1,9 @@
+# P4 - Validate transport config before use
+
+When `transport` comes from a JSON config file, the raw values overwrite the
+defaults in `mergeConfigs()` (`src/utils/config.ts:490`) but `validateConfig()`
+never checks the new section. A typo such as `{ "mode": "sse", "ssePort": "3000" }`
+leaves `ssePort` as a string, which Node treats as a Unix/named-pipe path instead
+of a TCP port, while `run()` still logs `http://host:3000`, so configured SSE
+clients cannot connect. Validate `mode`, `sseHost`, and the numeric port range
+during config loading, not only for CLI flags.

--- a/docs/tasks/http_sse_transport/comment_5_malformed_host_header.md
+++ b/docs/tasks/http_sse_transport/comment_5_malformed_host_header.md
@@ -1,0 +1,11 @@
+# P5 - Handle malformed Host headers
+
+A client can send an invalid `Host` header such as `%%%%`. Node accepts the
+request, but constructing the request URL with that value as the base via
+`new URL()` at `src/utils/transport.ts:53` -- throws an `ERR_INVALID_URL`
+exception before any
+route-level handling. Because the HTTP callback is `async`, the throw becomes an
+unhandled promise rejection and, under the default Node behavior, terminates the
+process. An unauthenticated malformed request can therefore kill the SSE server.
+Parse the URL defensively and return a 400 instead of letting the exception
+escape.

--- a/docs/tasks/http_sse_transport/comment_6_track_sockets_shutdown.md
+++ b/docs/tasks/http_sse_transport/comment_6_track_sockets_shutdown.md
@@ -1,0 +1,10 @@
+# P6 - Track sockets instead of relying on closeAllConnections
+
+`closeSseServer()` (`src/utils/transport.ts:150`) destroys lingering sockets only
+through `server.closeAllConnections()`. That API was added in Node 18.2, but the
+package still allows Node 18.0/18.1 via `engines.node >=18.0.0`, where the method
+is `undefined` and the fallback becomes a no-op. With any active `/sse` stream,
+`server.close()` then waits for the client to disconnect on its own, so
+`cleanup()`/SIGINT can hang indefinitely. Track the open sockets explicitly and
+destroy them on shutdown (or raise the minimum Node version) so close always
+completes.

--- a/docs/tasks/http_sse_transport/comment_7_per_session_active_directory.md
+++ b/docs/tasks/http_sse_transport/comment_7_per_session_active_directory.md
@@ -1,0 +1,9 @@
+# P7 - Isolate active directories per SSE session
+
+Every SSE connection now gets a fresh MCP protocol object, but the handlers
+created in `createServerInstance()` (`src/index.ts:1415`) still close over the
+same `CLIServer` instance. `set_current_directory` in one client mutates
+`this.serverActiveCwd`, which `execute_command` reads when `workingDir` is
+omitted, so concurrent SSE clients can silently run in whichever directory
+another session last selected. In SSE mode the mutable active working directory
+should be per-session rather than shared through the outer `CLIServer`.

--- a/docs/tasks/http_sse_transport/comment_8_cors_allowed_origins.md
+++ b/docs/tasks/http_sse_transport/comment_8_cors_allowed_origins.md
@@ -1,0 +1,10 @@
+# P8 - Return CORS headers for allowed browser origins
+
+For the advertised web-based MCP clients, a page served from an allowed loopback
+origin but a different port still issues a cross-origin EventSource/fetch request
+to this server. After the `Origin` check passes (`src/utils/transport.ts:62`),
+the responses never include `Access-Control-Allow-Origin`, and a
+`POST /messages` with `application/json` also needs an `OPTIONS` preflight that
+currently falls through to 404. Browsers therefore block the connection before
+the MCP handshake can complete. Echo the allowed origin on responses and answer
+preflight `OPTIONS` requests when the `Origin` is accepted.

--- a/docs/tasks/http_sse_transport/comment_9_cli_fractional_sse_port.md
+++ b/docs/tasks/http_sse_transport/comment_9_cli_fractional_sse_port.md
@@ -1,0 +1,9 @@
+# P9 - Reject fractional SSE ports from the CLI
+
+Because `applyCliTransport` (`src/utils/config.ts:921`) runs after
+`loadConfig`/`validateConfig`, the integer check in `validateTransportConfig`
+is bypassed for CLI overrides. Yargs `number` options accept decimals, so
+`--transport sse --sse-port 9444.5` satisfies the `ssePort > 0 && ssePort <= 65535`
+condition and is assigned; `httpServer.listen()` then throws `ERR_SOCKET_BAD_PORT`
+at startup instead of warning and ignoring it. Add `Number.isInteger(ssePort)`
+to the guard here, or revalidate after applying CLI overrides.

--- a/docs/tasks/http_sse_transport/implementation_plan.md
+++ b/docs/tasks/http_sse_transport/implementation_plan.md
@@ -32,7 +32,7 @@ flowchart TB
 
 ## Phase 1: Types and Configuration
 
-### Implementation Work
+### Implementation Work (Phase 1)
 
 - Add `TransportConfig` interface to `src/types/config.ts`:
 
@@ -58,13 +58,13 @@ transport: {
 - Add `applyCliTransport()` function in `src/utils/config.ts` that applies `--transport`, `--sse-host`, `--sse-port` overrides to the loaded config.
 - Load transport section from config file (if present) in the existing config loading flow.
 
-### Test Work
+### Test Work (Phase 1)
 
 - Unit test: verify `TransportConfig` defaults are correct.
 - Unit test: verify `applyCliTransport()` overrides config values.
 - Unit test: verify CLI flags take precedence over config file values.
 
-### Verification
+### Verification (Phase 1)
 
 ```bash
 npm run lint
@@ -73,7 +73,7 @@ npm test -- tests/unit/
 
 ## Phase 2: CLI Arguments
 
-### Implementation Work
+### Implementation Work (Phase 2)
 
 - Add to `parseArgs()` in `src/index.ts`:
 
@@ -95,13 +95,13 @@ npm test -- tests/unit/
 
 - Call `applyCliTransport()` in the `main()` function after loading config.
 
-### Test Work
+### Test Work (Phase 2)
 
 - Unit test: `parseArgs` returns correct defaults when no transport flags.
 - Unit test: `parseArgs` returns `--transport sse` correctly.
 - Unit test: `parseArgs` returns `--sse-host` and `--sse-port` correctly.
 
-### Verification
+### Verification (Phase 2)
 
 ```bash
 npm run lint
@@ -110,7 +110,7 @@ npm test -- tests/unit/
 
 ## Phase 3: SSE Transport Module
 
-### Implementation Work
+### Implementation Work (Phase 3)
 
 - Create `src/utils/transport.ts` with:
 
@@ -130,14 +130,14 @@ export function createSseServer(
   5. Returns a promise that resolves with the `http.Server` once it's listening.
 - Export a `closeSseServer(server)` helper for clean shutdown.
 
-### Test Work
+### Test Work (Phase 3)
 
 - Unit test: `createSseServer` creates an HTTP server that listens.
 - Unit test: GET `/sse` returns SSE content type headers.
 - Unit test: POST to non-existent session returns error.
 - Unit test: session map is populated after SSE connection.
 
-### Verification
+### Verification (Phase 3)
 
 ```bash
 npm run lint
@@ -146,7 +146,7 @@ npm test -- tests/unit/transport.test.ts
 
 ## Phase 4: CLIServer Integration
 
-### Implementation Work
+### Implementation Work (Phase 4)
 
 - Update `CLIServer.run()` in `src/index.ts`:
 
@@ -169,14 +169,14 @@ async run(): Promise<void> {
 - Update cleanup handler to close HTTP server if in SSE mode.
 - Store the HTTP server reference on `CLIServer` for cleanup.
 
-### Test Work
+### Test Work (Phase 4)
 
 - Integration test: start `CLIServer` in SSE mode on port 0.
 - Integration test: client connects to SSE, sends `initialize` request, receives response.
 - Integration test: server shuts down cleanly on signal.
 - Regression test: stdio mode still works end-to-end.
 
-### Verification
+### Verification (Phase 4)
 
 ```bash
 npm run lint
@@ -186,7 +186,7 @@ npm test
 
 ## Phase 5: Documentation
 
-### Implementation Work
+### Implementation Work (Phase 5)
 
 - Update `README.md` to document:
   - `--transport` flag with choices and default.
@@ -194,11 +194,11 @@ npm test
   - Config file `transport` section example.
   - Usage example: `npx wcli0 --transport sse`.
 
-### Test Work
+### Test Work (Phase 5)
 
 - Verify README examples are syntactically correct.
 
-### Verification
+### Verification (Phase 5)
 
 ```bash
 npm run lint

--- a/docs/tasks/http_sse_transport/implementation_plan.md
+++ b/docs/tasks/http_sse_transport/implementation_plan.md
@@ -1,0 +1,225 @@
+# Implementation Plan: HTTP/SSE Transport for MCP Server
+
+## Overview
+
+Add HTTP/SSE transport as an alternative to stdio. The server detects the transport mode from CLI flags or config file, then either starts stdio (existing path) or creates an HTTP server with `SSEServerTransport`. A new `src/utils/transport.ts` module encapsulates all HTTP/SSE setup logic.
+
+```mermaid
+flowchart TB
+    subgraph Startup
+        A[parseArgs] --> B{--transport flag?}
+        B -->|stdio / default| C[StdioServerTransport]
+        B -->|sse| D[createSseServer]
+        D --> E[http.createServer]
+        E --> F["GET /sse -> SSEServerTransport"]
+        E --> G["POST /messages -> transport.handlePostMessage"]
+        F --> H[server.connect transport]
+        C --> H
+    end
+```
+
+## Affected Files
+
+| File | Change Type | Description |
+| ---- | ----------- | ----------- |
+| `src/utils/transport.ts` | Create | SSE transport factory, HTTP server setup, session routing |
+| `src/types/config.ts` | Update | Add `TransportConfig` type and fields |
+| `src/utils/config.ts` | Update | Load transport config from file, apply CLI overrides |
+| `src/index.ts` | Update | Add CLI flags to `parseArgs()`, update `CLIServer.run()` |
+| `tests/unit/transport.test.ts` | Create | Unit tests for transport selection and config |
+| `tests/integration/sse-transport.test.ts` | Create | Integration tests for SSE transport |
+| `README.md` | Update | Document new CLI flags and config options |
+
+## Phase 1: Types and Configuration
+
+### Implementation Work
+
+- Add `TransportConfig` interface to `src/types/config.ts`:
+
+```typescript
+export interface TransportConfig {
+  mode: 'stdio' | 'sse';
+  sseHost: string;
+  ssePort: number;
+}
+```
+
+- Add `transport` field to `ServerConfig` in `src/types/config.ts`.
+- Add default transport config to `DEFAULT_CONFIG` in `src/utils/config.ts`:
+
+```typescript
+transport: {
+  mode: 'stdio',
+  sseHost: '127.0.0.1',
+  ssePort: 9444
+}
+```
+
+- Add `applyCliTransport()` function in `src/utils/config.ts` that applies `--transport`, `--sse-host`, `--sse-port` overrides to the loaded config.
+- Load transport section from config file (if present) in the existing config loading flow.
+
+### Test Work
+
+- Unit test: verify `TransportConfig` defaults are correct.
+- Unit test: verify `applyCliTransport()` overrides config values.
+- Unit test: verify CLI flags take precedence over config file values.
+
+### Verification
+
+```bash
+npm run lint
+npm test -- tests/unit/
+```
+
+## Phase 2: CLI Arguments
+
+### Implementation Work
+
+- Add to `parseArgs()` in `src/index.ts`:
+
+```typescript
+.option('transport', {
+  type: 'string',
+  choices: ['stdio', 'sse'],
+  description: 'Transport protocol (default: stdio)'
+})
+.option('sse-host', {
+  type: 'string',
+  description: 'Host address for SSE transport (default: 127.0.0.1)'
+})
+.option('sse-port', {
+  type: 'number',
+  description: 'Port for SSE transport (default: 9444)'
+})
+```
+
+- Call `applyCliTransport()` in the `main()` function after loading config.
+
+### Test Work
+
+- Unit test: `parseArgs` returns correct defaults when no transport flags.
+- Unit test: `parseArgs` returns `--transport sse` correctly.
+- Unit test: `parseArgs` returns `--sse-host` and `--sse-port` correctly.
+
+### Verification
+
+```bash
+npm run lint
+npm test -- tests/unit/
+```
+
+## Phase 3: SSE Transport Module
+
+### Implementation Work
+
+- Create `src/utils/transport.ts` with:
+
+```typescript
+export function createSseServer(
+  mcpServer: Server,
+  host: string,
+  port: number
+): Promise<http.Server>
+```
+
+- The function:
+  1. Creates `http.createServer()`.
+  2. Maintains a `Map<string, SSEServerTransport>` for session routing.
+  3. On `GET /sse`: creates `SSEServerTransport('/messages', res)`, calls `transport.start()`, stores transport by session ID, connects to `mcpServer`.
+  4. On `POST /messages`: extracts session ID from URL, looks up transport, calls `transport.handlePostMessage(req, res)`.
+  5. Returns a promise that resolves with the `http.Server` once it's listening.
+- Export a `closeSseServer(server)` helper for clean shutdown.
+
+### Test Work
+
+- Unit test: `createSseServer` creates an HTTP server that listens.
+- Unit test: GET `/sse` returns SSE content type headers.
+- Unit test: POST to non-existent session returns error.
+- Unit test: session map is populated after SSE connection.
+
+### Verification
+
+```bash
+npm run lint
+npm test -- tests/unit/transport.test.ts
+```
+
+## Phase 4: CLIServer Integration
+
+### Implementation Work
+
+- Update `CLIServer.run()` in `src/index.ts`:
+
+```typescript
+async run(): Promise<void> {
+  if (this.config.transport?.mode === 'sse') {
+    const { createSseServer } = await import('./utils/transport.js');
+    const host = this.config.transport.sseHost ?? '127.0.0.1';
+    const port = this.config.transport.ssePort ?? 9444;
+    const httpServer = await createSseServer(this.server, host, port);
+    debugLog(`Windows CLI MCP Server running on SSE at http://${host}:${port}`);
+  } else {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    debugLog("Windows CLI MCP Server running on stdio");
+  }
+}
+```
+
+- Update cleanup handler to close HTTP server if in SSE mode.
+- Store the HTTP server reference on `CLIServer` for cleanup.
+
+### Test Work
+
+- Integration test: start `CLIServer` in SSE mode on port 0.
+- Integration test: client connects to SSE, sends `initialize` request, receives response.
+- Integration test: server shuts down cleanly on signal.
+- Regression test: stdio mode still works end-to-end.
+
+### Verification
+
+```bash
+npm run lint
+npm test -- tests/integration/sse-transport.test.ts
+npm test
+```
+
+## Phase 5: Documentation
+
+### Implementation Work
+
+- Update `README.md` to document:
+  - `--transport` flag with choices and default.
+  - `--sse-host` and `--sse-port` flags with defaults.
+  - Config file `transport` section example.
+  - Usage example: `npx wcli0 --transport sse`.
+
+### Test Work
+
+- Verify README examples are syntactically correct.
+
+### Verification
+
+```bash
+npm run lint
+```
+
+## Dependency Graph
+
+```mermaid
+flowchart TB
+    P1["Phase 1: Types and Config"] --> P2["Phase 2: CLI Arguments"]
+    P2 --> P3["Phase 3: SSE Transport Module"]
+    P3 --> P4["Phase 4: CLIServer Integration"]
+    P4 --> P5["Phase 5: Documentation"]
+```
+
+## Estimated Scope
+
+| Phase | Source Files | Test Files | Effort |
+| ----- | ------------ | ---------- | ------ |
+| Phase 1 | 2 | 1 | Small |
+| Phase 2 | 1 | 1 | Small |
+| Phase 3 | 1 | 1 | Medium |
+| Phase 4 | 1 | 1 | Medium |
+| Phase 5 | 1 | 0 | Small |

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -18,12 +18,12 @@
 - [x] Create progress.md
 
 ## Phase 1: Types and Configuration
-- [ ] Add `TransportConfig` interface to `src/types/config.ts`
-- [ ] Add `transport` field to `ServerConfig`
-- [ ] Add default transport config to `DEFAULT_CONFIG` in `src/utils/config.ts`
-- [ ] Add `applyCliTransport()` function in `src/utils/config.ts`
-- [ ] Load transport section from config file
-- [ ] Write unit tests for transport config defaults and overrides
+- [x] Add `TransportConfig` interface to `src/types/config.ts`
+- [x] Add `transport` field to `ServerConfig`
+- [x] Add default transport config to `DEFAULT_CONFIG` in `src/utils/config.ts`
+- [x] Add `applyCliTransport()` function in `src/utils/config.ts`
+- [x] Load transport section from config file
+- [x] Write unit tests for transport config defaults and overrides
 
 ## Phase 2: CLI Arguments
 - [ ] Add `--transport` flag to `parseArgs()` in `src/index.ts`

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -104,6 +104,7 @@ closed here so both transports are fully exercised.
       `transport.onclose`, so disconnected sessions were never removed from the
       session map (leak; POST to a dead session returned 500 instead of 404).
       Fixed in `src/utils/transport.ts` by registering cleanup after connect().
+      See [session-leak-on-disconnect.md](session-leak-on-disconnect.md).
 
 ### Phase 8c: Documentation sync
 

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -26,11 +26,11 @@
 - [x] Write unit tests for transport config defaults and overrides
 
 ## Phase 2: CLI Arguments
-- [ ] Add `--transport` flag to `parseArgs()` in `src/index.ts`
-- [ ] Add `--sse-host` flag to `parseArgs()`
-- [ ] Add `--sse-port` flag to `parseArgs()`
-- [ ] Call `applyCliTransport()` in `main()` function
-- [ ] Write unit tests for CLI argument parsing
+- [x] Add `--transport` flag to `parseArgs()` in `src/index.ts`
+- [x] Add `--sse-host` flag to `parseArgs()`
+- [x] Add `--sse-port` flag to `parseArgs()`
+- [x] Call `applyCliTransport()` in `main()` function
+- [x] Write unit tests for CLI argument parsing
 
 ## Phase 3: SSE Transport Module
 - [ ] Create `src/utils/transport.ts`

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -56,12 +56,12 @@
 
 See [test-implementation-plan.md](test-implementation-plan.md) for full details.
 
-- [ ] Phase 6a: Create `SseTestClient` helper in `tests/helpers/SseTestClient.ts`
-- [ ] Phase 6b: Add tool execution tests over SSE (`sse-tool-execution.test.ts`) -- 11 test cases
-- [ ] Phase 6c: Add security scenario tests over SSE (`sse-security.test.ts`) -- 11 test cases
-- [ ] Phase 6d: Add stdio protocol handshake tests (update `mcpProtocol.test.ts`) -- 5 test cases
-- [ ] Phase 6e: Refactor existing SSE tests to use `SseTestClient` helper
-- [ ] Run full regression: `npm test`
+- [x] Phase 6a: Create `SseTestClient` helper in `tests/helpers/SseTestClient.ts`
+- [x] Phase 6b: Add tool execution tests over SSE (`sse-tool-execution.test.ts`) -- 11 test cases
+- [x] Phase 6c: Add security scenario tests over SSE (`sse-security.test.ts`) -- 11 test cases
+- [x] Phase 6d: Add stdio protocol handshake tests (update `mcpProtocol.test.ts`) -- 5 test cases
+- [x] Phase 6e: Refactor existing SSE tests to use `SseTestClient` helper
+- [x] Run full regression: `npm test`
 
 ## Review Feedback
 (Section appears when PR review feedback arrives. Each comment gets a checkbox.)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -96,10 +96,14 @@ closed here so both transports are fully exercised.
 
 ### Phase 8b: SSE edge-case coverage (gaps #5, #6, #7, #8)
 
-- [ ] Same-session concurrent requests (gap #5)
-- [ ] SSE disconnection / reconnection (gap #6)
-- [ ] Large response over SSE (gap #7)
-- [ ] Malformed JSON-RPC over SSE (gap #8)
+- [x] Same-session concurrent requests (gap #5) -- `sse-edge-cases.test.ts`
+- [x] SSE disconnection / reconnection (gap #6) -- `sse-edge-cases.test.ts`
+- [x] Large response over SSE (gap #7) -- `sse-edge-cases.test.ts`
+- [x] Malformed JSON-RPC over SSE (gap #8) -- `sse-edge-cases.test.ts`
+- [x] Fix production bug surfaced by gap #6: `mcpServer.connect()` overwrote
+      `transport.onclose`, so disconnected sessions were never removed from the
+      session map (leak; POST to a dead session returned 500 instead of 404).
+      Fixed in `src/utils/transport.ts` by registering cleanup after connect().
 
 ### Phase 8c: Documentation sync
 

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -126,3 +126,20 @@ closed here so both transports are fully exercised.
 - [x] P4: Validate transport config before use (fixed -- `validateConfig()` now
       calls `validateTransportConfig()` checking `mode`, `sseHost`, and the
       `1..65535` port range)
+
+### Second review round
+
+- [x] P5: Handle malformed Host headers (fixed -- the request URL is now parsed
+      in a `try/catch` that returns 400, so a bad `Host` like `%%%%` no longer
+      crashes the server via an unhandled rejection)
+- [x] P6: Track sockets instead of relying on closeAllConnections (fixed --
+      `createSseServer()` tracks accepted sockets in a per-server `WeakMap` set;
+      `closeSseServer()` destroys them when `closeAllConnections` is missing on
+      Node 18.0/18.1)
+- [x] P7: Isolate active directories per SSE session (fixed -- introduced a
+      per-session `SessionState`; `_executeTool(params, session)` reads/writes
+      `session.activeCwd`, and each SSE connection gets its own state seeded from
+      the primary session)
+- [x] P8: Return CORS headers for allowed browser origins (fixed -- allowed
+      origins are echoed via `Access-Control-Allow-Origin`/`Vary`, and `OPTIONS`
+      preflight requests are answered with 204)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -33,12 +33,12 @@
 - [x] Write unit tests for CLI argument parsing
 
 ## Phase 3: SSE Transport Module
-- [ ] Create `src/utils/transport.ts`
-- [ ] Implement `createSseServer()` function
-- [ ] Implement SSE connection handling (GET `/sse`)
-- [ ] Implement message routing (POST `/messages`)
-- [ ] Implement `closeSseServer()` helper
-- [ ] Write unit tests for transport module
+- [x] Create `src/utils/transport.ts`
+- [x] Implement `createSseServer()` function
+- [x] Implement SSE connection handling (GET `/sse`)
+- [x] Implement message routing (POST `/messages`)
+- [x] Implement `closeSseServer()` helper
+- [x] Write unit tests for transport module
 
 ## Phase 4: CLIServer Integration
 - [ ] Update `CLIServer.run()` to support both transports

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -48,9 +48,9 @@
 - [x] Write regression tests for stdio transport
 
 ## Phase 5: Documentation
-- [ ] Update README.md with transport CLI flags
-- [ ] Add config file transport section example
-- [ ] Add SSE usage example
+- [x] Update README.md with transport CLI flags
+- [x] Add config file transport section example
+- [x] Add SSE usage example
 
 ## Review Feedback
 (Section appears when PR review feedback arrives. Each comment gets a checkbox.)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -52,6 +52,17 @@
 - [x] Add config file transport section example
 - [x] Add SSE usage example
 
+## Phase 6: Integration Test Coverage (Test Implementation Plan)
+
+See [test-implementation-plan.md](test-implementation-plan.md) for full details.
+
+- [ ] Phase 6a: Create `SseTestClient` helper in `tests/helpers/SseTestClient.ts`
+- [ ] Phase 6b: Add tool execution tests over SSE (`sse-tool-execution.test.ts`) -- 11 test cases
+- [ ] Phase 6c: Add security scenario tests over SSE (`sse-security.test.ts`) -- 11 test cases
+- [ ] Phase 6d: Add stdio protocol handshake tests (update `mcpProtocol.test.ts`) -- 5 test cases
+- [ ] Phase 6e: Refactor existing SSE tests to use `SseTestClient` helper
+- [ ] Run full regression: `npm test`
+
 ## Review Feedback
 (Section appears when PR review feedback arrives. Each comment gets a checkbox.)
 - [ ] P1: (pending review)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -1,0 +1,57 @@
+# Progress: HTTP/SSE Transport for MCP Server
+
+## Status Legend
+| Marker | Meaning |
+| ------ | ------- |
+| `[ ]`  | Not started |
+| `[x]`  | Complete |
+| `[~]`  | In progress |
+| `[!]`  | Blocked or needs decision |
+| `[-]`  | Skipped / not applicable |
+
+## Planning Checklist
+- [x] Analyze current behavior.
+- [x] Create analysis.md
+- [x] Create PRD.md
+- [x] Create implementation_plan.md
+- [x] Create verification.md
+- [x] Create progress.md
+
+## Phase 1: Types and Configuration
+- [ ] Add `TransportConfig` interface to `src/types/config.ts`
+- [ ] Add `transport` field to `ServerConfig`
+- [ ] Add default transport config to `DEFAULT_CONFIG` in `src/utils/config.ts`
+- [ ] Add `applyCliTransport()` function in `src/utils/config.ts`
+- [ ] Load transport section from config file
+- [ ] Write unit tests for transport config defaults and overrides
+
+## Phase 2: CLI Arguments
+- [ ] Add `--transport` flag to `parseArgs()` in `src/index.ts`
+- [ ] Add `--sse-host` flag to `parseArgs()`
+- [ ] Add `--sse-port` flag to `parseArgs()`
+- [ ] Call `applyCliTransport()` in `main()` function
+- [ ] Write unit tests for CLI argument parsing
+
+## Phase 3: SSE Transport Module
+- [ ] Create `src/utils/transport.ts`
+- [ ] Implement `createSseServer()` function
+- [ ] Implement SSE connection handling (GET `/sse`)
+- [ ] Implement message routing (POST `/messages`)
+- [ ] Implement `closeSseServer()` helper
+- [ ] Write unit tests for transport module
+
+## Phase 4: CLIServer Integration
+- [ ] Update `CLIServer.run()` to support both transports
+- [ ] Store HTTP server reference for cleanup
+- [ ] Update cleanup handler for SSE mode
+- [ ] Write integration tests for SSE transport
+- [ ] Write regression tests for stdio transport
+
+## Phase 5: Documentation
+- [ ] Update README.md with transport CLI flags
+- [ ] Add config file transport section example
+- [ ] Add SSE usage example
+
+## Review Feedback
+(Section appears when PR review feedback arrives. Each comment gets a checkbox.)
+- [ ] P1: (pending review)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -107,8 +107,9 @@ closed here so both transports are fully exercised.
 
 ### Phase 8c: Documentation sync
 
-- [ ] Update `test-coverage-comparison.md` to reflect closed gaps
-- [ ] Update `verification.md` final acceptance checklist
+- [x] Update `test-coverage-comparison.md` to reflect closed gaps
+- [x] Update `verification.md` final acceptance checklist
+- [x] Run full regression: 918 passed, 24 skipped, 0 failed, no worker warnings
 
 ## Review Feedback
 

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -1,15 +1,17 @@
 # Progress: HTTP/SSE Transport for MCP Server
 
 ## Status Legend
-| Marker | Meaning |
-| ------ | ------- |
-| `[ ]`  | Not started |
-| `[x]`  | Complete |
-| `[~]`  | In progress |
+
+| Marker | Meaning                   |
+| ------ | ------------------------- |
+| `[ ]`  | Not started               |
+| `[x]`  | Complete                  |
+| `[~]`  | In progress               |
 | `[!]`  | Blocked or needs decision |
-| `[-]`  | Skipped / not applicable |
+| `[-]`  | Skipped / not applicable  |
 
 ## Planning Checklist
+
 - [x] Analyze current behavior.
 - [x] Create analysis.md
 - [x] Create PRD.md
@@ -18,6 +20,7 @@
 - [x] Create progress.md
 
 ## Phase 1: Types and Configuration
+
 - [x] Add `TransportConfig` interface to `src/types/config.ts`
 - [x] Add `transport` field to `ServerConfig`
 - [x] Add default transport config to `DEFAULT_CONFIG` in `src/utils/config.ts`
@@ -26,6 +29,7 @@
 - [x] Write unit tests for transport config defaults and overrides
 
 ## Phase 2: CLI Arguments
+
 - [x] Add `--transport` flag to `parseArgs()` in `src/index.ts`
 - [x] Add `--sse-host` flag to `parseArgs()`
 - [x] Add `--sse-port` flag to `parseArgs()`
@@ -33,6 +37,7 @@
 - [x] Write unit tests for CLI argument parsing
 
 ## Phase 3: SSE Transport Module
+
 - [x] Create `src/utils/transport.ts`
 - [x] Implement `createSseServer()` function
 - [x] Implement SSE connection handling (GET `/sse`)
@@ -41,6 +46,7 @@
 - [x] Write unit tests for transport module
 
 ## Phase 4: CLIServer Integration
+
 - [x] Update `CLIServer.run()` to support both transports
 - [x] Store HTTP server reference for cleanup
 - [x] Update cleanup handler for SSE mode
@@ -48,6 +54,7 @@
 - [x] Write regression tests for stdio transport
 
 ## Phase 5: Documentation
+
 - [x] Update README.md with transport CLI flags
 - [x] Add config file transport section example
 - [x] Add SSE usage example
@@ -63,6 +70,21 @@ See [test-implementation-plan.md](test-implementation-plan.md) for full details.
 - [x] Phase 6e: Refactor existing SSE tests to use `SseTestClient` helper
 - [x] Run full regression: `npm test`
 
+## Phase 7: Worker Exit Warning
+
+See [worker-exit-investigation.md](worker-exit-investigation.md) for full details.
+
+- [x] Verify SIGINT handler leak fix is implemented (`src/index.ts`)
+- [x] Reproduce the `worker process has failed to exit gracefully` warning
+- [x] Bisect the warning to `tests/integration/sse-transport.test.ts`
+- [x] Confirm there is no real resource leak (`--detectOpenHandles`, handle snapshot)
+- [x] Add `server.closeAllConnections()` to `closeSseServer()` (production shutdown fix)
+- [x] Document findings in `worker-exit-investigation.md`
+- [ ] Apply a fix that removes the worker warning from `npm test`
+- [ ] Re-run full regression and confirm a clean run
+
 ## Review Feedback
+
 (Section appears when PR review feedback arrives. Each comment gets a checkbox.)
+
 - [ ] P1: (pending review)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -153,3 +153,18 @@ closed here so both transports are fully exercised.
 - [x] P10: Include transport in serialized config (fixed --
       `createSerializableConfig()` now copies `config.transport` when present, so
       `get_config` and `cli://config` report the active mode/host/port)
+
+### Fourth review round
+
+- [x] P11: Avoid changing global cwd for per-session SSE directories (fixed --
+      `execute_command` now anchors a relative `workingDir` to the calling
+      session's `activeCwd` via `resolveWorkingDirForSession()`, so it no longer
+      resolves against the shared process cwd that another session changed)
+- [x] P12: Allow origins for wildcard SSE binds (fixed -- added
+      `transport.sseAllowedOrigins` config + `--sse-allowed-origins` CLI flag;
+      `isOriginAllowed()` accepts configured origins in addition to loopback and
+      the bind host, enabling browser clients on a `0.0.0.0` bind)
+- [x] P13: Register SSE cleanup before the connection can close (fixed -- the
+      session-cleanup listener is registered on `res.on('close')` before
+      `connect()`, eliminating the disconnect-during-connect race that leaked
+      session entries and turned later POSTs into 500s instead of 404s)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -143,3 +143,13 @@ closed here so both transports are fully exercised.
 - [x] P8: Return CORS headers for allowed browser origins (fixed -- allowed
       origins are echoed via `Access-Control-Allow-Origin`/`Vary`, and `OPTIONS`
       preflight requests are answered with 204)
+
+### Third review round
+
+- [x] P9: Reject fractional SSE ports from the CLI (fixed -- `applyCliTransport()`
+      now requires `Number.isInteger(ssePort)`, so `--sse-port 9444.5` is warned
+      about and ignored instead of crashing `httpServer.listen()` with
+      `ERR_SOCKET_BAD_PORT`)
+- [x] P10: Include transport in serialized config (fixed --
+      `createSerializableConfig()` now copies `config.transport` when present, so
+      `get_config` and `cli://config` report the active mode/host/port)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -77,11 +77,11 @@ See [worker-exit-investigation.md](worker-exit-investigation.md) for full detail
 - [x] Verify SIGINT handler leak fix is implemented (`src/index.ts`)
 - [x] Reproduce the `worker process has failed to exit gracefully` warning
 - [x] Bisect the warning to `tests/integration/sse-transport.test.ts`
-- [x] Confirm there is no real resource leak (`--detectOpenHandles`, handle snapshot)
+- [x] Identify the root cause: stdio transport leaves `process.stdin` flowing/referenced
 - [x] Add `server.closeAllConnections()` to `closeSseServer()` (production shutdown fix)
+- [x] Fix `CLIServer.cleanup()` to close the MCP transport and pause `process.stdin`
 - [x] Document findings in `worker-exit-investigation.md`
-- [ ] Apply a fix that removes the worker warning from `npm test`
-- [ ] Re-run full regression and confirm a clean run
+- [x] Re-run full regression in parallel: 900 passed, 0 warnings, ~17s (3 runs)
 
 ## Review Feedback
 

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -112,8 +112,17 @@ closed here so both transports are fully exercised.
 - [x] Update `verification.md` final acceptance checklist
 - [x] Run full regression: 918 passed, 24 skipped, 0 failed, no worker warnings
 
-## Review Feedback
+## Review Feedback (PR #83)
 
-(Section appears when PR review feedback arrives. Each comment gets a checkbox.)
-
-- [ ] P1: (pending review)
+- [x] P1: Create a fresh MCP server per SSE session (fixed -- `createSseServer()`
+      now takes a `() => Server` factory; `CLIServer.createServerInstance()`
+      builds one wired server per `GET /sse`, so each session owns its transport)
+- [x] P2: Reject untrusted Origin headers (fixed -- added `isOriginAllowed()` and
+      a 403 on disallowed origins for `GET /sse` and `POST /messages`; no-Origin
+      and loopback/bind-host origins still pass)
+- [x] P3: Avoid advertising unauthenticated bind-all example (fixed -- README
+      example now binds `127.0.0.1`; added a prominent security warning about
+      `0.0.0.0`)
+- [x] P4: Validate transport config before use (fixed -- `validateConfig()` now
+      calls `validateTransportConfig()` checking `mode`, `sseHost`, and the
+      `1..65535` port range)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -83,6 +83,29 @@ See [worker-exit-investigation.md](worker-exit-investigation.md) for full detail
 - [x] Document findings in `worker-exit-investigation.md`
 - [x] Re-run full regression in parallel: 900 passed, 0 warnings, ~17s (3 runs)
 
+## Phase 8: Close Remaining Coverage Gaps
+
+See [test-coverage-comparison.md](test-coverage-comparison.md) "Gaps in HTTP/SSE Test
+Coverage". Gaps 1-3 (and partial 7) were closed in Phase 6. The remaining gaps are
+closed here so both transports are fully exercised.
+
+### Phase 8a: Resource handler coverage (gap #4)
+
+- [x] Create `tests/integration/sse-resources.test.ts` (resources over SSE) -- 7 test cases
+- [x] Add stdio resource handler tests to `tests/integration/mcpProtocol.test.ts` -- 4 test cases
+
+### Phase 8b: SSE edge-case coverage (gaps #5, #6, #7, #8)
+
+- [ ] Same-session concurrent requests (gap #5)
+- [ ] SSE disconnection / reconnection (gap #6)
+- [ ] Large response over SSE (gap #7)
+- [ ] Malformed JSON-RPC over SSE (gap #8)
+
+### Phase 8c: Documentation sync
+
+- [ ] Update `test-coverage-comparison.md` to reflect closed gaps
+- [ ] Update `verification.md` final acceptance checklist
+
 ## Review Feedback
 
 (Section appears when PR review feedback arrives. Each comment gets a checkbox.)

--- a/docs/tasks/http_sse_transport/progress.md
+++ b/docs/tasks/http_sse_transport/progress.md
@@ -41,11 +41,11 @@
 - [x] Write unit tests for transport module
 
 ## Phase 4: CLIServer Integration
-- [ ] Update `CLIServer.run()` to support both transports
-- [ ] Store HTTP server reference for cleanup
-- [ ] Update cleanup handler for SSE mode
-- [ ] Write integration tests for SSE transport
-- [ ] Write regression tests for stdio transport
+- [x] Update `CLIServer.run()` to support both transports
+- [x] Store HTTP server reference for cleanup
+- [x] Update cleanup handler for SSE mode
+- [x] Write integration tests for SSE transport
+- [x] Write regression tests for stdio transport
 
 ## Phase 5: Documentation
 - [ ] Update README.md with transport CLI flags

--- a/docs/tasks/http_sse_transport/session-leak-on-disconnect.md
+++ b/docs/tasks/http_sse_transport/session-leak-on-disconnect.md
@@ -1,0 +1,158 @@
+# SSE Session Leak on Client Disconnect - Investigation
+
+## Context
+
+While closing test coverage gap #6 (SSE disconnection / reconnection) from
+[test-coverage-comparison.md](test-coverage-comparison.md), a new integration
+test in `tests/integration/sse-edge-cases.test.ts` asserted that a POST to a
+session whose client had disconnected returns HTTP 404. Instead it returned
+HTTP 500, exposing a real production bug in the SSE transport. This document
+records the root cause and the fix (commit `621d457`).
+
+## Summary of findings
+
+- `createSseServer()` in `src/utils/transport.ts` registered a `transport.onclose`
+  handler (to remove the session from its routing map) **before** calling
+  `mcpServer.connect(transport)`.
+- `mcpServer.connect()` overwrites `transport.onclose` with its own handler, so
+  the session-cleanup handler was silently discarded.
+- Consequently, sessions were **never removed from the routing map** when a
+  client disconnected. Every disconnect leaked one `Map` entry for the lifetime
+  of the server.
+- A POST to a disconnected-but-still-mapped session passed the map lookup and
+  reached `SSEServerTransport.handlePostMessage()`, which found its SSE response
+  already gone and replied `500 SSE connection not established` instead of the
+  expected `404 Session not found`.
+
+## Root cause
+
+`createSseServer()` set up cleanup in the wrong order:
+
+```typescript
+const transport = new SSEServerTransport('/messages', res);
+sessions.set(transport.sessionId, transport);
+
+transport.onclose = () => {
+  sessions.delete(transport.sessionId);   // <- intended cleanup
+  debugLog(`SSE session closed: ${transport.sessionId}`);
+};
+
+await mcpServer.connect(transport);        // <- overwrites onclose
+```
+
+The MCP SDK's `Protocol.connect()` (in `@modelcontextprotocol/sdk`,
+`dist/shared/protocol.js`) reassigns the transport callbacks:
+
+```js
+async connect(transport) {
+    this._transport = transport;
+    this._transport.onclose = () => {
+        this._onclose();
+    };
+    // ...also overwrites onerror and onmessage
+    await this._transport.start();
+}
+```
+
+Because `connect()` runs after our assignment, the SDK's `onclose` replaces ours.
+When the client socket closes, `SSEServerTransport.start()`'s
+`res.on("close", ...)` fires, sets the internal SSE response to `undefined`, and
+invokes only the SDK `onclose` - never our `sessions.delete()`. The session entry
+remains in the map.
+
+### Why the response was 500 and not 404
+
+`createSseServer()` routes POSTs in two stages:
+
+1. Look up the session id in the map. Missing entry -> `404 Session not found`.
+2. Found entry -> delegate to `transport.handlePostMessage(req, res)`.
+
+After a disconnect the entry still existed (stage 1 passed), so the request
+reached stage 2. But the transport's `_sseResponse` had already been cleared by
+the socket-close event, so `handlePostMessage()` took its guard branch:
+
+```js
+if (!this._sseResponse) {
+    const message = "SSE connection not established";
+    res.writeHead(500).end(message);
+    throw new Error(message);
+}
+```
+
+Hence `500` for what should be a `404`.
+
+## Impact
+
+| Aspect | Effect |
+| ------ | ------ |
+| Memory | The session `Map` grew by one entry per client disconnect and was never reclaimed (unbounded growth on a long-running server). |
+| Correctness | POSTs to a dead session returned `500` instead of `404`, misrepresenting the failure to clients. |
+| Scope | SSE transport only (`--transport sse`). The stdio transport is unaffected. |
+
+## Evidence
+
+The failing assertion from `tests/integration/sse-edge-cases.test.ts`
+("cleans up the session when the client disconnects"):
+
+```text
+expect(received).toBe(expected) // Object.is equality
+
+Expected: 404
+Received: 500
+```
+
+The test opens an SSE stream, confirms a POST is accepted (`202`), destroys the
+client stream, then polls the session with a notification until it is removed.
+Before the fix the session was never removed, so the poll only ever observed
+`500` and the test timed out on the `404` expectation.
+
+## Fix
+
+`src/utils/transport.ts` - register cleanup **after** `connect()` and chain to the
+SDK handler so the MCP server's own teardown still runs:
+
+```typescript
+const transport = new SSEServerTransport('/messages', res);
+sessions.set(transport.sessionId, transport);
+
+await mcpServer.connect(transport);
+
+// mcpServer.connect() assigns its own transport.onclose handler, so any
+// handler set before connect() is overwritten. Register session cleanup
+// afterward and chain to the SDK handler so the MCP server's own teardown
+// still runs.
+const mcpOnClose = transport.onclose;
+transport.onclose = () => {
+  sessions.delete(transport.sessionId);
+  debugLog(`SSE session closed: ${transport.sessionId}`);
+  mcpOnClose?.();
+};
+```
+
+## Verified outcome
+
+- The disconnect test now observes `404` once the socket-close event is
+  processed, and the reconnect test confirms a fresh session id is issued.
+- Full regression (`npm test`): 918 passed, 24 skipped, 0 failed, no worker
+  warnings.
+- Lint (`npm run lint` / `tsc --noEmit`): clean.
+
+## How to re-verify
+
+```bash
+# The disconnect/reconnect tests that exercise this path
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration/sse-edge-cases
+
+# Full suite
+node --experimental-vm-modules node_modules/jest/bin/jest.js
+```
+
+## Lessons
+
+- When a library takes ownership of an object's callbacks on a lifecycle call
+  (`connect`, `start`, `attach`), set your own callbacks **after** that call and
+  chain to whatever the library installed, rather than assuming your earlier
+  assignment survives.
+- A transport-layer "it connects" test is not enough; session teardown on
+  disconnect needs its own coverage. This bug was invisible until a test drove a
+  real client disconnect and then probed the dead session.

--- a/docs/tasks/http_sse_transport/test-coverage-comparison.md
+++ b/docs/tasks/http_sse_transport/test-coverage-comparison.md
@@ -1,0 +1,98 @@
+# Test Coverage Comparison: stdio vs HTTP/SSE Transport
+
+## Overview
+
+The stdio transport is tested via `TestCLIServer` helper that calls `CLIServer._executeTool()` directly (in-process, no transport layer). The HTTP/SSE transport is tested via raw HTTP requests against a live server with real SSE connections.
+
+## Test Files
+
+| Aspect | stdio | HTTP/SSE |
+| ------ | ----- | -------- |
+| Test file | `tests/integration/mcpProtocol.test.ts` | `tests/integration/sse-transport.test.ts` |
+| Unit/config file | `tests/unit/transport.test.ts` | (same file -- shared) |
+| Shell exec tests | `tests/integration/shellExecution.test.ts` | (none) |
+| E2E tests | `tests/integration/endToEnd.test.ts` | (none) |
+| Test helper | `tests/helpers/TestCLIServer.ts` | (inline HTTP helpers) |
+| Transport under test | N/A (direct `_executeTool` call) | Real HTTP server + SSE stream |
+
+## MCP Protocol Methods
+
+| Protocol Method | stdio | HTTP/SSE |
+| --------------- | ----- | -------- |
+| `initialize` handshake | No (bypassed via `_executeTool`) | Yes |
+| `notifications/initialized` | No | Yes |
+| `tools/list` | No (bypassed) | Yes |
+| `tools/call` (get_config) | Yes (direct) | Yes (over SSE) |
+| `tools/call` (execute_command) | Yes (direct) | No |
+| `tools/call` (validate_directories) | Yes (direct) | No |
+| `resources/list` | No | No |
+| `resources/read` | No | No |
+| `resources/templates/list` | No | No |
+
+## Tool-Level Coverage
+
+| Tool / Feature | stdio | HTTP/SSE |
+| -------------- | ----- | -------- |
+| `get_config` returns valid JSON | Yes | Yes |
+| `validate_directories` valid path | Yes | No |
+| `validate_directories` invalid path | No | No |
+| `execute_command` basic echo | Yes | No |
+| `execute_command` with workingDir | Yes | No |
+| `execute_command` blocked operators | Yes | No |
+| `execute_command` path restriction | Yes | No |
+| `execute_command` output truncation | Yes (unit tests) | No |
+| `execute_command` timeout | Yes (unit tests) | No |
+| `execute_command` logging | Yes (unit tests) | No |
+
+## Transport-Layer Concerns
+
+| Concern | stdio | HTTP/SSE |
+| ------- | ----- | -------- |
+| Server starts and listens | N/A | Yes |
+| SSE endpoint returns `text/event-stream` | N/A | Yes |
+| Session ID assigned on connect | N/A | Yes |
+| POST `/messages` without session returns 400 | N/A | Yes |
+| POST `/messages` with fake session returns 404 | N/A | Yes |
+| Unknown path returns 404 | N/A | Yes |
+| Server close / cleanup | N/A | Yes |
+| Multiple concurrent SSE sessions | N/A | Yes |
+| Transport mode `stdio` produces no HTTP server | N/A | Yes |
+| Transport config defaults (mode, host, port) | Yes (unit) | -- |
+| `applyCliTransport` overrides | Yes (unit) | -- |
+| CLI `--transport`, `--sse-host`, `--sse-port` flags | Yes (unit) | -- |
+| Config merge transport section | Yes (unit) | -- |
+
+## Security / Edge Cases
+
+| Scenario | stdio | HTTP/SSE |
+| -------- | ----- | -------- |
+| Blocked operator rejection (`;`, `&`, etc.) | Yes | No |
+| Working directory restriction enforcement | Yes | No |
+| Working directory allowed path passes | Yes | No |
+| Path validation edge cases | Yes (dedicated tests) | No |
+| Path traversal prevention | Yes (unit tests) | No |
+| Injection protection | Yes (integration) | No |
+| Error response format | Yes | No |
+
+## Gaps in HTTP/SSE Test Coverage
+
+1. **No `execute_command` tool call over SSE** -- the most important tool is never exercised through the SSE transport
+2. **No `validate_directories` tool call over SSE** -- second tool untested over SSE
+3. **No error scenarios over SSE** -- blocked commands, invalid paths, timeout, truncation
+4. **No resource handlers over SSE** -- `resources/list`, `resources/read`, `resources/templates/list`
+5. **No concurrent request handling** -- multiple requests on the same session
+6. **No SSE disconnection / reconnection** -- client drops and reconnects
+7. **No large response over SSE** -- output truncation edge cases
+8. **No malformed JSON-RPC over SSE** -- invalid request body handling
+
+## Summary
+
+| Metric | stdio | HTTP/SSE |
+| ------ | ----- | -------- |
+| Total test files (integration) | 3 | 1 |
+| Total test cases (integration) | 7 | 11 |
+| Tool calls tested | 3 (get_config, validate_directories, execute_command) | 1 (get_config only) |
+| Security tests | 3 | 0 |
+| Protocol handshake tested | No (bypassed) | Yes |
+
+The stdio side has broad tool-level coverage but skips the MCP protocol handshake. The SSE side has good transport-layer and protocol-handshake coverage but barely exercises the actual tools over SSE.

--- a/docs/tasks/http_sse_transport/test-coverage-comparison.md
+++ b/docs/tasks/http_sse_transport/test-coverage-comparison.md
@@ -19,29 +19,30 @@ The stdio transport is tested via `TestCLIServer` helper that calls `CLIServer._
 
 | Protocol Method | stdio | HTTP/SSE |
 | --------------- | ----- | -------- |
-| `initialize` handshake | No (bypassed via `_executeTool`) | Yes |
-| `notifications/initialized` | No | Yes |
-| `tools/list` | No (bypassed) | Yes |
+| `initialize` handshake | Yes (Phase 6d) | Yes |
+| `notifications/initialized` | Yes (Phase 6d) | Yes |
+| `tools/list` | Yes (Phase 6d) | Yes |
 | `tools/call` (get_config) | Yes (direct) | Yes (over SSE) |
-| `tools/call` (execute_command) | Yes (direct) | No |
-| `tools/call` (validate_directories) | Yes (direct) | No |
-| `resources/list` | No | No |
-| `resources/read` | No | No |
-| `resources/templates/list` | No | No |
+| `tools/call` (execute_command) | Yes (direct) | Yes (Phase 6b) |
+| `tools/call` (validate_directories) | Yes (direct) | Yes (Phase 6b) |
+| `resources/list` | Yes (Phase 8a) | Yes (Phase 8a) |
+| `resources/read` | Yes (Phase 8a) | Yes (Phase 8a) |
+| `resources/templates/list` | Yes (Phase 8a) | Yes (Phase 8a) |
 
 ## Tool-Level Coverage
 
 | Tool / Feature | stdio | HTTP/SSE |
 | -------------- | ----- | -------- |
 | `get_config` returns valid JSON | Yes | Yes |
-| `validate_directories` valid path | Yes | No |
-| `validate_directories` invalid path | No | No |
-| `execute_command` basic echo | Yes | No |
-| `execute_command` with workingDir | Yes | No |
-| `execute_command` blocked operators | Yes | No |
-| `execute_command` path restriction | Yes | No |
-| `execute_command` output truncation | Yes (unit tests) | No |
-| `execute_command` timeout | Yes (unit tests) | No |
+| `validate_directories` valid path | Yes | Yes (Phase 6b) |
+| `validate_directories` invalid path | No | Yes (Phase 6c) |
+| `execute_command` basic echo | Yes | Yes (Phase 6b) |
+| `execute_command` with workingDir | Yes | Yes (Phase 6b) |
+| `execute_command` blocked operators | Yes | Yes (Phase 6c) |
+| `execute_command` path restriction | Yes | Yes (Phase 6c) |
+| `execute_command` output truncation | Yes (unit tests) | Yes (Phase 6b) |
+| `execute_command` timeout | Yes (unit tests) | Yes (Phase 6b) |
+| `execute_command` large untruncated output | Yes (unit tests) | Yes (Phase 8b) |
 | `execute_command` logging | Yes (unit tests) | No |
 
 ## Transport-Layer Concerns
@@ -56,6 +57,9 @@ The stdio transport is tested via `TestCLIServer` helper that calls `CLIServer._
 | Unknown path returns 404 | N/A | Yes |
 | Server close / cleanup | N/A | Yes |
 | Multiple concurrent SSE sessions | N/A | Yes |
+| Concurrent requests on a single session | N/A | Yes (Phase 8b) |
+| Client disconnect removes session from map | N/A | Yes (Phase 8b) |
+| Reconnect issues a fresh session id | N/A | Yes (Phase 8b) |
 | Transport mode `stdio` produces no HTTP server | N/A | Yes |
 | Transport config defaults (mode, host, port) | Yes (unit) | -- |
 | `applyCliTransport` overrides | Yes (unit) | -- |
@@ -66,33 +70,45 @@ The stdio transport is tested via `TestCLIServer` helper that calls `CLIServer._
 
 | Scenario | stdio | HTTP/SSE |
 | -------- | ----- | -------- |
-| Blocked operator rejection (`;`, `&`, etc.) | Yes | No |
-| Working directory restriction enforcement | Yes | No |
-| Working directory allowed path passes | Yes | No |
+| Blocked operator rejection (`;`, `&`, etc.) | Yes | Yes (Phase 6c) |
+| Working directory restriction enforcement | Yes | Yes (Phase 6c) |
+| Working directory allowed path passes | Yes | Yes (Phase 6c) |
 | Path validation edge cases | Yes (dedicated tests) | No |
 | Path traversal prevention | Yes (unit tests) | No |
-| Injection protection | Yes (integration) | No |
-| Error response format | Yes | No |
+| Injection protection | Yes (integration) | Yes (Phase 6c) |
+| Error response format | Yes | Yes (Phase 6c) |
+| Malformed JSON / non-JSON-RPC body | N/A | Yes (Phase 8b) |
 
 ## Gaps in HTTP/SSE Test Coverage
 
-1. **No `execute_command` tool call over SSE** -- the most important tool is never exercised through the SSE transport
-2. **No `validate_directories` tool call over SSE** -- second tool untested over SSE
-3. **No error scenarios over SSE** -- blocked commands, invalid paths, timeout, truncation
-4. **No resource handlers over SSE** -- `resources/list`, `resources/read`, `resources/templates/list`
-5. **No concurrent request handling** -- multiple requests on the same session
-6. **No SSE disconnection / reconnection** -- client drops and reconnects
-7. **No large response over SSE** -- output truncation edge cases
-8. **No malformed JSON-RPC over SSE** -- invalid request body handling
+All gaps identified in the original analysis are now closed.
+
+1. ~~No `execute_command` tool call over SSE~~ -- CLOSED (Phase 6b, `sse-tool-execution.test.ts`)
+2. ~~No `validate_directories` tool call over SSE~~ -- CLOSED (Phase 6b, `sse-tool-execution.test.ts`)
+3. ~~No error scenarios over SSE~~ -- CLOSED (Phase 6c, `sse-security.test.ts`)
+4. ~~No resource handlers over SSE~~ -- CLOSED (Phase 8a, `sse-resources.test.ts`)
+5. ~~No concurrent request handling on a single session~~ -- CLOSED (Phase 8b, `sse-edge-cases.test.ts`)
+6. ~~No SSE disconnection / reconnection~~ -- CLOSED (Phase 8b, `sse-edge-cases.test.ts`); surfaced and fixed a session-leak bug in `src/utils/transport.ts`
+7. ~~No large response over SSE~~ -- CLOSED (Phase 8b, `sse-edge-cases.test.ts`)
+8. ~~No malformed JSON-RPC over SSE~~ -- CLOSED (Phase 8b, `sse-edge-cases.test.ts`)
+
+### Remaining minor items (not in original gap list)
+
+- `execute_command` logging assertions over SSE (covered by stdio unit tests).
+- Path validation / traversal edge cases over SSE (covered by dedicated stdio tests; the validator is transport-agnostic).
 
 ## Summary
 
 | Metric | stdio | HTTP/SSE |
 | ------ | ----- | -------- |
-| Total test files (integration) | 3 | 1 |
-| Total test cases (integration) | 7 | 11 |
-| Tool calls tested | 3 (get_config, validate_directories, execute_command) | 1 (get_config only) |
-| Security tests | 3 | 0 |
-| Protocol handshake tested | No (bypassed) | Yes |
+| Total test files (integration) | 3 | 4 |
+| Tool calls tested | get_config, validate_directories, execute_command | get_config, validate_directories, execute_command |
+| Resource handlers tested | Yes (Phase 8a) | Yes (Phase 8a) |
+| Security tests | Yes | Yes (Phase 6c) |
+| Protocol handshake tested | Yes (Phase 6d) | Yes |
+| Edge cases (concurrency, disconnect, malformed) | N/A | Yes (Phase 8b) |
 
-The stdio side has broad tool-level coverage but skips the MCP protocol handshake. The SSE side has good transport-layer and protocol-handshake coverage but barely exercises the actual tools over SSE.
+Both transports now have matching coverage across the MCP protocol handshake,
+all tools, resource handlers, and security scenarios. The SSE side additionally
+covers transport-specific edge cases (session lifecycle, concurrency on a single
+session, and malformed input handling).

--- a/docs/tasks/http_sse_transport/test-implementation-plan.md
+++ b/docs/tasks/http_sse_transport/test-implementation-plan.md
@@ -16,11 +16,11 @@ Close the test coverage gaps identified in `test-coverage-comparison.md`. The ex
 
 ## Phase 1: Shared SSE Test Helper
 
-### Why
+### Why (Phase 1)
 
 The existing `sse-transport.test.ts` has inline `connectSSE`, `postMessage`, `waitForMessage` helpers duplicated in every test. Extracting these into a reusable module reduces boilerplate and ensures consistent test patterns across new test files.
 
-### Implementation
+### Implementation (Phase 1)
 
 Create `tests/helpers/SseTestClient.ts`:
 
@@ -41,7 +41,7 @@ export class SseTestClient {
 }
 ```
 
-### Verification
+### Verification (Phase 1)
 
 ```bash
 npm test -- tests/integration/sse-transport.test.ts
@@ -51,11 +51,11 @@ Existing tests should continue to pass after refactoring to use the new helper.
 
 ## Phase 2: Tool Execution Over SSE
 
-### Why
+### Why (Phase 2)
 
 The comparison shows that only `get_config` is tested over SSE. The primary tool `execute_command` and the validation tool `validate_directories` have zero SSE coverage.
 
-### Test Cases
+### Test Cases (Phase 2)
 
 File: `tests/integration/sse-tool-execution.test.ts`
 
@@ -73,7 +73,7 @@ File: `tests/integration/sse-tool-execution.test.ts`
 | set_current_directory | Call `set_current_directory` with a valid path, then `get_current_directory` to confirm |
 | tools/list includes all tools | Verify `execute_command`, `get_config`, `get_current_directory`, `set_current_directory`, `validate_directories` are listed |
 
-### Verification
+### Verification (Phase 2)
 
 ```bash
 npm test -- tests/integration/sse-tool-execution.test.ts
@@ -81,11 +81,11 @@ npm test -- tests/integration/sse-tool-execution.test.ts
 
 ## Phase 3: Security Scenarios Over SSE
 
-### Why
+### Why (Phase 3)
 
 The comparison shows zero security tests over SSE. Blocked operators, path restrictions, and injection protection are only tested via direct `_executeTool` calls. These must also work through the full SSE transport path.
 
-### Test Cases
+### Test Cases (Phase 3)
 
 File: `tests/integration/sse-security.test.ts`
 
@@ -103,7 +103,7 @@ File: `tests/integration/sse-security.test.ts`
 | unknown session POST | POST a message to a non-existent session ID, verify HTTP 404 |
 | concurrent sessions isolated | Open two SSE sessions on separate servers, verify each gets its own responses |
 
-### Verification
+### Verification (Phase 3)
 
 ```bash
 npm test -- tests/integration/sse-security.test.ts
@@ -111,11 +111,11 @@ npm test -- tests/integration/sse-security.test.ts
 
 ## Phase 4: Stdio Protocol Handshake Tests
 
-### Why
+### Why (Phase 4)
 
 The comparison shows stdio tests bypass the MCP protocol handshake entirely by calling `_executeTool` directly. While the transport is implicitly tested by the fact that tools work, the protocol-level behavior (initialize, capabilities negotiation, notifications) is not verified for stdio.
 
-### Test Cases
+### Test Cases (Phase 4)
 
 Update `tests/integration/mcpProtocol.test.ts`:
 
@@ -131,7 +131,7 @@ Update `tests/integration/mcpProtocol.test.ts`:
 
 This requires spawning the server as a child process or using `StdioServerTransport` in-memory. The MCP SDK provides `Client` class that can connect to a `Server` via in-memory transport for testing. See `@modelcontextprotocol/sdk/dist/inMemory.test.js` for the pattern.
 
-### Verification
+### Verification (Phase 4)
 
 ```bash
 npm test -- tests/integration/mcpProtocol.test.ts
@@ -139,17 +139,17 @@ npm test -- tests/integration/mcpProtocol.test.ts
 
 ## Phase 5: Refactor Existing SSE Tests
 
-### Why
+### Why (Phase 5)
 
 The existing `sse-transport.test.ts` has inline helper functions (`connectSSE`, `postMessage`, `waitForMessage`) that are duplicated. Once the shared `SseTestClient` helper exists, refactor to use it. This reduces maintenance burden and ensures consistency.
 
-### Implementation
+### Implementation (Phase 5)
 
 - Replace inline helpers in `sse-transport.test.ts` with `SseTestClient`
 - Keep the transport-layer tests (server start, SSE headers, 404/400 responses, close) as-is since they test lower-level HTTP behavior
 - Move protocol-handshake tests that are already passing to use `SseTestClient` for brevity
 
-### Verification
+### Verification (Phase 5)
 
 ```bash
 npm test -- tests/integration/sse-transport.test.ts

--- a/docs/tasks/http_sse_transport/test-implementation-plan.md
+++ b/docs/tasks/http_sse_transport/test-implementation-plan.md
@@ -1,0 +1,198 @@
+# Test Implementation Plan: Integration Test Coverage Gaps
+
+## Purpose
+
+Close the test coverage gaps identified in `test-coverage-comparison.md`. The existing SSE tests verify transport-layer mechanics but barely exercise the actual MCP tools. The existing stdio tests exercise tools directly but skip the MCP protocol handshake. This plan adds tests that cover both gaps.
+
+## Affected Files
+
+| File | Change Type | Description |
+| ---- | ----------- | ----------- |
+| `tests/helpers/SseTestClient.ts` | Create | Reusable SSE client helper for integration tests |
+| `tests/integration/sse-transport.test.ts` | Update | Add tool execution and security tests over SSE |
+| `tests/integration/mcpProtocol.test.ts` | Update | Add protocol handshake tests for stdio |
+| `tests/integration/sse-tool-execution.test.ts` | Create | Dedicated SSE tool execution integration tests |
+| `tests/integration/sse-security.test.ts` | Create | Security scenario tests over SSE transport |
+
+## Phase 1: Shared SSE Test Helper
+
+### Why
+
+The existing `sse-transport.test.ts` has inline `connectSSE`, `postMessage`, `waitForMessage` helpers duplicated in every test. Extracting these into a reusable module reduces boilerplate and ensures consistent test patterns across new test files.
+
+### Implementation
+
+Create `tests/helpers/SseTestClient.ts`:
+
+```typescript
+export class SseTestClient {
+  // Starts CLIServer in SSE mode on port 0, connects SSE stream,
+  // performs initialize + initialized handshake automatically.
+  static async create(configOverrides?: Partial<ServerConfig>): Promise<SseTestClient>
+
+  // Sends a JSON-RPC request and returns the response.
+  async call(method: string, params?: object): Promise<any>
+
+  // Calls a tool by name with arguments and returns the result.
+  async callTool(name: string, args: Record<string, any>): Promise<any>
+
+  // Tears down SSE stream and closes HTTP server.
+  async close(): Promise<void>
+}
+```
+
+### Verification
+
+```bash
+npm test -- tests/integration/sse-transport.test.ts
+```
+
+Existing tests should continue to pass after refactoring to use the new helper.
+
+## Phase 2: Tool Execution Over SSE
+
+### Why
+
+The comparison shows that only `get_config` is tested over SSE. The primary tool `execute_command` and the validation tool `validate_directories` have zero SSE coverage.
+
+### Test Cases
+
+File: `tests/integration/sse-tool-execution.test.ts`
+
+| Test Case | Description |
+| --------- | ----------- |
+| execute_command basic echo | Call `execute_command` over SSE with `echo hello`, verify output contains `hello` and exitCode is 0 |
+| execute_command with workingDir | Call `execute_command` with explicit `workingDir`, verify `workingDirectory` in metadata matches |
+| execute_command output metadata | Call `seq 1 50` with `maxOutputLines: 20`, verify `totalLines`, `returnedLines`, `wasTruncated` |
+| execute_command with timeout | Call a short command with explicit `timeout`, verify it completes within the timeout |
+| execute_command failed command | Call `ls /nonexistent`, verify `exitCode` is non-zero and output contains error text |
+| validate_directories valid path | Call `validate_directories` with allowed path, verify no error |
+| validate_directories invalid path | Call `validate_directories` with disallowed path, verify error response |
+| get_config returns structure | Call `get_config`, verify response has `global`, `shells`, `transport` sections |
+| get_current_directory | Call `get_current_directory`, verify it returns a valid path |
+| set_current_directory | Call `set_current_directory` with a valid path, then `get_current_directory` to confirm |
+| tools/list includes all tools | Verify `execute_command`, `get_config`, `get_current_directory`, `set_current_directory`, `validate_directories` are listed |
+
+### Verification
+
+```bash
+npm test -- tests/integration/sse-tool-execution.test.ts
+```
+
+## Phase 3: Security Scenarios Over SSE
+
+### Why
+
+The comparison shows zero security tests over SSE. Blocked operators, path restrictions, and injection protection are only tested via direct `_executeTool` calls. These must also work through the full SSE transport path.
+
+### Test Cases
+
+File: `tests/integration/sse-security.test.ts`
+
+| Test Case | Description |
+| --------- | ----------- |
+| blocked operator rejection | Call `execute_command` with `echo hi ; ls` (blocked `;`), verify MCP error response |
+| blocked pipe rejection | Call `execute_command` with `echo hi \| grep hi` (blocked `\|`), verify MCP error response |
+| blocked ampersand rejection | Call `execute_command` with `echo hi & ls` (blocked `&`), verify MCP error response |
+| path restriction enforced | Configure `restrictWorkingDirectory: true` with `allowedPaths: ['/allowed']`, call `execute_command` with `workingDir: '/tmp'`, verify error |
+| path restriction allowed | Configure `restrictWorkingDirectory: true` with `allowedPaths: ['/tmp']`, call `execute_command` with `workingDir: '/tmp'`, verify success |
+| unknown tool name | Call a non-existent tool name, verify MCP error with appropriate error code |
+| missing required argument | Call `execute_command` without `command` argument, verify validation error |
+| invalid shell name | Call `execute_command` with `shell: 'nonexistent'`, verify error |
+| command too long | Configure `maxCommandLength: 10`, send a command exceeding it, verify error |
+| unknown session POST | POST a message to a non-existent session ID, verify HTTP 404 |
+| concurrent sessions isolated | Open two SSE sessions on separate servers, verify each gets its own responses |
+
+### Verification
+
+```bash
+npm test -- tests/integration/sse-security.test.ts
+```
+
+## Phase 4: Stdio Protocol Handshake Tests
+
+### Why
+
+The comparison shows stdio tests bypass the MCP protocol handshake entirely by calling `_executeTool` directly. While the transport is implicitly tested by the fact that tools work, the protocol-level behavior (initialize, capabilities negotiation, notifications) is not verified for stdio.
+
+### Test Cases
+
+Update `tests/integration/mcpProtocol.test.ts`:
+
+| Test Case | Description |
+| --------- | ----------- |
+| initialize handshake via stdio | Use `StdioServerTransport` + `Client` from MCP SDK to perform full initialize handshake against `CLIServer`, verify `serverInfo.name` is `wcli0` |
+| initialized notification via stdio | Complete initialize, then send `notifications/initialized`, verify no error |
+| tools/list via stdio client | After handshake, call `tools/list` through SDK client, verify all expected tools are present |
+| tools/call via stdio client | After handshake, call `get_config` through SDK client, verify response structure |
+| error response on unknown method | Send a JSON-RPC request with unknown method, verify error response |
+
+### Note
+
+This requires spawning the server as a child process or using `StdioServerTransport` in-memory. The MCP SDK provides `Client` class that can connect to a `Server` via in-memory transport for testing. See `@modelcontextprotocol/sdk/dist/inMemory.test.js` for the pattern.
+
+### Verification
+
+```bash
+npm test -- tests/integration/mcpProtocol.test.ts
+```
+
+## Phase 5: Refactor Existing SSE Tests
+
+### Why
+
+The existing `sse-transport.test.ts` has inline helper functions (`connectSSE`, `postMessage`, `waitForMessage`) that are duplicated. Once the shared `SseTestClient` helper exists, refactor to use it. This reduces maintenance burden and ensures consistency.
+
+### Implementation
+
+- Replace inline helpers in `sse-transport.test.ts` with `SseTestClient`
+- Keep the transport-layer tests (server start, SSE headers, 404/400 responses, close) as-is since they test lower-level HTTP behavior
+- Move protocol-handshake tests that are already passing to use `SseTestClient` for brevity
+
+### Verification
+
+```bash
+npm test -- tests/integration/sse-transport.test.ts
+```
+
+## Dependency Graph
+
+```mermaid
+flowchart TB
+    P1["Phase 1: SseTestClient helper"] --> P2["Phase 2: Tool execution over SSE"]
+    P1 --> P3["Phase 3: Security over SSE"]
+    P1 --> P5["Phase 5: Refactor existing SSE tests"]
+    P2 --> P4["Phase 4: Stdio protocol handshake"]
+    P3 --> P4
+```
+
+Phases 2 and 3 can run in parallel after Phase 1. Phase 4 is independent of SSE work but depends on understanding the patterns from Phases 2-3. Phase 5 is cleanup and can happen last.
+
+## Coverage Targets
+
+After all phases are complete, both transports should have matching coverage:
+
+| Category | stdio | HTTP/SSE |
+| -------- | ----- | -------- |
+| Protocol handshake | Phase 4 | Already covered |
+| tools/list | Phase 4 | Already covered |
+| execute_command | Already covered | Phase 2 |
+| get_config | Already covered | Already covered |
+| validate_directories | Already covered | Phase 2 |
+| get/set current directory | Already covered | Phase 2 |
+| Blocked operators | Already covered | Phase 3 |
+| Path restrictions | Already covered | Phase 3 |
+| Error handling | Already covered | Phase 3 |
+| Transport lifecycle | N/A | Already covered |
+| Concurrent sessions | N/A | Phase 3 |
+
+## Scope
+
+| Phase | New Files | Updated Files | Test Cases Added |
+| ----- | --------- | ------------- | ---------------- |
+| Phase 1 | 1 | 0 | 0 (refactor only) |
+| Phase 2 | 1 | 0 | 11 |
+| Phase 3 | 1 | 0 | 11 |
+| Phase 4 | 0 | 1 | 5 |
+| Phase 5 | 0 | 1 | 0 (refactor only) |
+| **Total** | **3** | **2** | **27** |

--- a/docs/tasks/http_sse_transport/verification.md
+++ b/docs/tasks/http_sse_transport/verification.md
@@ -40,6 +40,7 @@ npm test -- tests/unit/ --testNamePattern="transport config"
 ```
 
 Expected:
+
 - Transport config defaults to stdio mode.
 - `applyCliTransport()` overrides mode, host, port.
 - CLI flags override config file values.
@@ -51,6 +52,7 @@ npm test -- tests/unit/ --testNamePattern="parseArgs.*transport"
 ```
 
 Expected:
+
 - `--transport stdio` and `--transport sse` are accepted.
 - `--sse-host` and `--sse-port` are parsed.
 - Invalid `--transport` value is rejected by yargs choices.
@@ -62,6 +64,7 @@ npm test -- tests/unit/transport.test.ts
 ```
 
 Expected:
+
 - HTTP server starts and listens.
 - GET `/sse` returns SSE headers.
 - POST `/messages` routes to correct session.
@@ -74,6 +77,7 @@ npm test -- tests/integration/sse-transport.test.ts
 ```
 
 Expected:
+
 - Server starts in SSE mode when configured.
 - Full MCP initialize handshake completes over SSE.
 - Server shuts down cleanly.
@@ -106,6 +110,7 @@ Expected: all tests pass, no regressions.
 ## Final Acceptance Verification
 
 The feature can be accepted when all items are true:
+
 - [x] `npx wcli0` starts in stdio mode (unchanged behavior) -- default `transport.mode` is `stdio`; `sse-transport.test.ts` confirms stdio mode creates no HTTP server
 - [x] `npx wcli0 --transport sse` starts HTTP server on `127.0.0.1:9444` -- defaults verified in `transport.test.ts`; SSE startup verified in `sse-transport.test.ts`
 - [x] `npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000` binds to `0.0.0.0:3000` -- `applyCliTransport` override verified in `transport.test.ts`; bind host/port verified in `sse-transport.test.ts`

--- a/docs/tasks/http_sse_transport/verification.md
+++ b/docs/tasks/http_sse_transport/verification.md
@@ -106,13 +106,13 @@ Expected: all tests pass, no regressions.
 ## Final Acceptance Verification
 
 The feature can be accepted when all items are true:
-- [ ] `npx wcli0` starts in stdio mode (unchanged behavior)
-- [ ] `npx wcli0 --transport sse` starts HTTP server on `127.0.0.1:9444`
-- [ ] `npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000` binds to `0.0.0.0:3000`
-- [ ] SSE client can connect, initialize, and receive responses
-- [ ] Config file `transport` section is respected
-- [ ] CLI flags override config file values
-- [ ] Graceful shutdown works in SSE mode
-- [ ] All existing tests pass (no regression)
-- [ ] `npm run lint` passes
-- [ ] New transport code has test coverage
+- [x] `npx wcli0` starts in stdio mode (unchanged behavior) -- default `transport.mode` is `stdio`; `sse-transport.test.ts` confirms stdio mode creates no HTTP server
+- [x] `npx wcli0 --transport sse` starts HTTP server on `127.0.0.1:9444` -- defaults verified in `transport.test.ts`; SSE startup verified in `sse-transport.test.ts`
+- [x] `npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000` binds to `0.0.0.0:3000` -- `applyCliTransport` override verified in `transport.test.ts`; bind host/port verified in `sse-transport.test.ts`
+- [x] SSE client can connect, initialize, and receive responses -- `sse-transport.test.ts`, `sse-tool-execution.test.ts`
+- [x] Config file `transport` section is respected -- `transport.test.ts`
+- [x] CLI flags override config file values -- `transport.test.ts`
+- [x] Graceful shutdown works in SSE mode -- `closeSseServer` + `CLIServer.cleanup` verified in `sse-transport.test.ts`
+- [x] All existing tests pass (no regression) -- full `npm test` suite green
+- [x] `npm run lint` passes -- `tsc --noEmit` clean
+- [x] New transport code has test coverage -- unit (`transport.test.ts`) + integration (`sse-transport`, `sse-tool-execution`, `sse-security`, `sse-resources`, `sse-edge-cases`)

--- a/docs/tasks/http_sse_transport/verification.md
+++ b/docs/tasks/http_sse_transport/verification.md
@@ -1,0 +1,118 @@
+# Verification Plan: HTTP/SSE Transport for MCP Server
+
+## Purpose
+
+Verify that HTTP/SSE transport is correctly implemented alongside existing stdio transport, with proper configuration, CLI flags, and test coverage.
+
+## Pre-Implementation Verification
+
+### Existing Tests Pass
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+### Linter Clean
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+### Coverage Baseline (Before)
+
+| Module | Baseline Coverage | After Coverage | Delta |
+| ------ | ----------------- | -------------- | ----- |
+| src/index.ts | -- % | -- % | -- % |
+| src/utils/config.ts | -- % | -- % | -- % |
+| src/types/config.ts | -- % | -- % | -- % |
+| src/utils/transport.ts | N/A (new) | -- % | N/A |
+
+## Post-Implementation Verification
+
+### Phase 1 Verification: Types and Configuration
+
+```bash
+npm test -- tests/unit/ --testNamePattern="transport config"
+```
+
+Expected:
+- Transport config defaults to stdio mode.
+- `applyCliTransport()` overrides mode, host, port.
+- CLI flags override config file values.
+
+### Phase 2 Verification: CLI Arguments
+
+```bash
+npm test -- tests/unit/ --testNamePattern="parseArgs.*transport"
+```
+
+Expected:
+- `--transport stdio` and `--transport sse` are accepted.
+- `--sse-host` and `--sse-port` are parsed.
+- Invalid `--transport` value is rejected by yargs choices.
+
+### Phase 3 Verification: SSE Transport Module
+
+```bash
+npm test -- tests/unit/transport.test.ts
+```
+
+Expected:
+- HTTP server starts and listens.
+- GET `/sse` returns SSE headers.
+- POST `/messages` routes to correct session.
+- Unknown session returns appropriate error.
+
+### Phase 4 Verification: CLIServer Integration
+
+```bash
+npm test -- tests/integration/sse-transport.test.ts
+```
+
+Expected:
+- Server starts in SSE mode when configured.
+- Full MCP initialize handshake completes over SSE.
+- Server shuts down cleanly.
+- Stdio mode still passes all existing tests.
+
+### Phase 5 Verification: Documentation
+
+```bash
+npm run lint
+```
+
+Expected: no errors, README references are valid.
+
+### Linter
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+### Regression Check
+
+```bash
+npm test
+```
+
+Expected: all tests pass, no regressions.
+
+## Final Acceptance Verification
+
+The feature can be accepted when all items are true:
+- [ ] `npx wcli0` starts in stdio mode (unchanged behavior)
+- [ ] `npx wcli0 --transport sse` starts HTTP server on `127.0.0.1:9444`
+- [ ] `npx wcli0 --transport sse --sse-host 0.0.0.0 --sse-port 3000` binds to `0.0.0.0:3000`
+- [ ] SSE client can connect, initialize, and receive responses
+- [ ] Config file `transport` section is respected
+- [ ] CLI flags override config file values
+- [ ] Graceful shutdown works in SSE mode
+- [ ] All existing tests pass (no regression)
+- [ ] `npm run lint` passes
+- [ ] New transport code has test coverage

--- a/docs/tasks/http_sse_transport/worker-exit-investigation.md
+++ b/docs/tasks/http_sse_transport/worker-exit-investigation.md
@@ -1,0 +1,122 @@
+# Worker Exit Warning - Investigation
+
+## Context
+
+After the SIGINT handler leak was fixed (commit `efa1d4c`), `npm test` still printed:
+
+```text
+A worker process has failed to exit gracefully and has been force exited.
+This is likely caused by tests leaking due to improper teardown. Try running
+with --detectOpenHandles to find leaks. Active timers can also cause this,
+ensure that .unref() was called on them.
+```
+
+The original commit message attributed this to "other test files" (LogStorageManager
+timers or Windows shell child processes). This document records the actual root cause,
+the evidence gathered, and what does and does not remove the warning.
+
+## Summary of findings
+
+- The warning is NOT produced by the shell-execution or LogStorageManager tests.
+- It is produced by `tests/integration/sse-transport.test.ts` (the HTTP/SSE tests).
+- There is NO real resource leak. `jest --detectOpenHandles` reports zero open handles.
+- It is a known interaction between Jest worker processes and Node's
+  `--experimental-vm-modules` ESM loader, triggered by the volume of HTTP server and
+  socket churn in that single file.
+
+## Root cause
+
+At the moment a Jest worker finishes `sse-transport.test.ts` and is asked to exit, the
+worker still holds transient handles from the just-closed HTTP/SSE servers:
+
+- 2 `Server` handles with `listening=false` and `connections=0` (already closed).
+- 6 `Socket` handles with `destroyed=true` (already destroyed) but still listed as
+  active by `process._getActiveHandles()`.
+
+These handles are reaped by libuv within roughly 50 ms. The worker, however, is
+force-exited by `jest-worker` before that happens, which prints the warning. Under
+`--experimental-vm-modules` the worker does not self-terminate even after the handles
+are gone, because the VM module context keeps a reference the event loop cannot drain.
+
+## Evidence
+
+### Bisection (parallel worker mode)
+
+| Test group | Worker warning |
+| ---------- | -------------- |
+| Full suite | yes |
+| All non-subdirectory tests | no |
+| Spawn-heavy shell/timeout/process tests | no |
+| `tests/wsl/**` | no |
+| `tests/integration/**` | yes |
+| `tests/integration/**` minus the three `sse-*` files | no |
+| `sse-transport.test.ts` alone (paired with a trivial file) | yes |
+| `sse-security.test.ts` alone (paired with a trivial file) | no |
+| `sse-tool-execution.test.ts` alone (paired with a trivial file) | no |
+| Each `sse-transport.test.ts` describe block run on its own | no |
+
+Conclusion: only `sse-transport.test.ts` triggers it, and only when its three describe
+blocks run together (a cumulative, not per-test, effect).
+
+### Open handle analysis
+
+`jest --detectOpenHandles` (which implies `--runInBand`) reports zero open handles for
+the SSE tests, both for the full suite and for the SSE files in isolation. There is no
+permanently leaked timer, socket, or child process.
+
+Note: `--detectOpenHandles` is also unreliable under `--experimental-vm-modules`, so a
+direct handle snapshot was taken inside the worker to confirm the above.
+
+### Handle snapshot at worker exit
+
+Instrumenting the worker (`process._getActiveHandles()`) immediately after the file's
+tests complete shows, for `sse-transport.test.ts`:
+
+```text
+Server listening=false connections=0          (x2)
+Socket destroyed=true reading=true fd=undefined (x6, mix of client and server side)
++ the standard worker stdio pipes and IPC channel
+```
+
+All application handles are already closed/destroyed; they clear on their own within
+~50 ms.
+
+## What does NOT remove the warning
+
+The following were each tried and verified to NOT remove the worker warning:
+
+- `forceExit: true` in the Jest config. It only force-exits the main process at the end
+  of the run; the worker warning is emitted earlier by `jest-worker` and is unaffected.
+- `server.closeAllConnections()` in `closeSseServer()` (see below). It makes the
+  isolated `SseTestClient` flow clean but does not fix the full `sse-transport.test.ts`
+  file.
+- Converting the dynamic `import('./utils/transport.js')` in `CLIServer` to a static
+  import.
+- Yielding the event loop (`setImmediate`) in `SseTestClient.close()`.
+- A 100 ms delay after every test.
+
+The only thing that removes it is running the tests serially (no worker child
+processes): `jest --runInBand` (or `maxWorkers: 1`) produces a fully clean run
+(exit 0, 0 warnings, all tests pass) in ~35 s versus ~20 s in parallel.
+
+## Related production-correctness fix
+
+Independently of the test warning, `closeSseServer()` in `src/utils/transport.ts` was
+improved to call `server.closeAllConnections()`. `http.Server.close()` only stops
+accepting new connections and waits for existing ones to end on their own; long-lived
+SSE streams would otherwise keep the server (and a SIGINT shutdown) from completing.
+This is a real improvement for production shutdown and is kept regardless of the test
+strategy chosen for the warning.
+
+## How to re-verify
+
+```bash
+# Reproduce the warning (parallel workers)
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration/sse-transport
+
+# Confirm no real leak (serial + handle detection)
+npm run test:debug -- tests/integration/sse-transport
+
+# Confirm a clean serial run
+node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand
+```

--- a/docs/tasks/http_sse_transport/worker-exit-investigation.md
+++ b/docs/tasks/http_sse_transport/worker-exit-investigation.md
@@ -12,31 +12,44 @@ ensure that .unref() was called on them.
 ```
 
 The original commit message attributed this to "other test files" (LogStorageManager
-timers or Windows shell child processes). This document records the actual root cause,
-the evidence gathered, and what does and does not remove the warning.
+timers or Windows shell child processes). This document records the actual root cause
+and the fix.
 
 ## Summary of findings
 
 - The warning is NOT produced by the shell-execution or LogStorageManager tests.
-- It is produced by `tests/integration/sse-transport.test.ts` (the HTTP/SSE tests).
-- There is NO real resource leak. `jest --detectOpenHandles` reports zero open handles.
-- It is a known interaction between Jest worker processes and Node's
-  `--experimental-vm-modules` ESM loader, triggered by the volume of HTTP server and
-  socket churn in that single file.
+- It is produced by `tests/integration/sse-transport.test.ts`, and specifically by its
+  one test that starts the server in stdio mode.
+- Root cause: starting the stdio transport leaves `process.stdin` in flowing (referenced)
+  mode, which keeps the worker process alive. `CLIServer.cleanup()` did not close the MCP
+  transport, so stdin was never released.
+- Fix: `CLIServer.cleanup()` now closes the MCP server transport and pauses `process.stdin`.
+  The warning is gone in normal parallel execution and all tests pass.
 
 ## Root cause
 
-At the moment a Jest worker finishes `sse-transport.test.ts` and is asked to exit, the
-worker still holds transient handles from the just-closed HTTP/SSE servers:
+`StdioServerTransport.start()` (MCP SDK) attaches a `data` listener to `process.stdin`:
 
-- 2 `Server` handles with `listening=false` and `connections=0` (already closed).
-- 6 `Socket` handles with `destroyed=true` (already destroyed) but still listed as
-  active by `process._getActiveHandles()`.
+```js
+this._stdin.on("data", this._ondata);
+```
 
-These handles are reaped by libuv within roughly 50 ms. The worker, however, is
-force-exited by `jest-worker` before that happens, which prints the warning. Under
-`--experimental-vm-modules` the worker does not self-terminate even after the handles
-are gone, because the VM module context keeps a reference the event loop cannot drain.
+Adding a `data` listener puts `process.stdin` into flowing mode, which references the
+stdin handle and keeps the Node process (the Jest worker) alive.
+
+The test `should use stdio mode when transport is stdio` calls `cliServer.run()`, which
+in stdio mode does `new StdioServerTransport()` + `server.connect(transport)` and starts
+reading stdin. `CLIServer.cleanup()` (run in `afterEach`) removed the SIGINT handler and
+closed the HTTP server, but never closed the MCP server, so the stdin `data` listener was
+left attached. Even calling `transport.close()` is not enough on its own:
+`StdioServerTransport.close()` only removes the `data` listener; it does not take stdin
+out of flowing mode, so the handle stays referenced.
+
+Only `sse-transport.test.ts` exercises stdio mode, which is why only that file triggered
+the warning.
+
+Why `--detectOpenHandles` looked clean: Jest's open-handle detector ignores the standard
+streams (`stdin`/`stdout`/`stderr`), so a referenced `process.stdin` is never reported.
 
 ## Evidence
 
@@ -48,75 +61,71 @@ are gone, because the VM module context keeps a reference the event loop cannot 
 | All non-subdirectory tests | no |
 | Spawn-heavy shell/timeout/process tests | no |
 | `tests/wsl/**` | no |
-| `tests/integration/**` | yes |
 | `tests/integration/**` minus the three `sse-*` files | no |
 | `sse-transport.test.ts` alone (paired with a trivial file) | yes |
 | `sse-security.test.ts` alone (paired with a trivial file) | no |
 | `sse-tool-execution.test.ts` alone (paired with a trivial file) | no |
-| Each `sse-transport.test.ts` describe block run on its own | no |
 
-Conclusion: only `sse-transport.test.ts` triggers it, and only when its three describe
-blocks run together (a cumulative, not per-test, effect).
-
-### Open handle analysis
-
-`jest --detectOpenHandles` (which implies `--runInBand`) reports zero open handles for
-the SSE tests, both for the full suite and for the SSE files in isolation. There is no
-permanently leaked timer, socket, or child process.
-
-Note: `--detectOpenHandles` is also unreliable under `--experimental-vm-modules`, so a
-direct handle snapshot was taken inside the worker to confirm the above.
+`sse-security` and `sse-tool-execution` only use the SSE client helper; `sse-transport` is
+the only one that starts a stdio-mode server.
 
 ### Handle snapshot at worker exit
 
 Instrumenting the worker (`process._getActiveHandles()`) immediately after the file's
-tests complete shows, for `sse-transport.test.ts`:
+tests complete showed, among the standard worker pipes:
 
 ```text
-Server listening=false connections=0          (x2)
-Socket destroyed=true reading=true fd=undefined (x6, mix of client and server side)
-+ the standard worker stdio pipes and IPC channel
+Socket fd=0 reading=true   <- process.stdin, still in flowing mode
 ```
 
-All application handles are already closed/destroyed; they clear on their own within
-~50 ms.
+Polling `process.getActiveResourcesInfo()` into the worker's exit window showed only the
+standard `PipeWrap` stream handles remained - no leaked sockets, servers, timers, or
+requests. The referenced stdin stream was what kept the worker from exiting before Jest's
+500 ms force-exit deadline (`FORCE_EXIT_DELAY` in `jest-worker`).
 
-## What does NOT remove the warning
+### Confirmation
 
-The following were each tried and verified to NOT remove the worker warning:
+Adding `process.stdin.pause()` to `CLIServer.cleanup()` removed the warning in parallel
+worker mode immediately and deterministically.
 
-- `forceExit: true` in the Jest config. It only force-exits the main process at the end
-  of the run; the worker warning is emitted earlier by `jest-worker` and is unaffected.
-- `server.closeAllConnections()` in `closeSseServer()` (see below). It makes the
-  isolated `SseTestClient` flow clean but does not fix the full `sse-transport.test.ts`
-  file.
-- Converting the dynamic `import('./utils/transport.js')` in `CLIServer` to a static
-  import.
-- Yielding the event loop (`setImmediate`) in `SseTestClient.close()`.
-- A 100 ms delay after every test.
+## Fix
 
-The only thing that removes it is running the tests serially (no worker child
-processes): `jest --runInBand` (or `maxWorkers: 1`) produces a fully clean run
-(exit 0, 0 warnings, all tests pass) in ~35 s versus ~20 s in parallel.
+`src/index.ts` - `CLIServer.cleanup()`:
 
-## Related production-correctness fix
+- `await this.server.close()` - disconnects the MCP transport (stdio or SSE).
+- `process.stdin.pause()` for non-SSE modes - takes stdin out of flowing mode so the
+  handle is released and the event loop can drain.
 
-Independently of the test warning, `closeSseServer()` in `src/utils/transport.ts` was
-improved to call `server.closeAllConnections()`. `http.Server.close()` only stops
-accepting new connections and waits for existing ones to end on their own; long-lived
-SSE streams would otherwise keep the server (and a SIGINT shutdown) from completing.
-This is a real improvement for production shutdown and is kept regardless of the test
-strategy chosen for the warning.
+`src/utils/transport.ts` - `closeSseServer()` was also hardened to call
+`server.closeAllConnections()`. `http.Server.close()` only stops accepting new
+connections and waits for existing ones to end; long-lived SSE streams would otherwise
+keep a SIGINT shutdown from completing. This is an independent production-shutdown
+improvement.
+
+### Verified outcome
+
+`npm test` (normal parallel execution, no `--runInBand`, no `forceExit`):
+
+- 0 worker warnings, exit code 0.
+- 900 passed, 24 skipped, 0 failed (3 consecutive runs).
+- Run time ~17 s (full parallelism preserved).
+
+## Approaches that were rejected
+
+| Approach | Result |
+| -------- | ------ |
+| `forceExit: true` | Only force-exits the main process; the worker warning (emitted earlier by `jest-worker`) is unaffected. |
+| `maxWorkers: 1` / `--runInBand` | Removes the warning but only by disabling parallelism (~35 s vs ~17 s). A workaround, not a fix. |
+| `workerThreads: true` | Removes the warning but breaks `process.chdir()` (unsupported in worker threads), failing the `set_current_directory` test. |
+| `server.closeAllConnections()` alone | Good for SSE shutdown, but did not address the stdin handle. |
+| Static import of the transport module, `setImmediate` yields, 100 ms per-test delays | No effect. |
 
 ## How to re-verify
 
 ```bash
-# Reproduce the warning (parallel workers)
+# Should be clean (no warning), full parallel run
+node --experimental-vm-modules node_modules/jest/bin/jest.js
+
+# The previously-offending file on its own
 node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration/sse-transport
-
-# Confirm no real leak (serial + handle detection)
-npm run test:debug -- tests/integration/sse-transport
-
-# Confirm a clean serial run
-node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1364,6 +1364,22 @@ class CLIServer {
       process.removeListener('SIGINT', this.sigintHandler);
       this.sigintHandler = undefined;
     }
+    // Disconnect the MCP transport. In stdio mode this removes the 'data'
+    // listener that StdioServerTransport attaches to process.stdin (which keeps
+    // stdin in flowing mode and the process alive); in SSE mode it ends the
+    // active SSE response. Best-effort: the server may never have been connected.
+    try {
+      await this.server.close();
+    } catch {
+      // ignore - server may not be connected to a transport
+    }
+    // StdioServerTransport.close() only removes its stdin 'data' listener; it
+    // does not take stdin out of flowing mode, so the stdin handle stays
+    // referenced and keeps the process alive. Pause it explicitly so the event
+    // loop can drain (harmless when stdin was never used, e.g. SSE mode).
+    if (this.config.transport?.mode !== 'sse') {
+      process.stdin.pause();
+    }
     // Close HTTP server if in SSE mode
     if (this.httpServer) {
       const { closeSseServer } = await import('./utils/transport.js');

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,15 +197,9 @@ class CLIServer {
 
   constructor(config: ServerConfig) {
     this.config = config;
-    this.server = new Server({
-      name: "wcli0",
-      version: packageJson.version,
-    }, {
-      capabilities: {
-        tools: {},
-        resources: {}
-      }
-    });
+    // Build the primary server (used for stdio mode and shutdown). In SSE mode a
+    // fresh instance is created per connection via createServerInstance().
+    this.server = this.createServerInstance();
 
     // Pre-resolve enabled shell configurations
     this.initializeShellConfigs();
@@ -228,8 +222,26 @@ class CLIServer {
         debugLog('Log storage: in-memory only (no logDirectory configured)');
       }
     }
+  }
 
-    this.setupHandlers();
+  /**
+   * Create a fully-wired MCP Server instance. Used for the primary server and,
+   * in SSE mode, for the per-connection server handed to createSseServer(). Each
+   * instance gets its own request handlers; all handlers close over `this`, so
+   * they share the CLIServer's config, resolved shells, and log storage.
+   */
+  private createServerInstance(): Server {
+    const server = new Server({
+      name: "wcli0",
+      version: packageJson.version,
+    }, {
+      capabilities: {
+        tools: {},
+        resources: {}
+      }
+    });
+    this.setupHandlers(server);
+    return server;
   }
 
   private initializeShellConfigs(): void {
@@ -595,9 +607,9 @@ class CLIServer {
     return createSerializableConfig(this.config);
   }
 
-  private setupHandlers(): void {
+  private setupHandlers(server: Server = this.server): void {
     // List available resources
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    server.setRequestHandler(ListResourcesRequestSchema, async () => {
       const resources: Array<{uri:string,name:string,description:string,mimeType:string}> = [];
       
       // Add resources for configuration
@@ -668,12 +680,12 @@ class CLIServer {
     });
 
     // Provide an empty list of resource templates for now
-    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
       return { resourceTemplates: [] };
     });
 
     // Read resource content
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       const uri = request.params.uri;
       
       // Handle CLI configuration resource
@@ -805,7 +817,7 @@ class CLIServer {
     });
 
     // List available tools with dynamic descriptions and schemas
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
       // Get enabled shells and their resolved configurations
       const enabledShells = this.getEnabledShells();
       const tools = [];
@@ -876,7 +888,7 @@ class CLIServer {
     });
 
     // Handle tool execution
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Directly call the public tool execution logic
       return this._executeTool(request.params);
     });
@@ -1398,7 +1410,11 @@ class CLIServer {
       const { createSseServer } = await import('./utils/transport.js');
       const host = this.config.transport.sseHost ?? '127.0.0.1';
       const port = this.config.transport.ssePort ?? 9444;
-      this.httpServer = await createSseServer(this.server, host, port);
+      this.httpServer = await createSseServer(
+        () => this.createServerInstance(),
+        host,
+        port
+      );
       debugLog(`Windows CLI MCP Server running on SSE at http://${host}:${port}`);
     } else {
       const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ class CLIServer {
   constructor(config: ServerConfig) {
     this.config = config;
     this.server = new Server({
-      name: "windows-cli-server",
+      name: "wcli0",
       version: packageJson.version,
     }, {
       capabilities: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,8 @@ class CLIServer {
   private logStorage?: LogStorageManager;
   // HTTP server reference for SSE mode cleanup
   private httpServer?: import('http').Server;
+  // Stored SIGINT handler reference for cleanup removal
+  private sigintHandler?: () => Promise<void>;
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -1356,7 +1358,12 @@ class CLIServer {
     }
   }
 
-  private async cleanup(): Promise<void> {
+  async cleanup(): Promise<void> {
+    // Remove SIGINT handler
+    if (this.sigintHandler) {
+      process.removeListener('SIGINT', this.sigintHandler);
+      this.sigintHandler = undefined;
+    }
     // Close HTTP server if in SSE mode
     if (this.httpServer) {
       const { closeSseServer } = await import('./utils/transport.js');
@@ -1384,10 +1391,11 @@ class CLIServer {
     }
 
     // Set up cleanup handler
-    process.on('SIGINT', async () => {
+    this.sigintHandler = async () => {
       await this.cleanup();
       process.exit(0);
-    });
+    };
+    process.on('SIGINT', this.sigintHandler);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,8 @@ class CLIServer {
   private resolvedConfigs: Map<string, ResolvedShellConfig> = new Map();
   // Log storage manager
   private logStorage?: LogStorageManager;
+  // HTTP server reference for SSE mode cleanup
+  private httpServer?: import('http').Server;
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -1355,6 +1357,12 @@ class CLIServer {
   }
 
   private async cleanup(): Promise<void> {
+    // Close HTTP server if in SSE mode
+    if (this.httpServer) {
+      const { closeSseServer } = await import('./utils/transport.js');
+      await closeSseServer(this.httpServer);
+      this.httpServer = undefined;
+    }
     // Stop and clear log storage
     if (this.logStorage) {
       this.logStorage.stopCleanup();
@@ -1363,16 +1371,23 @@ class CLIServer {
   }
 
   async run(): Promise<void> {
-    const transport = new StdioServerTransport();
-    
+    if (this.config.transport?.mode === 'sse') {
+      const { createSseServer } = await import('./utils/transport.js');
+      const host = this.config.transport.sseHost ?? '127.0.0.1';
+      const port = this.config.transport.ssePort ?? 9444;
+      this.httpServer = await createSseServer(this.server, host, port);
+      debugLog(`Windows CLI MCP Server running on SSE at http://${host}:${port}`);
+    } else {
+      const transport = new StdioServerTransport();
+      await this.server.connect(transport);
+      debugLog("Windows CLI MCP Server running on stdio");
+    }
+
     // Set up cleanup handler
     process.on('SIGINT', async () => {
       await this.cleanup();
       process.exit(0);
     });
-    
-    await this.server.connect(transport);
-    debugLog("Windows CLI MCP Server running on stdio");
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,10 +182,21 @@ const ValidateDirectoriesArgsSchema = z.object({
 });
 
 
+/**
+ * Mutable per-session state. In stdio mode there is a single session
+ * (`primarySession`); in SSE mode each connection gets its own SessionState so
+ * the active working directory selected by one client cannot leak into another.
+ */
+export interface SessionState {
+  activeCwd: string | undefined;
+}
+
 class CLIServer {
   private server: Server;
   private config: ServerConfig;
-  private serverActiveCwd: string | undefined;
+  // State for the primary (stdio) session. Each SSE connection carries its own
+  // SessionState instead (see createServerInstance / run).
+  private primarySession: SessionState = { activeCwd: undefined };
   // Cache resolved configurations for performance
   private resolvedConfigs: Map<string, ResolvedShellConfig> = new Map();
   // Log storage manager
@@ -225,12 +236,29 @@ class CLIServer {
   }
 
   /**
+   * Backwards-compatible accessor for the primary session's active working
+   * directory. Stdio-mode code paths, initialization, and tests read and write
+   * `serverActiveCwd`; it now proxies to `primarySession`. SSE connections each
+   * carry their own SessionState (see createServerInstance / _executeTool), so
+   * concurrent SSE clients no longer share a directory.
+   */
+  private get serverActiveCwd(): string | undefined {
+    return this.primarySession.activeCwd;
+  }
+
+  private set serverActiveCwd(value: string | undefined) {
+    this.primarySession.activeCwd = value;
+  }
+
+  /**
    * Create a fully-wired MCP Server instance. Used for the primary server and,
    * in SSE mode, for the per-connection server handed to createSseServer(). Each
    * instance gets its own request handlers; all handlers close over `this`, so
-   * they share the CLIServer's config, resolved shells, and log storage.
+   * they share the CLIServer's config, resolved shells, and log storage. The
+   * `session` argument holds the per-instance mutable state (active working
+   * directory); it defaults to the primary session used by stdio mode.
    */
-  private createServerInstance(): Server {
+  private createServerInstance(session: SessionState = this.primarySession): Server {
     const server = new Server({
       name: "wcli0",
       version: packageJson.version,
@@ -240,7 +268,7 @@ class CLIServer {
         resources: {}
       }
     });
-    this.setupHandlers(server);
+    this.setupHandlers(server, session);
     return server;
   }
 
@@ -607,7 +635,7 @@ class CLIServer {
     return createSerializableConfig(this.config);
   }
 
-  private setupHandlers(server: Server = this.server): void {
+  private setupHandlers(server: Server = this.server, session: SessionState = this.primarySession): void {
     // List available resources
     server.setRequestHandler(ListResourcesRequestSchema, async () => {
       const resources: Array<{uri:string,name:string,description:string,mimeType:string}> = [];
@@ -889,13 +917,19 @@ class CLIServer {
 
     // Handle tool execution
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      // Directly call the public tool execution logic
-      return this._executeTool(request.params);
+      // Directly call the public tool execution logic, scoped to this server
+      // instance's session so the active working directory stays per-session.
+      return this._executeTool(request.params, session);
     });
   }
 
-  // Public method for testing or direct invocation of tool logic
-  public async _executeTool(toolParams: z.infer<typeof CallToolRequestSchema>['params']): Promise<CallToolResult> { // Changed return type
+  // Public method for testing or direct invocation of tool logic. `session`
+  // defaults to the primary session so existing callers (stdio, tests) are
+  // unaffected; SSE handlers pass their own per-connection SessionState.
+  public async _executeTool(
+    toolParams: z.infer<typeof CallToolRequestSchema>['params'],
+    session: SessionState = this.primarySession
+  ): Promise<CallToolResult> { // Changed return type
     try {
       switch (toolParams.name) {
         case "execute_command": {
@@ -983,7 +1017,7 @@ class CLIServer {
               }
             }
           } else {
-            if (!this.serverActiveCwd) {
+            if (!session.activeCwd) {
               return {
                 content: [{
                   type: "text",
@@ -993,7 +1027,7 @@ class CLIServer {
                 metadata: {}
               };
             }
-            workingDir = this.serverActiveCwd;
+            workingDir = session.activeCwd;
 
             if (shellConfig.security.restrictWorkingDirectory) {
               try {
@@ -1022,7 +1056,7 @@ class CLIServer {
         }
 
         case "get_current_directory": {
-          if (!this.serverActiveCwd) {
+          if (!session.activeCwd) {
             return {
               content: [{
                 type: "text",
@@ -1032,7 +1066,7 @@ class CLIServer {
               metadata: {}
             };
           }
-          const currentDir = this.serverActiveCwd;
+          const currentDir = session.activeCwd;
           return {
             content: [{
               type: "text",
@@ -1062,11 +1096,14 @@ class CLIServer {
             }
 
             // Store the actual previous directory for metadata
-            const actualPreviousDir = this.serverActiveCwd;
+            const actualPreviousDir = session.activeCwd;
 
-            // Change directory and update server state
+            // Change directory and update the session's state. process.chdir is
+            // process-global, but command execution always uses an explicit cwd
+            // resolved from session.activeCwd, so concurrent SSE sessions keep
+            // independent working directories for routing.
             process.chdir(newDir);
-            this.serverActiveCwd = newDir;
+            session.activeCwd = newDir;
 
             return {
               content: [{
@@ -1411,7 +1448,10 @@ class CLIServer {
       const host = this.config.transport.sseHost ?? '127.0.0.1';
       const port = this.config.transport.ssePort ?? 9444;
       this.httpServer = await createSseServer(
-        () => this.createServerInstance(),
+        // Each SSE connection gets a fresh SessionState seeded from the primary
+        // session's initial cwd, so one client's set_current_directory cannot
+        // change another client's active working directory.
+        () => this.createServerInstance({ activeCwd: this.primarySession.activeCwd }),
         host,
         port
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import path from 'path';
 import { buildToolDescription } from './utils/toolDescription.js';
 import { buildExecuteCommandSchema, buildValidateDirectoriesSchema, buildGetCommandOutputSchema } from './utils/toolSchemas.js';
 import { buildExecuteCommandDescription, buildValidateDirectoriesDescription, buildGetConfigDescription, buildGetCommandOutputDescription } from './utils/toolDescription.js';
-import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides, applyCliWslMountPoint, applyCliRestrictions, applyCliLogging, applyCliUnsafeMode, applyDebugLogDirectory } from './utils/config.js';
+import { loadConfig, createDefaultConfig, getResolvedShellConfig, applyCliInitialDir, applyCliShellAndAllowedDirs, applyCliSecurityOverrides, applyCliWslMountPoint, applyCliRestrictions, applyCliLogging, applyCliUnsafeMode, applyDebugLogDirectory, applyCliTransport } from './utils/config.js';
 import { createSerializableConfig, createResolvedConfigSummary } from './utils/configUtils.js';
 import type { ServerConfig, ResolvedShellConfig, GlobalConfig, LoggingConfig } from './types/config.js';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -158,6 +158,19 @@ const parseArgs = async () => {
     .option('logDirectory', {
       type: 'string',
       description: 'Directory to store command output log files (enables file-based logging)'
+    })
+    .option('transport', {
+      type: 'string',
+      choices: ['stdio', 'sse'],
+      description: 'Transport protocol (default: stdio)'
+    })
+    .option('sse-host', {
+      type: 'string',
+      description: 'Host address for SSE transport (default: 127.0.0.1)'
+    })
+    .option('sse-port', {
+      type: 'number',
+      description: 'Port for SSE transport (default: 9444)'
     })
     .help()
     .parse();
@@ -1431,6 +1444,12 @@ const main = async () => {
       unsafe: args.unsafe as boolean | undefined,
       yolo: args.yolo as boolean | undefined
     });
+    applyCliTransport(
+      config,
+      args.transport as string | undefined,
+      args['sse-host'] as string | undefined,
+      args['sse-port'] as number | undefined
+    );
 
     const server = new CLIServer(config);
     await server.run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,10 @@ const parseArgs = async () => {
       type: 'number',
       description: 'Port for SSE transport (default: 9444)'
     })
+    .option('sse-allowed-origins', {
+      type: 'string',
+      description: 'Comma-separated browser origins allowed to use the SSE transport, in addition to loopback hosts and the bind host (e.g. "https://app.example.com,192.168.1.10"). Required for browser clients when binding to 0.0.0.0.'
+    })
     .help()
     .parse();
 };
@@ -428,6 +432,33 @@ class CLIServer {
       `Validation error: ${message}`,
       -1
     );
+  }
+
+  /**
+   * Resolve a working directory to an absolute path anchored to this session's
+   * active directory. A relative `workingDir` would otherwise be handed to
+   * spawn({ cwd }) verbatim and resolved against the process-global cwd, which
+   * set_current_directory mutates via process.chdir(). Because that global is
+   * shared by every concurrent SSE session, one client's set_current_directory
+   * could silently change the base another client's relative path resolves
+   * against. Anchoring relative paths to session.activeCwd keeps each session
+   * isolated. Absolute paths (Windows drive/UNC or POSIX/WSL `/`-rooted) are
+   * returned unchanged, as is any path when the session has no active directory.
+   */
+  private resolveWorkingDirForSession(workingDir: string, session: SessionState): string {
+    const isAbsolute = workingDir.startsWith('/') || path.win32.isAbsolute(workingDir);
+    if (isAbsolute) {
+      return workingDir;
+    }
+    const base = session.activeCwd;
+    if (!base) {
+      return workingDir;
+    }
+    // Resolve with the path flavor of the base so the result keeps the base's
+    // separator style (POSIX for `/`-rooted WSL paths, Windows otherwise).
+    return base.startsWith('/')
+      ? path.posix.resolve(base, workingDir)
+      : path.win32.resolve(base, workingDir);
   }
 
   private async executeShellCommand(
@@ -1006,6 +1037,10 @@ class CLIServer {
           let workingDir: string;
           if (args.workingDir) {
             workingDir = normalizePathForShell(args.workingDir, context);
+            // Anchor a relative workingDir to this session's active directory so
+            // it never resolves against the shared process-global cwd (which
+            // another SSE session can change via set_current_directory).
+            workingDir = this.resolveWorkingDirForSession(workingDir, session);
             if (shellConfig.security.restrictWorkingDirectory) {
               try {
                 validateWorkingDirectoryWithContext(workingDir, context);
@@ -1447,13 +1482,15 @@ class CLIServer {
       const { createSseServer } = await import('./utils/transport.js');
       const host = this.config.transport.sseHost ?? '127.0.0.1';
       const port = this.config.transport.ssePort ?? 9444;
+      const allowedOrigins = this.config.transport.sseAllowedOrigins ?? [];
       this.httpServer = await createSseServer(
         // Each SSE connection gets a fresh SessionState seeded from the primary
         // session's initial cwd, so one client's set_current_directory cannot
         // change another client's active working directory.
         () => this.createServerInstance({ activeCwd: this.primarySession.activeCwd }),
         host,
-        port
+        port,
+        allowedOrigins
       );
       debugLog(`Windows CLI MCP Server running on SSE at http://${host}:${port}`);
     } else {
@@ -1543,7 +1580,8 @@ const main = async () => {
       config,
       args.transport as string | undefined,
       args['sse-host'] as string | undefined,
-      args['sse-port'] as number | undefined
+      args['sse-port'] as number | undefined,
+      args['sse-allowed-origins'] as string | undefined
     );
 
     const server = new CLIServer(config);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -243,6 +243,16 @@ export interface TransportConfig {
   mode: 'stdio' | 'sse';
   sseHost: string;
   ssePort: number;
+  /**
+   * Browser origins permitted to use the SSE transport in addition to loopback
+   * hosts and the configured `sseHost`. Each entry is an origin URL
+   * (`https://app.example.com`) or a bare host (`192.168.1.10`); only the host
+   * component is compared, case-insensitively. Required to admit browser
+   * clients when binding to a wildcard address (`0.0.0.0` / `::`), where the
+   * bind host is not a usable origin, and for reverse-proxy deployments whose
+   * public hostname differs from the bind host. Defaults to an empty list.
+   */
+  sseAllowedOrigins?: string[];
 }
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -236,6 +236,16 @@ export interface WslShellConfig extends BaseShellConfig {
 }
 
 /**
+ * Transport protocol configuration for the MCP server.
+ * Controls how clients connect to the server (stdio or HTTP/SSE).
+ */
+export interface TransportConfig {
+  mode: 'stdio' | 'sse';
+  sseHost: string;
+  ssePort: number;
+}
+
+/**
  * Complete server configuration
  */
 export interface ServerConfig {
@@ -243,7 +253,7 @@ export interface ServerConfig {
    * Global configuration that applies to all shells by default
    */
   global: GlobalConfig;
-  
+
   /**
    * Configuration for specific shell types
    */
@@ -254,6 +264,11 @@ export interface ServerConfig {
     bash?: WslShellConfig;
     wsl?: WslShellConfig;
   };
+
+  /**
+   * Transport protocol configuration (default: stdio)
+   */
+  transport?: TransportConfig;
 }
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -596,6 +596,31 @@ function validateLoggingConfig(config?: LoggingConfig): void {
   }
 }
 
+function validateTransportConfig(transport?: TransportConfig): void {
+  if (!transport) return;
+
+  if (transport.mode !== 'stdio' && transport.mode !== 'sse') {
+    throw new Error("transport.mode must be 'stdio' or 'sse'");
+  }
+
+  if (transport.sseHost !== undefined) {
+    if (typeof transport.sseHost !== 'string' || transport.sseHost.trim() === '') {
+      throw new Error('transport.sseHost must be a non-empty string');
+    }
+  }
+
+  if (transport.ssePort !== undefined) {
+    if (
+      typeof transport.ssePort !== 'number' ||
+      !Number.isInteger(transport.ssePort) ||
+      transport.ssePort < 1 ||
+      transport.ssePort > 65535
+    ) {
+      throw new Error('transport.ssePort must be an integer between 1 and 65535');
+    }
+  }
+}
+
 export function validateConfig(config: ServerConfig): void {
   // Validate security settings
   if (config.global.security.maxCommandLength < 1) {
@@ -616,6 +641,10 @@ export function validateConfig(config: ServerConfig): void {
 
   // Validate logging configuration
   validateLoggingConfig(config.global.logging);
+
+  // Validate transport configuration (catches malformed config-file values such
+  // as a string ssePort that would otherwise be treated as a named-pipe path)
+  validateTransportConfig(config.transport);
 }
 
 // Helper function to create a default config file

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { ServerConfig, ResolvedShellConfig, WslShellConfig, BaseShellConfig, LoggingConfig } from '../types/config.js';
+import { ServerConfig, ResolvedShellConfig, WslShellConfig, BaseShellConfig, LoggingConfig, TransportConfig } from '../types/config.js';
 import { normalizeWindowsPath, normalizeAllowedPaths } from './validation.js';
 import { resolveShellConfiguration, applyWslPathInheritance } from './configMerger.js';
 import { debugWarn, errorLog } from './log.js';
@@ -120,6 +120,11 @@ export const DEFAULT_CONFIG: ServerConfig = {
         inheritGlobalPaths: true
       }
     }
+  },
+  transport: {
+    mode: 'stdio',
+    sseHost: '127.0.0.1',
+    ssePort: 9444
   }
 };
 
@@ -478,12 +483,16 @@ export function mergeConfigs(defaultConfig: ServerConfig, userConfig: Partial<Se
     }
   }
 
+  // Merge transport config
+  if (defaultConfig.transport || (userConfig as any).transport) {
+    merged.transport = {
+      ...defaultConfig.transport,
+      ...((userConfig as any).transport || {})
+    };
+  }
+
   return merged;
 }
-
-/**
- * Validates logging configuration values
- */
 function validateLoggingConfig(config?: LoggingConfig): void {
   if (!config) return;
 
@@ -853,5 +862,36 @@ export function applyCliUnsafeMode(
         shell.overrides.restrictions.blockedOperators = [];
       }
     }
+  }
+}
+
+export function applyCliTransport(
+  config: ServerConfig,
+  transport?: string,
+  sseHost?: string,
+  ssePort?: number
+): void {
+  if (!config.transport) {
+    config.transport = {
+      mode: 'stdio',
+      sseHost: '127.0.0.1',
+      ssePort: 9444
+    };
+  }
+
+  if (transport === 'sse') {
+    config.transport.mode = 'sse';
+  } else if (transport === 'stdio') {
+    config.transport.mode = 'stdio';
+  }
+
+  if (sseHost !== undefined && sseHost.trim() !== '') {
+    config.transport.sseHost = sseHost.trim();
+  }
+
+  if (ssePort !== undefined && ssePort > 0 && ssePort <= 65535) {
+    config.transport.ssePort = ssePort;
+  } else if (ssePort !== undefined) {
+    debugWarn(`WARN: Invalid ssePort '${ssePort}', ignoring.`);
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -918,7 +918,12 @@ export function applyCliTransport(
     config.transport.sseHost = sseHost.trim();
   }
 
-  if (ssePort !== undefined && ssePort > 0 && ssePort <= 65535) {
+  if (
+    ssePort !== undefined &&
+    Number.isInteger(ssePort) &&
+    ssePort > 0 &&
+    ssePort <= 65535
+  ) {
     config.transport.ssePort = ssePort;
   } else if (ssePort !== undefined) {
     debugWarn(`WARN: Invalid ssePort '${ssePort}', ignoring.`);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -124,7 +124,8 @@ export const DEFAULT_CONFIG: ServerConfig = {
   transport: {
     mode: 'stdio',
     sseHost: '127.0.0.1',
-    ssePort: 9444
+    ssePort: 9444,
+    sseAllowedOrigins: []
   }
 };
 
@@ -619,6 +620,17 @@ function validateTransportConfig(transport?: TransportConfig): void {
       throw new Error('transport.ssePort must be an integer between 1 and 65535');
     }
   }
+
+  if (transport.sseAllowedOrigins !== undefined) {
+    if (
+      !Array.isArray(transport.sseAllowedOrigins) ||
+      transport.sseAllowedOrigins.some(
+        origin => typeof origin !== 'string' || origin.trim() === ''
+      )
+    ) {
+      throw new Error('transport.sseAllowedOrigins must be an array of non-empty strings');
+    }
+  }
 }
 
 export function validateConfig(config: ServerConfig): void {
@@ -898,13 +910,15 @@ export function applyCliTransport(
   config: ServerConfig,
   transport?: string,
   sseHost?: string,
-  ssePort?: number
+  ssePort?: number,
+  sseAllowedOrigins?: string
 ): void {
   if (!config.transport) {
     config.transport = {
       mode: 'stdio',
       sseHost: '127.0.0.1',
-      ssePort: 9444
+      ssePort: 9444,
+      sseAllowedOrigins: []
     };
   }
 
@@ -927,5 +941,15 @@ export function applyCliTransport(
     config.transport.ssePort = ssePort;
   } else if (ssePort !== undefined) {
     debugWarn(`WARN: Invalid ssePort '${ssePort}', ignoring.`);
+  }
+
+  if (sseAllowedOrigins !== undefined) {
+    const origins = sseAllowedOrigins
+      .split(',')
+      .map(origin => origin.trim())
+      .filter(origin => origin !== '');
+    if (origins.length > 0) {
+      config.transport.sseAllowedOrigins = origins;
+    }
   }
 }

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -89,6 +89,16 @@ export function createSerializableConfig(config: ServerConfig): any {
     serializable.shells[shellName] = shellInfo;
   }
 
+  // Include the active transport configuration so clients can inspect the
+  // real connection settings (mode/host/port) via get_config and cli://config.
+  if (config.transport) {
+    serializable.transport = {
+      mode: config.transport.mode,
+      sseHost: config.transport.sseHost,
+      ssePort: config.transport.ssePort
+    };
+  }
+
   return serializable;
 }
 

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -18,12 +18,21 @@ export function createSseServer(
         const transport = new SSEServerTransport('/messages', res);
         sessions.set(transport.sessionId, transport);
 
+        await mcpServer.connect(transport);
+
+        // mcpServer.connect() assigns its own transport.onclose handler, so any
+        // handler set before connect() is overwritten. Register session cleanup
+        // afterward and chain to the SDK handler so the MCP server's own
+        // teardown still runs. Without this the session is never removed from
+        // the map on disconnect, leaking entries and making later POSTs to the
+        // dead session return 500 instead of 404.
+        const mcpOnClose = transport.onclose;
         transport.onclose = () => {
           sessions.delete(transport.sessionId);
           debugLog(`SSE session closed: ${transport.sessionId}`);
+          mcpOnClose?.();
         };
 
-        await mcpServer.connect(transport);
         debugLog(`SSE session established: ${transport.sessionId}`);
       } catch (err) {
         errorLog('Error establishing SSE connection:', err);

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -75,8 +75,22 @@ export function createSseServer(
 }
 
 export function closeSseServer(server: http.Server): Promise<void> {
+  // http.Server.close() only stops accepting new connections and waits for
+  // existing ones to end on their own. SSE streams are long-lived, so without
+  // forcibly destroying open sockets the server never finishes closing and the
+  // event loop stays alive (surfacing as the Jest "worker failed to exit
+  // gracefully" warning). closeAllConnections() was added in Node 18.2, so it
+  // is called defensively to remain compatible with older 18.x runtimes.
+  const destroyOpenConnections = () => {
+    const closeAll = (server as { closeAllConnections?: () => void }).closeAllConnections;
+    if (typeof closeAll === 'function') {
+      closeAll.call(server);
+    }
+  };
+
   return new Promise((resolve, reject) => {
     if (!server.listening) {
+      destroyOpenConnections();
       resolve();
       return;
     }
@@ -87,5 +101,7 @@ export function closeSseServer(server: http.Server): Promise<void> {
         resolve();
       }
     });
+    // Destroy lingering sockets so close() can complete promptly.
+    destroyOpenConnections();
   });
 }

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -1,0 +1,92 @@
+import http from 'http';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { debugLog, errorLog } from './log.js';
+
+export function createSseServer(
+  mcpServer: Server,
+  host: string,
+  port: number
+): Promise<http.Server> {
+  const sessions = new Map<string, SSEServerTransport>();
+
+  const httpServer = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+
+    if (req.method === 'GET' && url.pathname === '/sse') {
+      try {
+        const transport = new SSEServerTransport('/messages', res);
+        sessions.set(transport.sessionId, transport);
+
+        transport.onclose = () => {
+          sessions.delete(transport.sessionId);
+          debugLog(`SSE session closed: ${transport.sessionId}`);
+        };
+
+        await transport.start();
+        await mcpServer.connect(transport);
+        debugLog(`SSE session established: ${transport.sessionId}`);
+      } catch (err) {
+        errorLog('Error establishing SSE connection:', err);
+        if (!res.headersSent) {
+          res.writeHead(500);
+          res.end('Internal Server Error');
+        }
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/messages') {
+      const sessionId = url.searchParams.get('sessionId');
+      if (!sessionId) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Missing sessionId parameter' }));
+        return;
+      }
+
+      const transport = sessions.get(sessionId);
+      if (!transport) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Session not found' }));
+        return;
+      }
+
+      try {
+        await transport.handlePostMessage(req, res);
+      } catch (err) {
+        errorLog('Error handling POST message:', err);
+        if (!res.headersSent) {
+          res.writeHead(500);
+          res.end('Internal Server Error');
+        }
+      }
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  return new Promise((resolve, reject) => {
+    httpServer.on('error', reject);
+    httpServer.listen(port, host, () => {
+      resolve(httpServer);
+    });
+  });
+}
+
+export function closeSseServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -14,19 +14,55 @@ const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 const serverSockets = new WeakMap<http.Server, Set<Socket>>();
 
 /**
+ * Extract the lowercased host from a configured allowed-origin entry. Accepts
+ * either a full origin URL (`https://app.example.com:8443`) or a bare host
+ * (`app.example.com`, `192.168.1.10`); only the host component is compared,
+ * matching the host-only comparison used for the bind host. Returns `undefined`
+ * for values that cannot be parsed into a host.
+ */
+function parseAllowedOriginHost(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    // Bare host without a scheme. Retry with a dummy scheme so `URL` can still
+    // parse `host` and `host:port` forms.
+    try {
+      return new URL(`http://${trimmed}`).hostname.toLowerCase();
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/**
  * Decide whether an incoming request's `Origin` header may use the SSE
  * transport. Requests with no `Origin` header are treated as non-browser
  * clients (native MCP clients, curl) and are permitted. A present `Origin` must
- * point at a loopback host or the configured bind host; everything else --
- * including malformed values and the literal `null` origin used by sandboxed
- * iframes and `file://` pages -- is rejected.
+ * point at a loopback host, the configured bind host, or one of the explicitly
+ * configured `allowedOrigins`; everything else -- including malformed values
+ * and the literal `null` origin used by sandboxed iframes and `file://` pages
+ * -- is rejected.
  *
  * This blocks DNS-rebinding attacks: the browser sets `Origin` to the page's own
  * domain (for example `https://evil.example`), not the rebound `127.0.0.1`
  * address, so allowlisting trusted origins rejects the attacker even when their
  * domain resolves to loopback.
+ *
+ * The `allowedOrigins` list is required to admit browser clients when binding to
+ * a wildcard address (`0.0.0.0` / `::`): the bind host is then not a usable
+ * origin to compare against, and a reverse-proxy deployment whose public
+ * hostname differs from the bind host needs its origin listed explicitly. The
+ * list is empty by default, so the loopback-only default behavior is unchanged.
  */
-export function isOriginAllowed(originHeader: string | undefined, bindHost: string): boolean {
+export function isOriginAllowed(
+  originHeader: string | undefined,
+  bindHost: string,
+  allowedOrigins: readonly string[] = []
+): boolean {
   // No Origin header => non-browser client. Allow.
   if (originHeader === undefined) {
     return true;
@@ -45,7 +81,16 @@ export function isOriginAllowed(originHeader: string | undefined, bindHost: stri
   if (LOOPBACK_HOSTS.has(hostname)) {
     return true;
   }
-  return bindHost.trim() !== '' && hostname === bindHost.trim().toLowerCase();
+  if (bindHost.trim() !== '' && hostname === bindHost.trim().toLowerCase()) {
+    return true;
+  }
+  // Explicitly configured origins (compared by host).
+  for (const allowed of allowedOrigins) {
+    if (parseAllowedOriginHost(allowed) === hostname) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -64,7 +109,8 @@ function corsOriginToEcho(originHeader: string | undefined): string | undefined 
 export function createSseServer(
   createServer: () => Server,
   host: string,
-  port: number
+  port: number,
+  allowedOrigins: readonly string[] = []
 ): Promise<http.Server> {
   const sessions = new Map<string, SSEServerTransport>();
 
@@ -86,7 +132,7 @@ export function createSseServer(
 
     // Reject browser requests from untrusted origins before doing any work
     // (DNS-rebinding defense). Non-browser clients send no Origin and pass.
-    if (!isOriginAllowed(req.headers.origin, host)) {
+    if (!isOriginAllowed(req.headers.origin, host, allowedOrigins)) {
       errorLog(`Rejected SSE request from disallowed origin: ${req.headers.origin}`);
       res.writeHead(403, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Forbidden origin' }));
@@ -137,21 +183,26 @@ export function createSseServer(
         const sessionServer = createServer();
         sessions.set(transport.sessionId, transport);
 
-        await sessionServer.connect(transport);
-
-        // sessionServer.connect() assigns its own transport.onclose handler, so
-        // any handler set before connect() is overwritten. Register session
-        // cleanup afterward and chain to the SDK handler so the MCP server's own
-        // teardown still runs. Without this the session is never removed from
-        // the map on disconnect, leaking entries and making later POSTs to the
-        // dead session return 500 instead of 404. The per-session server holds no
-        // OS resources once its transport closes, so it is left for GC.
-        const mcpOnClose = transport.onclose;
-        transport.onclose = () => {
+        // Prune the session as soon as its underlying response closes. This is
+        // registered on `res` *before* connect() rather than by overwriting
+        // transport.onclose afterward, which closes a race: connect() calls
+        // transport.start(), which writes the SSE headers and attaches the SDK's
+        // own `res` close listener while connect() is still awaiting. A client
+        // that opens /sse and immediately disconnects can fire that listener
+        // before execution returns here, so an after-the-fact onclose handler
+        // would never run -- leaking this map entry and making later POSTs to the
+        // dead session return 500 instead of 404. Listening on `res` directly is
+        // race-free because the listener is in place before the response can
+        // close. The SDK transport still runs its own onclose for protocol
+        // teardown; this listener only removes the routing entry, and the
+        // per-session server holds no OS resources once its transport closes, so
+        // it is left for GC.
+        res.on('close', () => {
           sessions.delete(transport.sessionId);
           debugLog(`SSE session closed: ${transport.sessionId}`);
-          mcpOnClose?.();
-        };
+        });
+
+        await sessionServer.connect(transport);
 
         debugLog(`SSE session established: ${transport.sessionId}`);
       } catch (err) {

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import type { Socket } from 'net';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { debugLog, errorLog } from './log.js';
@@ -6,6 +7,11 @@ import { debugLog, errorLog } from './log.js';
 // Loopback hostnames that are always trusted as request origins. `URL.hostname`
 // returns the bracketed form for IPv6, so both `::1` and `[::1]` are listed.
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+// Open TCP sockets tracked per server so closeSseServer() can force-destroy them
+// on Node runtimes that lack http.Server.closeAllConnections() (added in 18.2).
+// Keyed weakly so entries disappear when a server is garbage-collected.
+const serverSockets = new WeakMap<http.Server, Set<Socket>>();
 
 /**
  * Decide whether an incoming request's `Origin` header may use the SSE
@@ -42,6 +48,19 @@ export function isOriginAllowed(originHeader: string | undefined, bindHost: stri
   return bindHost.trim() !== '' && hostname === bindHost.trim().toLowerCase();
 }
 
+/**
+ * Return the `Origin` value to echo back via CORS headers, or `undefined` when
+ * the request is from a non-browser client (no usable Origin). Only call this
+ * after isOriginAllowed() has accepted the request, so a returned value is
+ * guaranteed to be a trusted origin that is safe to reflect.
+ */
+function corsOriginToEcho(originHeader: string | undefined): string | undefined {
+  if (originHeader === undefined || originHeader === 'null' || originHeader.trim() === '') {
+    return undefined;
+  }
+  return originHeader;
+}
+
 export function createSseServer(
   createServer: () => Server,
   host: string,
@@ -50,7 +69,20 @@ export function createSseServer(
   const sessions = new Map<string, SSEServerTransport>();
 
   const httpServer = http.createServer(async (req, res) => {
-    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    // Parse the request URL defensively. A malformed Host header (for example
+    // "%%%%") makes `new URL()` throw; because this callback is async that throw
+    // would surface as an unhandled rejection and, under Node's default policy,
+    // crash the process. Return 400 instead so a bad request cannot take the
+    // server down.
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    } catch {
+      errorLog(`Rejected SSE request with malformed Host header: ${req.headers.host}`);
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Bad Request' }));
+      return;
+    }
 
     // Reject browser requests from untrusted origins before doing any work
     // (DNS-rebinding defense). Non-browser clients send no Origin and pass.
@@ -61,8 +93,42 @@ export function createSseServer(
       return;
     }
 
+    // The origin is trusted at this point. Echo it back so browser EventSource/
+    // fetch clients served from an allowed origin on a different port can read
+    // the responses; without Access-Control-Allow-Origin the browser blocks the
+    // MCP handshake. Non-browser clients send no Origin and get no CORS headers,
+    // preserving prior behavior.
+    const corsOrigin = corsOriginToEcho(req.headers.origin);
+    const applyCors = (): void => {
+      if (corsOrigin) {
+        res.setHeader('Access-Control-Allow-Origin', corsOrigin);
+        res.setHeader('Vary', 'Origin');
+      }
+    };
+    const corsHeaders = (extra: http.OutgoingHttpHeaders = {}): http.OutgoingHttpHeaders =>
+      corsOrigin
+        ? { ...extra, 'Access-Control-Allow-Origin': corsOrigin, Vary: 'Origin' }
+        : extra;
+
+    // Answer CORS preflight requests. A cross-origin `POST /messages` with
+    // `application/json` triggers an OPTIONS preflight that would otherwise fall
+    // through to 404 and block the real request.
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, corsHeaders({
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Max-Age': '86400',
+      }));
+      res.end();
+      return;
+    }
+
     if (req.method === 'GET' && url.pathname === '/sse') {
       try {
+        // Set CORS headers before the transport writes its own SSE headers;
+        // writeHead() merges previously set headers, so the echoed origin
+        // survives onto the 200 event-stream response.
+        applyCors();
         const transport = new SSEServerTransport('/messages', res);
         // Each SSE connection gets its own MCP server instance. The MCP Protocol
         // object owns a single transport at a time (connect() overwrites
@@ -91,7 +157,7 @@ export function createSseServer(
       } catch (err) {
         errorLog('Error establishing SSE connection:', err);
         if (!res.headersSent) {
-          res.writeHead(500);
+          res.writeHead(500, corsHeaders());
           res.end('Internal Server Error');
         }
       }
@@ -101,32 +167,43 @@ export function createSseServer(
     if (req.method === 'POST' && url.pathname === '/messages') {
       const sessionId = url.searchParams.get('sessionId');
       if (!sessionId) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.writeHead(400, corsHeaders({ 'Content-Type': 'application/json' }));
         res.end(JSON.stringify({ error: 'Missing sessionId parameter' }));
         return;
       }
 
       const transport = sessions.get(sessionId);
       if (!transport) {
-        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.writeHead(404, corsHeaders({ 'Content-Type': 'application/json' }));
         res.end(JSON.stringify({ error: 'Session not found' }));
         return;
       }
 
       try {
+        // Echo CORS before handlePostMessage writes the 202/4xx response.
+        applyCors();
         await transport.handlePostMessage(req, res);
       } catch (err) {
         errorLog('Error handling POST message:', err);
         if (!res.headersSent) {
-          res.writeHead(500);
+          res.writeHead(500, corsHeaders());
           res.end('Internal Server Error');
         }
       }
       return;
     }
 
-    res.writeHead(404);
+    res.writeHead(404, corsHeaders());
     res.end('Not Found');
+  });
+
+  // Track open sockets so closeSseServer() can force them closed even on Node
+  // runtimes without closeAllConnections() (see closeSseServer below).
+  const openSockets = new Set<Socket>();
+  serverSockets.set(httpServer, openSockets);
+  httpServer.on('connection', (socket) => {
+    openSockets.add(socket);
+    socket.once('close', () => openSockets.delete(socket));
   });
 
   return new Promise((resolve, reject) => {
@@ -142,13 +219,18 @@ export function closeSseServer(server: http.Server): Promise<void> {
   // existing ones to end on their own. SSE streams are long-lived, so without
   // forcibly destroying open sockets the server never finishes closing and the
   // event loop stays alive (surfacing as the Jest "worker failed to exit
-  // gracefully" warning). closeAllConnections() was added in Node 18.2, so it
-  // is called defensively to remain compatible with older 18.x runtimes.
+  // gracefully" warning).
   const destroyOpenConnections = () => {
     const closeAll = (server as { closeAllConnections?: () => void }).closeAllConnections;
     if (typeof closeAll === 'function') {
       closeAll.call(server);
+      return;
     }
+    // closeAllConnections() was added in Node 18.2. On 18.0/18.1 it is
+    // undefined, so destroy the sockets tracked at accept time instead;
+    // otherwise close() would hang waiting for active SSE streams to end.
+    const openSockets = serverSockets.get(server);
+    openSockets?.forEach((socket) => socket.destroy());
   };
 
   return new Promise((resolve, reject) => {

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -23,7 +23,6 @@ export function createSseServer(
           debugLog(`SSE session closed: ${transport.sessionId}`);
         };
 
-        await transport.start();
         await mcpServer.connect(transport);
         debugLog(`SSE session established: ${transport.sessionId}`);
       } catch (err) {

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -3,8 +3,47 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { debugLog, errorLog } from './log.js';
 
+// Loopback hostnames that are always trusted as request origins. `URL.hostname`
+// returns the bracketed form for IPv6, so both `::1` and `[::1]` are listed.
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+/**
+ * Decide whether an incoming request's `Origin` header may use the SSE
+ * transport. Requests with no `Origin` header are treated as non-browser
+ * clients (native MCP clients, curl) and are permitted. A present `Origin` must
+ * point at a loopback host or the configured bind host; everything else --
+ * including malformed values and the literal `null` origin used by sandboxed
+ * iframes and `file://` pages -- is rejected.
+ *
+ * This blocks DNS-rebinding attacks: the browser sets `Origin` to the page's own
+ * domain (for example `https://evil.example`), not the rebound `127.0.0.1`
+ * address, so allowlisting trusted origins rejects the attacker even when their
+ * domain resolves to loopback.
+ */
+export function isOriginAllowed(originHeader: string | undefined, bindHost: string): boolean {
+  // No Origin header => non-browser client. Allow.
+  if (originHeader === undefined) {
+    return true;
+  }
+  // The literal "null" origin and empty values are untrusted.
+  if (originHeader === 'null' || originHeader.trim() === '') {
+    return false;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(originHeader).hostname.toLowerCase();
+  } catch {
+    // Malformed Origin header.
+    return false;
+  }
+  if (LOOPBACK_HOSTS.has(hostname)) {
+    return true;
+  }
+  return bindHost.trim() !== '' && hostname === bindHost.trim().toLowerCase();
+}
+
 export function createSseServer(
-  mcpServer: Server,
+  createServer: () => Server,
   host: string,
   port: number
 ): Promise<http.Server> {
@@ -13,19 +52,34 @@ export function createSseServer(
   const httpServer = http.createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
 
+    // Reject browser requests from untrusted origins before doing any work
+    // (DNS-rebinding defense). Non-browser clients send no Origin and pass.
+    if (!isOriginAllowed(req.headers.origin, host)) {
+      errorLog(`Rejected SSE request from disallowed origin: ${req.headers.origin}`);
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Forbidden origin' }));
+      return;
+    }
+
     if (req.method === 'GET' && url.pathname === '/sse') {
       try {
         const transport = new SSEServerTransport('/messages', res);
+        // Each SSE connection gets its own MCP server instance. The MCP Protocol
+        // object owns a single transport at a time (connect() overwrites
+        // this._transport), so sharing one server across sessions would misroute
+        // a session's responses to the most recently connected stream.
+        const sessionServer = createServer();
         sessions.set(transport.sessionId, transport);
 
-        await mcpServer.connect(transport);
+        await sessionServer.connect(transport);
 
-        // mcpServer.connect() assigns its own transport.onclose handler, so any
-        // handler set before connect() is overwritten. Register session cleanup
-        // afterward and chain to the SDK handler so the MCP server's own
+        // sessionServer.connect() assigns its own transport.onclose handler, so
+        // any handler set before connect() is overwritten. Register session
+        // cleanup afterward and chain to the SDK handler so the MCP server's own
         // teardown still runs. Without this the session is never removed from
         // the map on disconnect, leaking entries and making later POSTs to the
-        // dead session return 500 instead of 404.
+        // dead session return 500 instead of 404. The per-session server holds no
+        // OS resources once its transport closes, so it is left for GC.
         const mcpOnClose = transport.onclose;
         transport.onclose = () => {
           sessions.delete(transport.sessionId);

--- a/tests/configValidation.test.ts
+++ b/tests/configValidation.test.ts
@@ -32,4 +32,57 @@ describe('validateConfig helper', () => {
     const cfg = cloneDefault();
     expect(() => validateConfig(cfg)).not.toThrow();
   });
+
+  // P4: validateConfig must check the transport section, not only CLI flags.
+  describe('transport section (P4)', () => {
+    test('throws for non-numeric ssePort from config file', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: '3000' as any };
+      expect(() => validateConfig(cfg)).toThrow(
+        'transport.ssePort must be an integer between 1 and 65535'
+      );
+    });
+
+    test('throws for ssePort below 1', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
+      expect(() => validateConfig(cfg)).toThrow(/transport\.ssePort/);
+    });
+
+    test('throws for ssePort above 65535', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 70000 };
+      expect(() => validateConfig(cfg)).toThrow(/transport\.ssePort/);
+    });
+
+    test('throws for non-integer ssePort', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 3000.5 };
+      expect(() => validateConfig(cfg)).toThrow(/transport\.ssePort/);
+    });
+
+    test('throws for invalid mode', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'http' as any, sseHost: '127.0.0.1', ssePort: 9444 };
+      expect(() => validateConfig(cfg)).toThrow("transport.mode must be 'stdio' or 'sse'");
+    });
+
+    test('throws for empty sseHost', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '   ', ssePort: 9444 };
+      expect(() => validateConfig(cfg)).toThrow('transport.sseHost must be a non-empty string');
+    });
+
+    test('passes for valid sse transport', () => {
+      const cfg = cloneDefault();
+      cfg.transport = { mode: 'sse', sseHost: '0.0.0.0', ssePort: 3000 };
+      expect(() => validateConfig(cfg)).not.toThrow();
+    });
+
+    test('passes when transport section is absent', () => {
+      const cfg = cloneDefault();
+      cfg.transport = undefined;
+      expect(() => validateConfig(cfg)).not.toThrow();
+    });
+  });
 });

--- a/tests/documentation/configExamples.test.ts
+++ b/tests/documentation/configExamples.test.ts
@@ -102,4 +102,24 @@ describe('Configuration Examples', () => {
       expect(config.shells.cmd?.enabled).toBe(true);
     }
   });
+
+  // P3: the README must not advertise an unauthenticated bind-all-interfaces
+  // example and must warn before binding to a non-loopback address.
+  describe('README SSE transport documentation (P3)', () => {
+    const readme = fs.readFileSync(path.join(process.cwd(), 'README.md'), 'utf8');
+
+    test('does not present a runnable 0.0.0.0 SSE example', () => {
+      expect(readme).not.toMatch(/npx wcli0 --transport sse --sse-host 0\.0\.0\.0/);
+    });
+
+    test('documents the custom-port example bound to localhost', () => {
+      expect(readme).toMatch(/--sse-host 127\.0\.0\.1 --sse-port 3000/);
+    });
+
+    test('includes a security warning about binding to all interfaces', () => {
+      const warning = readme.match(/> \*\*Security:\*\*[\s\S]*?authenticated[\s\S]*?\n\n/i);
+      expect(warning).not.toBeNull();
+      expect(warning![0]).toMatch(/0\.0\.0\.0/);
+    });
+  });
 });

--- a/tests/getConfig.test.ts
+++ b/tests/getConfig.test.ts
@@ -184,6 +184,27 @@ describe('get_config tool', () => {
     expect(Object.keys(safeConfig.shells)).toHaveLength(0);
   });
 
+  test('P10: createSerializableConfig includes transport section when present', () => {
+    const configWithTransport: ServerConfig = {
+      ...testConfig,
+      transport: { mode: 'sse', sseHost: '0.0.0.0', ssePort: 3000 }
+    };
+
+    const safeConfig = createSerializableConfig(configWithTransport);
+
+    expect(safeConfig.transport).toEqual({
+      mode: 'sse',
+      sseHost: '0.0.0.0',
+      ssePort: 3000
+    });
+  });
+
+  test('P10: createSerializableConfig omits transport when absent', () => {
+    const safeConfig = createSerializableConfig(testConfig);
+
+    expect(safeConfig.transport).toBeUndefined();
+  });
+
   test('createSerializableConfig omits restrictions when injection protection disabled', () => {
     const disabledConfig: ServerConfig = {
       ...testConfig,

--- a/tests/helpers/InMemoryTransport.ts
+++ b/tests/helpers/InMemoryTransport.ts
@@ -1,0 +1,38 @@
+import type { Transport } from '@modelcontextprotocol/sdk/dist/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/dist/types.js';
+
+export class InMemoryTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  private _other: InMemoryTransport | null = null;
+
+  private constructor() {}
+
+  static createConnectedPair(): [InMemoryTransport, InMemoryTransport] {
+    const client = new InMemoryTransport();
+    const server = new InMemoryTransport();
+    client._other = server;
+    server._other = client;
+    return [client, server];
+  }
+
+  async start(): Promise<void> {
+    // no-op for in-memory
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this._other) {
+      throw new Error('Not connected');
+    }
+    this._other.onmessage?.(message);
+  }
+
+  async close(): Promise<void> {
+    const other = this._other;
+    this._other = null;
+    other?.onclose?.();
+    this.onclose?.();
+  }
+}

--- a/tests/helpers/SseTestClient.ts
+++ b/tests/helpers/SseTestClient.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import path from 'path';
 import { CLIServer } from '../../src/index.js';
 import { DEFAULT_CONFIG } from '../../src/utils/config.js';
 import type { ServerConfig } from '../../src/types/config.js';
@@ -32,6 +33,31 @@ export class SseTestClient {
     const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
     config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
     config.global.security.restrictWorkingDirectory = false;
+
+    // Set up WSL emulator for cross-platform testing
+    const wslEmulatorPath = path.resolve(process.cwd(), 'scripts/wsl-emulator.js');
+    config.shells.wsl = {
+      type: 'wsl',
+      enabled: true,
+      executable: {
+        command: process.execPath,
+        args: [wslEmulatorPath, '-e'],
+      },
+      overrides: {
+        restrictions: { blockedOperators: ['&', '|', ';', '`'] },
+      },
+      wslConfig: { mountPoint: '/mnt/', inheritGlobalPaths: true },
+    };
+
+    // Disable non-WSL shells for cross-platform reliability
+    if (config.shells.powershell) config.shells.powershell.enabled = false;
+    if (config.shells.cmd) config.shells.cmd.enabled = false;
+    if (config.shells.gitbash) config.shells.gitbash.enabled = false;
+    if (config.shells.bash) config.shells.bash.enabled = false;
+
+    // Allow -e argument for the emulator
+    config.global.restrictions.blockedArguments =
+      (config.global.restrictions.blockedArguments || []).filter((a) => a !== '-e');
 
     // Apply overrides deeply
     if (configOverrides.global) {

--- a/tests/helpers/SseTestClient.ts
+++ b/tests/helpers/SseTestClient.ts
@@ -144,7 +144,7 @@ export class SseTestClient {
 
   async close(): Promise<void> {
     this.stream.destroy();
-    await closeSseServer(this.httpServer);
+    await (this.cliServer as any).cleanup();
   }
 
   get port(): number {

--- a/tests/helpers/SseTestClient.ts
+++ b/tests/helpers/SseTestClient.ts
@@ -1,0 +1,256 @@
+import http from 'http';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import { closeSseServer } from '../../src/utils/transport.js';
+
+let nextId = 1;
+
+export class SseTestClient {
+  private cliServer: CLIServer;
+  private httpServer: http.Server;
+  private sessionId: string;
+  private messages: any[] = [];
+  private stream: http.IncomingMessage;
+  private buffer = '';
+
+  private constructor(
+    cliServer: CLIServer,
+    httpServer: http.Server,
+    sessionId: string,
+    stream: http.IncomingMessage,
+    messages: any[]
+  ) {
+    this.cliServer = cliServer;
+    this.httpServer = httpServer;
+    this.sessionId = sessionId;
+    this.stream = stream;
+    this.messages = messages;
+  }
+
+  static async create(configOverrides: Partial<ServerConfig> = {}): Promise<SseTestClient> {
+    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
+    config.global.security.restrictWorkingDirectory = false;
+
+    // Apply overrides deeply
+    if (configOverrides.global) {
+      if (configOverrides.global.security) {
+        Object.assign(config.global.security, configOverrides.global.security);
+      }
+      if (configOverrides.global.restrictions) {
+        Object.assign(config.global.restrictions, configOverrides.global.restrictions);
+      }
+      if (configOverrides.global.paths) {
+        Object.assign(config.global.paths, configOverrides.global.paths);
+      }
+    }
+    if (configOverrides.shells) {
+      Object.assign(config.shells, configOverrides.shells);
+    }
+    if (configOverrides.transport) {
+      config.transport = configOverrides.transport;
+    }
+
+    const cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const httpServer = (cliServer as any).httpServer as http.Server;
+    const addr = httpServer.address() as http.AddressInfo;
+
+    const { sessionId, messages, stream } = await connectSSE(addr.port);
+
+    // Perform MCP initialize handshake
+    const initResult = await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: nextId++,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+
+    if (initResult.statusCode !== 202) {
+      stream.destroy();
+      await closeSseServer(httpServer);
+      throw new Error(`Initialize failed with status ${initResult.statusCode}`);
+    }
+
+    await waitForMessage(messages, (m: any) => m.result?.serverInfo);
+
+    // Send initialized notification
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    const client = new SseTestClient(cliServer, httpServer, sessionId, stream, messages);
+
+    // Continue collecting messages on the stream
+    stream.on('data', () => {
+      client.parseMessagesFromBuffer();
+    });
+
+    return client;
+  }
+
+  async call(method: string, params?: object): Promise<any> {
+    const id = nextId++;
+    const port = (this.httpServer.address() as http.AddressInfo).port;
+    await postMessage(port, this.sessionId, {
+      jsonrpc: '2.0',
+      id,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    });
+    return waitForMessage(this.messages, (m: any) => m.id === id);
+  }
+
+  async callTool(name: string, args: Record<string, any>): Promise<any> {
+    const response = await this.call('tools/call', { name, arguments: args });
+    if (response.error) {
+      throw new Error(`Tool call error: ${response.error.message}`);
+    }
+    return response.result;
+  }
+
+  async close(): Promise<void> {
+    this.stream.destroy();
+    await closeSseServer(this.httpServer);
+  }
+
+  get port(): number {
+    return (this.httpServer.address() as http.AddressInfo).port;
+  }
+
+  private parseMessagesFromBuffer() {
+    const parts = this.buffer.split('\n\n');
+    for (const part of parts) {
+      const dataMatch = part.match(/^data: (.+)$/m);
+      const eventMatch = part.match(/^event: (.+)$/m);
+      if (dataMatch && eventMatch && eventMatch[1] === 'message') {
+        try {
+          const parsed = JSON.parse(dataMatch[1]);
+          if (!this.messages.some((m) => JSON.stringify(m) === JSON.stringify(parsed))) {
+            this.messages.push(parsed);
+          }
+        } catch {
+          // ignore non-JSON data
+        }
+      }
+    }
+  }
+}
+
+function connectSSE(
+  port: number
+): Promise<{ sessionId: string; messages: any[]; stream: http.IncomingMessage }> {
+  const messages: any[] = [];
+  let buffer = '';
+
+  return new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}/sse`, (stream) => {
+      let sessionId: string | undefined;
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          stream.destroy();
+          reject(new Error('Timed out waiting for endpoint event'));
+        }
+      }, 5000);
+
+      stream.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString();
+
+        if (!sessionId) {
+          const endpointMatch = buffer.match(/data: \/messages\?sessionId=([^\s\n]+)/);
+          if (endpointMatch) {
+            sessionId = endpointMatch[1];
+          }
+        }
+
+        // Parse message events
+        const parts = buffer.split('\n\n');
+        for (const part of parts) {
+          const dataMatch = part.match(/^data: (.+)$/m);
+          const eventMatch = part.match(/^event: (.+)$/m);
+          if (dataMatch && eventMatch && eventMatch[1] === 'message') {
+            try {
+              const parsed = JSON.parse(dataMatch[1]);
+              if (!messages.some((m) => JSON.stringify(m) === JSON.stringify(parsed))) {
+                messages.push(parsed);
+              }
+            } catch {
+              // ignore non-JSON data
+            }
+          }
+        }
+
+        if (sessionId && !resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          resolve({ sessionId, messages, stream });
+        }
+      });
+
+      stream.on('error', (err) => {
+        clearTimeout(timeout);
+        if (!resolved) {
+          reject(err);
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+function postMessage(
+  port: number,
+  sessionId: string,
+  message: object
+): Promise<{ statusCode: number | undefined; body: string }> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(message);
+    const req = http.request(
+      `http://127.0.0.1:${port}/messages?sessionId=${sessionId}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }); });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function waitForMessage(messages: any[], predicate: (m: any) => boolean, timeoutMs = 5000): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const found = messages.find(predicate);
+    if (found) { resolve(found); return; }
+
+    const timer = setTimeout(() => {
+      clearInterval(check);
+      reject(new Error(`Timed out waiting for message. Collected: ${JSON.stringify(messages)}`));
+    }, timeoutMs);
+
+    const check = setInterval(() => {
+      const m = messages.find(predicate);
+      if (m) {
+        clearTimeout(timer);
+        clearInterval(check);
+        resolve(m);
+      }
+    }, 50);
+  });
+}

--- a/tests/integration/mcpProtocol.test.ts
+++ b/tests/integration/mcpProtocol.test.ts
@@ -1,11 +1,16 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, afterEach } from '@jest/globals';
 import { TestCLIServer } from '../helpers/TestCLIServer.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '../helpers/InMemoryTransport.js';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
 
 const server = new TestCLIServer({
   global: {
     security: { restrictWorkingDirectory: true },
-    paths: { allowedPaths: [process.cwd()] }
-  }
+    paths: { allowedPaths: [process.cwd()] },
+  },
 });
 
 describe('MCP Protocol Interactions', () => {
@@ -22,5 +27,113 @@ describe('MCP Protocol Interactions', () => {
     const res = await server.callTool('validate_directories', { directories: [process.cwd()] });
     expect(res.isError).toBe(false);
     expect(res.content[0].text).toContain('All specified directories');
+  });
+});
+
+describe('Stdio Protocol Handshake', () => {
+  let cliServer: CLIServer | null = null;
+  let mcpClient: Client | null = null;
+  let clientTransport: InMemoryTransport | null = null;
+
+  afterEach(async () => {
+    if (clientTransport) {
+      await clientTransport.close();
+      clientTransport = null;
+    }
+    mcpClient = null;
+    cliServer = null;
+  });
+
+  function createTestConfig(): ServerConfig {
+    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.global.security.restrictWorkingDirectory = false;
+    return config;
+  }
+
+  async function setupConnectedPair(): Promise<{
+    cliServer: CLIServer;
+    client: Client;
+    clientTransport: InMemoryTransport;
+  }> {
+    const config = createTestConfig();
+    const srv = new CLIServer(config);
+    const [clientSide, serverSide] = InMemoryTransport.createConnectedPair();
+
+    await (srv as any).server.connect(serverSide);
+
+    const cl = new Client(
+      { name: 'test-client', version: '1.0.0' },
+      { capabilities: {} }
+    );
+    await cl.connect(clientSide);
+
+    return { cliServer: srv, client: cl, clientTransport: clientSide };
+  }
+
+  test('initialize handshake via stdio', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    // Client.connect() performs initialize automatically
+    expect(cl.getServerVersion()).toBeDefined();
+    expect(cl.getServerVersion()?.name).toBe('wcli0');
+    expect(cl.getServerCapabilities()).toBeDefined();
+  });
+
+  test('initialized notification via stdio', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    // Client.connect() sends initialized notification automatically
+    // Verify we can make subsequent requests (proving handshake completed)
+    const tools = await cl.listTools();
+    expect(tools.tools).toBeDefined();
+    expect(tools.tools.length).toBeGreaterThan(0);
+  });
+
+  test('tools/list via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    const result = await cl.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain('execute_command');
+    expect(toolNames).toContain('get_config');
+    expect(toolNames).toContain('get_current_directory');
+    expect(toolNames).toContain('set_current_directory');
+  });
+
+  test('tools/call via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    const result = await cl.callTool({ name: 'get_config', arguments: {} });
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const cfg = JSON.parse(result.content[0].text as string);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg).toHaveProperty('shells');
+  });
+
+  test('error response on unknown method', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    await expect(
+      cl.request(
+        { method: 'nonexistent/method', params: {} },
+        { timeout: 5000 }
+      )
+    ).rejects.toThrow();
   });
 });

--- a/tests/integration/mcpProtocol.test.ts
+++ b/tests/integration/mcpProtocol.test.ts
@@ -137,3 +137,92 @@ describe('Stdio Protocol Handshake', () => {
     ).rejects.toThrow();
   });
 });
+
+describe('Stdio Resource Handlers', () => {
+  let cliServer: CLIServer | null = null;
+  let mcpClient: Client | null = null;
+  let clientTransport: InMemoryTransport | null = null;
+
+  afterEach(async () => {
+    if (clientTransport) {
+      await clientTransport.close();
+      clientTransport = null;
+    }
+    mcpClient = null;
+    cliServer = null;
+  });
+
+  function createTestConfig(): ServerConfig {
+    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.global.security.restrictWorkingDirectory = false;
+    return config;
+  }
+
+  async function setupConnectedPair(): Promise<{
+    cliServer: CLIServer;
+    client: Client;
+    clientTransport: InMemoryTransport;
+  }> {
+    const config = createTestConfig();
+    const srv = new CLIServer(config);
+    const [clientSide, serverSide] = InMemoryTransport.createConnectedPair();
+
+    await (srv as any).server.connect(serverSide);
+
+    const cl = new Client(
+      { name: 'test-client', version: '1.0.0' },
+      { capabilities: {} }
+    );
+    await cl.connect(clientSide);
+
+    return { cliServer: srv, client: cl, clientTransport: clientSide };
+  }
+
+  test('listResources via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    const result = await cl.listResources();
+    const uris = result.resources.map((r) => r.uri);
+    expect(uris).toContain('cli://config');
+    expect(uris).toContain('cli://config/global');
+    expect(uris).toContain('cli://info/security');
+  });
+
+  test('listResourceTemplates via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    const result = await cl.listResourceTemplates();
+    expect(Array.isArray(result.resourceTemplates)).toBe(true);
+    expect(result.resourceTemplates).toHaveLength(0);
+  });
+
+  test('readResource cli://config via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    const result = await cl.readResource({ uri: 'cli://config' });
+    expect(result.contents[0].mimeType).toBe('application/json');
+    const cfg = JSON.parse(result.contents[0].text as string);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg).toHaveProperty('shells');
+  });
+
+  test('readResource of unknown URI rejects via stdio client', async () => {
+    const { cliServer: srv, client: cl, clientTransport: ct } = await setupConnectedPair();
+    cliServer = srv;
+    mcpClient = cl;
+    clientTransport = ct;
+
+    await expect(
+      cl.readResource({ uri: 'cli://does/not/exist' })
+    ).rejects.toThrow();
+  });
+});

--- a/tests/integration/sse-edge-cases.test.ts
+++ b/tests/integration/sse-edge-cases.test.ts
@@ -1,0 +1,244 @@
+import { describe, test, expect, afterEach } from '@jest/globals';
+import http from 'http';
+import { SseTestClient } from '../helpers/SseTestClient.js';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+
+// --- Raw HTTP helpers (lower-level than SseTestClient, needed to drive
+// disconnect/reconnect and malformed-input scenarios that the client helper
+// intentionally hides). ---
+
+function startSseServer(): Promise<{ cliServer: CLIServer; port: number }> {
+  const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+  config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
+  config.global.security.restrictWorkingDirectory = false;
+  const cliServer = new CLIServer(config);
+  return cliServer.run().then(() => {
+    const httpServer = (cliServer as any).httpServer as http.Server;
+    const addr = httpServer.address() as http.AddressInfo;
+    return { cliServer, port: addr.port };
+  });
+}
+
+function openSseStream(
+  port: number
+): Promise<{ sessionId: string; stream: http.IncomingMessage }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${port}/sse`, (stream) => {
+      let buffer = '';
+      let resolved = false;
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          stream.destroy();
+          reject(new Error('Timed out waiting for endpoint event'));
+        }
+      }, 5000);
+
+      stream.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString();
+        const match = buffer.match(/data: \/messages\?sessionId=([^\s\n]+)/);
+        if (match && !resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          resolve({ sessionId: match[1], stream });
+        }
+      });
+
+      stream.on('error', (err) => {
+        clearTimeout(timeout);
+        if (!resolved) reject(err);
+      });
+    });
+    req.on('error', reject);
+  });
+}
+
+function rawPost(
+  port: number,
+  sessionId: string,
+  body: string,
+  contentType = 'application/json'
+): Promise<{ statusCode: number | undefined; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      `http://127.0.0.1:${port}/messages?sessionId=${sessionId}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': contentType,
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function initBody(id = 1): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' },
+    },
+  });
+}
+
+function notificationBody(): string {
+  return JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('SSE Edge Cases (client helper)', () => {
+  let client: SseTestClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = null;
+    }
+  });
+
+  test('handles multiple concurrent requests on a single session (gap #5)', async () => {
+    client = await SseTestClient.create();
+    const [r1, r2, r3, r4, r5] = await Promise.all([
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo first' }),
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo second' }),
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo third' }),
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo fourth' }),
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo fifth' }),
+    ]);
+    expect(r1.content[0].text).toContain('first');
+    expect(r2.content[0].text).toContain('second');
+    expect(r3.content[0].text).toContain('third');
+    expect(r4.content[0].text).toContain('fourth');
+    expect(r5.content[0].text).toContain('fifth');
+  }, 20000);
+
+  test('delivers a large command output over SSE without truncation (gap #7)', async () => {
+    client = await SseTestClient.create();
+    // maxOutputLines is set above the line count so the full large payload is
+    // returned untruncated, exercising a large single SSE frame end to end.
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'seq 1 2000',
+      maxOutputLines: 5000,
+    });
+    const meta = result.metadata as any;
+    expect(meta.totalLines).toBeGreaterThanOrEqual(2000);
+    expect(meta.returnedLines).toBe(meta.totalLines);
+    expect(meta.wasTruncated).toBe(false);
+    // Spot-check that content from across the large payload survived transit.
+    expect(result.content[0].text).toContain('2000');
+    expect(result.content[0].text).toContain('1000');
+  }, 20000);
+});
+
+describe('SSE Edge Cases (raw HTTP)', () => {
+  let cliServer: CLIServer | null = null;
+  const openStreams: http.IncomingMessage[] = [];
+
+  afterEach(async () => {
+    for (const stream of openStreams) {
+      stream.destroy();
+    }
+    openStreams.length = 0;
+    if (cliServer) {
+      await (cliServer as any).cleanup();
+      cliServer = null;
+    }
+  });
+
+  test('malformed JSON body returns 400 and keeps the session usable (gap #8)', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+    const { sessionId, stream } = await openSseStream(started.port);
+    openStreams.push(stream);
+
+    const bad = await rawPost(started.port, sessionId, 'this is not valid json {{{');
+    expect(bad.statusCode).toBe(400);
+
+    // The connection survives a malformed message: a valid request is accepted.
+    const good = await rawPost(started.port, sessionId, initBody());
+    expect(good.statusCode).toBe(202);
+  });
+
+  test('valid JSON that is not a JSON-RPC message returns 400 (gap #8)', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+    const { sessionId, stream } = await openSseStream(started.port);
+    openStreams.push(stream);
+
+    const resp = await rawPost(
+      started.port,
+      sessionId,
+      JSON.stringify({ not: 'a json-rpc message' })
+    );
+    expect(resp.statusCode).toBe(400);
+  });
+
+  test('non-JSON content-type returns 400 (gap #8)', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+    const { sessionId, stream } = await openSseStream(started.port);
+    openStreams.push(stream);
+
+    const resp = await rawPost(started.port, sessionId, initBody(), 'text/plain');
+    expect(resp.statusCode).toBe(400);
+  });
+
+  test('cleans up the session when the client disconnects (gap #6)', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+    const { sessionId, stream } = await openSseStream(started.port);
+
+    // The session is live: a POST is accepted (not 404).
+    const before = await rawPost(started.port, sessionId, initBody());
+    expect(before.statusCode).toBe(202);
+
+    // Disconnect the client. The server removes the session on the SSE
+    // 'close' event; poll a notification (no reply expected) until gone.
+    stream.destroy();
+
+    let status: number | undefined = before.statusCode;
+    for (let i = 0; i < 60; i++) {
+      await delay(50);
+      const resp = await rawPost(started.port, sessionId, notificationBody());
+      status = resp.statusCode;
+      if (status === 404) break;
+    }
+    expect(status).toBe(404);
+  }, 15000);
+
+  test('allows reconnecting with a fresh session after disconnect (gap #6)', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+
+    const first = await openSseStream(started.port);
+    const firstSession = first.sessionId;
+    first.stream.destroy();
+
+    const second = await openSseStream(started.port);
+    openStreams.push(second.stream);
+
+    expect(second.sessionId).not.toBe(firstSession);
+
+    // The fresh session accepts an initialize handshake.
+    const resp = await rawPost(started.port, second.sessionId, initBody());
+    expect(resp.statusCode).toBe(202);
+  }, 15000);
+});

--- a/tests/integration/sse-edge-cases.test.ts
+++ b/tests/integration/sse-edge-cases.test.ts
@@ -224,6 +224,51 @@ describe('SSE Edge Cases (raw HTTP)', () => {
     expect(status).toBe(404);
   }, 15000);
 
+  test('P13: an immediate disconnect right after connect still cleans up the session', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+
+    // Disconnect the instant the endpoint event arrives -- the closest a test
+    // can get to a client that drops during connect(). The cleanup is registered
+    // on the response's 'close' event before connect() resolves, so the session
+    // entry must still be pruned and a later POST must return 404, not 500.
+    const { sessionId, stream } = await openSseStream(started.port);
+    stream.destroy();
+
+    let status: number | undefined;
+    for (let i = 0; i < 60; i++) {
+      await delay(50);
+      const resp = await rawPost(started.port, sessionId, notificationBody());
+      status = resp.statusCode;
+      if (status === 404) break;
+    }
+    expect(status).toBe(404);
+  }, 15000);
+
+  test('P13: rapid connect/immediate-disconnect cycles do not leak dead sessions', async () => {
+    const started = await startSseServer();
+    cliServer = started.cliServer;
+
+    const deadSessionIds: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const { sessionId, stream } = await openSseStream(started.port);
+      deadSessionIds.push(sessionId);
+      stream.destroy();
+    }
+
+    // Every dropped session must eventually be gone (404), proving none leaked.
+    for (const sessionId of deadSessionIds) {
+      let status: number | undefined;
+      for (let i = 0; i < 60; i++) {
+        await delay(50);
+        const resp = await rawPost(started.port, sessionId, notificationBody());
+        status = resp.statusCode;
+        if (status === 404) break;
+      }
+      expect(status).toBe(404);
+    }
+  }, 30000);
+
   test('allows reconnecting with a fresh session after disconnect (gap #6)', async () => {
     const started = await startSseServer();
     cliServer = started.cliServer;

--- a/tests/integration/sse-resources.test.ts
+++ b/tests/integration/sse-resources.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, afterEach } from '@jest/globals';
+import { SseTestClient } from '../helpers/SseTestClient.js';
+
+describe('SSE Resource Handlers', () => {
+  let client: SseTestClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = null;
+    }
+  });
+
+  test('resources/list returns configuration resources', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/list');
+    expect(response.error).toBeUndefined();
+    const uris = response.result.resources.map((r: any) => r.uri);
+    expect(uris).toContain('cli://config');
+    expect(uris).toContain('cli://config/global');
+    expect(uris).toContain('cli://info/security');
+  });
+
+  test('resources/list includes enabled shell configuration resources', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/list');
+    const uris = response.result.resources.map((r: any) => r.uri);
+    // SseTestClient enables the wsl shell for cross-platform testing.
+    expect(uris).toContain('cli://config/shells/wsl');
+  });
+
+  test('resources/templates/list returns an empty list', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/templates/list');
+    expect(response.error).toBeUndefined();
+    expect(Array.isArray(response.result.resourceTemplates)).toBe(true);
+    expect(response.result.resourceTemplates).toHaveLength(0);
+  });
+
+  test('resources/read cli://config returns parseable JSON config', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/read', { uri: 'cli://config' });
+    expect(response.error).toBeUndefined();
+    const content = response.result.contents[0];
+    expect(content.uri).toBe('cli://config');
+    expect(content.mimeType).toBe('application/json');
+    const cfg = JSON.parse(content.text);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg).toHaveProperty('shells');
+  });
+
+  test('resources/read cli://config/global returns global settings', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/read', { uri: 'cli://config/global' });
+    expect(response.error).toBeUndefined();
+    const cfg = JSON.parse(response.result.contents[0].text);
+    expect(cfg).toHaveProperty('security');
+  });
+
+  test('resources/read cli://info/security returns security information', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/read', { uri: 'cli://info/security' });
+    expect(response.error).toBeUndefined();
+    const info = JSON.parse(response.result.contents[0].text);
+    expect(info).toHaveProperty('globalSettings');
+    expect(info).toHaveProperty('enabledShells');
+  });
+
+  test('resources/read of unknown URI returns an error', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('resources/read', { uri: 'cli://does/not/exist' });
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toContain('Unknown resource URI');
+  });
+});

--- a/tests/integration/sse-security.test.ts
+++ b/tests/integration/sse-security.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect, afterEach } from '@jest/globals';
+import http from 'http';
+import { SseTestClient } from '../helpers/SseTestClient.js';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import { closeSseServer } from '../../src/utils/transport.js';
+
+describe('SSE Security Scenarios', () => {
+  let client: SseTestClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = null;
+    }
+  });
+
+  test('blocked operator rejection (;)', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: false,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [';', '&', '|', '`'],
+        },
+        paths: { allowedPaths: [] },
+      },
+    });
+    await expect(
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo hi ; ls' })
+    ).rejects.toThrow();
+  });
+
+  test('blocked pipe rejection (|)', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: false,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [';', '&', '|', '`'],
+        },
+        paths: { allowedPaths: [] },
+      },
+    });
+    await expect(
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo hi | grep hi' })
+    ).rejects.toThrow();
+  });
+
+  test('blocked ampersand rejection (&)', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: false,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [';', '&', '|', '`'],
+        },
+        paths: { allowedPaths: [] },
+      },
+    });
+    await expect(
+      client.callTool('execute_command', { shell: 'wsl', command: 'echo hi & ls' })
+    ).rejects.toThrow();
+  });
+
+  test('path restriction enforced', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: false,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [],
+        },
+        paths: { allowedPaths: ['/allowed_only'] },
+      },
+    });
+    await expect(
+      client.callTool('execute_command', {
+        shell: 'wsl',
+        command: 'pwd',
+        workingDir: '/tmp',
+      })
+    ).rejects.toThrow();
+  });
+
+  test('path restriction allowed', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: false,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [],
+        },
+        paths: { allowedPaths: ['/tmp'] },
+      },
+    });
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'pwd',
+      workingDir: '/tmp',
+    });
+    expect(result.isError).toBeFalsy();
+    expect((result.metadata as any).exitCode).toBe(0);
+  });
+
+  test('unknown tool name returns error', async () => {
+    client = await SseTestClient.create();
+    await expect(
+      client.callTool('nonexistent_tool_xyz', {})
+    ).rejects.toThrow();
+  });
+
+  test('missing required argument returns error', async () => {
+    client = await SseTestClient.create();
+    await expect(
+      client.callTool('execute_command', { shell: 'wsl' })
+    ).rejects.toThrow();
+  });
+
+  test('invalid shell name returns error', async () => {
+    client = await SseTestClient.create();
+    await expect(
+      client.callTool('execute_command', { shell: 'nonexistent', command: 'echo hi' })
+    ).rejects.toThrow();
+  });
+
+  test('command too long returns error', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: false,
+          maxCommandLength: 10,
+          commandTimeout: 30,
+          enableInjectionProtection: false,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [],
+        },
+        paths: { allowedPaths: [] },
+      },
+    });
+    await expect(
+      client.callTool('execute_command', {
+        shell: 'wsl',
+        command: 'this command is way too long and exceeds the max',
+      })
+    ).rejects.toThrow();
+  });
+
+  test('unknown session POST returns 404', async () => {
+    client = await SseTestClient.create();
+    const port = client.port;
+
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 999,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+
+    const result = await new Promise<{ statusCode: number | undefined }>((resolve, reject) => {
+      const req = http.request(
+        `http://127.0.0.1:${port}/messages?sessionId=nonexistent-session-id`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          res.resume();
+          res.on('end', () => resolve({ statusCode: res.statusCode }));
+        }
+      );
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+
+    expect(result.statusCode).toBe(404);
+  });
+
+  test('concurrent sessions isolated', async () => {
+    const client1 = await SseTestClient.create();
+    const client2 = await SseTestClient.create();
+
+    try {
+      const [result1, result2] = await Promise.all([
+        client1.callTool('execute_command', { shell: 'wsl', command: 'echo one' }),
+        client2.callTool('execute_command', { shell: 'wsl', command: 'echo two' }),
+      ]);
+
+      expect(result1.content[0].text).toContain('one');
+      expect(result2.content[0].text).toContain('two');
+    } finally {
+      await client1.close();
+      await client2.close();
+    }
+  });
+});

--- a/tests/integration/sse-tool-execution.test.ts
+++ b/tests/integration/sse-tool-execution.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect, afterEach } from '@jest/globals';
+import { SseTestClient } from '../helpers/SseTestClient.js';
+
+describe('SSE Tool Execution', () => {
+  let client: SseTestClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close();
+      client = null;
+    }
+  });
+
+  test('execute_command basic echo', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'echo hello',
+    });
+    expect(result.content[0].text).toContain('hello');
+    expect(result.metadata).toBeDefined();
+    expect((result.metadata as any).exitCode).toBe(0);
+  });
+
+  test('execute_command with workingDir', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        restrictions: {
+          blockedCommands: [],
+          blockedArguments: [],
+          blockedOperators: [],
+        },
+        paths: { allowedPaths: ['/tmp'] },
+      },
+    });
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'pwd',
+      workingDir: '/tmp',
+    });
+    expect(result.content[0].text).toContain('/tmp');
+    expect((result.metadata as any).exitCode).toBe(0);
+    expect((result.metadata as any).workingDirectory).toBe('/tmp');
+  });
+
+  test('execute_command output metadata with truncation', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'seq 1 50',
+      maxOutputLines: 20,
+    });
+    const meta = result.metadata as any;
+    expect(meta.totalLines).toBeGreaterThanOrEqual(50);
+    expect(meta.returnedLines).toBe(20);
+    expect(meta.wasTruncated).toBe(true);
+    expect(meta.exitCode).toBe(0);
+  });
+
+  test('execute_command with timeout', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'echo fast',
+      timeout: 5,
+    });
+    expect(result.content[0].text).toContain('fast');
+    expect((result.metadata as any).exitCode).toBe(0);
+  });
+
+  test('execute_command failed command', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('execute_command', {
+      shell: 'wsl',
+      command: 'ls /nonexistent_dir_xyz',
+    });
+    expect((result.metadata as any).exitCode).not.toBe(0);
+    expect(result.isError).toBe(true);
+  });
+
+  test('validate_directories valid path', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        paths: { allowedPaths: [process.cwd()] },
+      },
+    });
+    const result = await client.callTool('validate_directories', {
+      directories: [process.cwd()],
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('All specified directories');
+  });
+
+  test('validate_directories invalid path', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        paths: { allowedPaths: ['/allowed_only'] },
+      },
+    });
+    const result = await client.callTool('validate_directories', {
+      directories: ['/not_allowed'],
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  test('get_config returns full structure', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('get_config', {});
+    const cfg = JSON.parse(result.content[0].text);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg).toHaveProperty('shells');
+    expect(cfg.global).toHaveProperty('security');
+    expect(cfg.global).toHaveProperty('restrictions');
+  });
+
+  test('get_current_directory returns a path', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('get_current_directory', {});
+    expect(result.content[0].text).toBeTruthy();
+    expect(result.content[0].text.length).toBeGreaterThan(0);
+  });
+
+  test('set_current_directory and verify', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        paths: { allowedPaths: [process.cwd()] },
+      },
+    });
+    const setResult = await client.callTool('set_current_directory', {
+      path: process.cwd(),
+    });
+    expect(setResult.isError).toBeFalsy();
+
+    const getResult = await client.callTool('get_current_directory', {});
+    expect(getResult.content[0].text).toBeTruthy();
+  });
+
+  test('tools/list includes all expected tools', async () => {
+    client = await SseTestClient.create({
+      global: {
+        security: {
+          restrictWorkingDirectory: true,
+          maxCommandLength: 2000,
+          commandTimeout: 30,
+          enableInjectionProtection: true,
+        },
+        paths: { allowedPaths: [process.cwd()] },
+      },
+    });
+    const response = await client.call('tools/list');
+    const toolNames = response.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain('execute_command');
+    expect(toolNames).toContain('get_config');
+    expect(toolNames).toContain('get_current_directory');
+    expect(toolNames).toContain('set_current_directory');
+    expect(toolNames).toContain('validate_directories');
+  });
+});

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -5,6 +5,7 @@ import { CLIServer } from '../../src/index.js';
 import { DEFAULT_CONFIG } from '../../src/utils/config.js';
 import type { ServerConfig } from '../../src/types/config.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { SseTestClient } from '../helpers/SseTestClient.js';
 
 describe('SSE Transport Module', () => {
   let server: http.Server | null = null;
@@ -162,87 +163,71 @@ describe('CLIServer SSE Integration', () => {
 });
 
 describe('SSE MCP Protocol Integration', () => {
-  let cliServer: CLIServer | null = null;
+  let client: SseTestClient | null = null;
 
   afterEach(async () => {
-    if (cliServer) {
-      const internalServer = (cliServer as any).httpServer as http.Server | undefined;
-      if (internalServer) {
-        await closeSseServer(internalServer);
-      }
+    if (client) {
+      await client.close();
+      client = null;
     }
-    cliServer = null;
   });
 
-  function makeSseConfig(): ServerConfig {
-    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
-    config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
-    config.global.security.restrictWorkingDirectory = false;
-    return config;
-  }
+  it('should complete MCP initialize handshake over SSE', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' },
+    });
+    expect(response.result.serverInfo.name).toBe('wcli0');
+    expect(response.result.capabilities).toBeDefined();
+  });
 
-  async function connectSSE(
-    port: number
-  ): Promise<{ sessionId: string; messages: any[]; stream: http.IncomingMessage }> {
-    const messages: any[] = [];
-    let buffer = '';
+  it('should handle initialized notification over SSE', async () => {
+    client = await SseTestClient.create();
+    // SseTestClient.create() already sends initialize + initialized
+    // Verify by listing tools (requires completed handshake)
+    const response = await client.call('tools/list');
+    expect(response.result.tools).toBeDefined();
+    expect(Array.isArray(response.result.tools)).toBe(true);
+  });
 
-    const stream = await new Promise<http.IncomingMessage>((resolve, reject) => {
-      http.get(`http://127.0.0.1:${port}/sse`, resolve).on('error', reject);
+  it('should list tools over SSE after initialization', async () => {
+    client = await SseTestClient.create();
+    const response = await client.call('tools/list');
+    const toolNames = response.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain('execute_command');
+    expect(toolNames).toContain('get_config');
+  });
+
+  it('should call get_config tool over SSE and return valid config', async () => {
+    client = await SseTestClient.create();
+    const result = await client.callTool('get_config', {});
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const cfg = JSON.parse(result.content[0].text as string);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg.global).toHaveProperty('security');
+  });
+
+  it('should reject POST to unknown session', async () => {
+    client = await SseTestClient.create();
+    const port = client.port;
+
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
     });
 
-    const sessionId = await new Promise<string>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        stream.destroy();
-        reject(new Error('Timed out waiting for endpoint event'));
-      }, 5000);
-
-      stream.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString();
-
-        // Parse endpoint event
-        const endpointMatch = buffer.match(/data: \/messages\?sessionId=([^\s\n]+)/);
-        if (endpointMatch) {
-          clearTimeout(timeout);
-          resolve(endpointMatch[1]);
-        }
-
-        // Parse message events
-        parseMessagesFromBuffer();
-      });
-      stream.on('error', reject);
-    });
-
-    function parseMessagesFromBuffer() {
-      const parts = buffer.split('\n\n');
-      for (const part of parts) {
-        const dataMatch = part.match(/^data: (.+)$/m);
-        const eventMatch = part.match(/^event: (.+)$/m);
-        if (dataMatch && eventMatch && eventMatch[1] === 'message') {
-          try {
-            const parsed = JSON.parse(dataMatch[1]);
-            if (!messages.some((m) => JSON.stringify(m) === JSON.stringify(parsed))) {
-              messages.push(parsed);
-            }
-          } catch {
-            // ignore non-JSON data
-          }
-        }
-      }
-    }
-
-    return { sessionId, messages, stream };
-  }
-
-  function postMessage(
-    port: number,
-    sessionId: string,
-    message: object
-  ): Promise<{ statusCode: number | undefined; body: string }> {
-    return new Promise((resolve, reject) => {
-      const body = JSON.stringify(message);
+    const result = await new Promise<{ statusCode: number | undefined }>((resolve, reject) => {
       const req = http.request(
-        `http://127.0.0.1:${port}/messages?sessionId=${sessionId}`,
+        `http://127.0.0.1:${port}/messages?sessionId=nonexistent-session-id`,
         {
           method: 'POST',
           headers: {
@@ -251,264 +236,41 @@ describe('SSE MCP Protocol Integration', () => {
           },
         },
         (res) => {
-          let data = '';
-          res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
-          res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }); });
+          res.resume();
+          res.on('end', () => resolve({ statusCode: res.statusCode }));
         }
       );
       req.on('error', reject);
       req.write(body);
       req.end();
     });
-  }
 
-  function waitForMessage(messages: any[], predicate: (m: any) => boolean, timeoutMs = 5000): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const found = messages.find(predicate);
-      if (found) { resolve(found); return; }
-
-      const timer = setTimeout(() => {
-        reject(new Error(`Timed out waiting for message. Collected: ${JSON.stringify(messages)}`));
-      }, timeoutMs);
-
-      const check = setInterval(() => {
-        const m = messages.find(predicate);
-        if (m) {
-          clearTimeout(timer);
-          clearInterval(check);
-          resolve(m);
-        }
-      }, 50);
-    });
-  }
-
-  it('should complete MCP initialize handshake over SSE', async () => {
-    const config = makeSseConfig();
-    cliServer = new CLIServer(config);
-    await cliServer.run();
-
-    const internalServer = (cliServer as any).httpServer as http.Server;
-    const addr = internalServer.address() as http.AddressInfo;
-    const { sessionId, messages, stream } = await connectSSE(addr.port);
-
-    expect(sessionId).toMatch(/^[0-9a-f-]+$/);
-
-    const initRequest = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    };
-
-    const postResult = await postMessage(addr.port, sessionId, initRequest);
-    expect(postResult.statusCode).toBe(202);
-
-    const response = await waitForMessage(messages, (m) => m.id === 1);
-    expect(response.jsonrpc).toBe('2.0');
-    expect(response.id).toBe(1);
-    expect(response.result).toBeDefined();
-    expect(response.result.serverInfo).toBeDefined();
-    expect(response.result.serverInfo.name).toBe('wcli0');
-    expect(response.result.capabilities).toBeDefined();
-
-    stream.destroy();
-  });
-
-  it('should handle initialized notification over SSE', async () => {
-    const config = makeSseConfig();
-    cliServer = new CLIServer(config);
-    await cliServer.run();
-
-    const internalServer = (cliServer as any).httpServer as http.Server;
-    const addr = internalServer.address() as http.AddressInfo;
-    const { sessionId, messages, stream } = await connectSSE(addr.port);
-
-    // Initialize first
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    });
-    await waitForMessage(messages, (m) => m.id === 1);
-
-    // Send initialized notification (no id = notification)
-    const postResult = await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      method: 'notifications/initialized',
-    });
-    expect(postResult.statusCode).toBe(202);
-
-    stream.destroy();
-  });
-
-  it('should list tools over SSE after initialization', async () => {
-    const config = makeSseConfig();
-    cliServer = new CLIServer(config);
-    await cliServer.run();
-
-    const internalServer = (cliServer as any).httpServer as http.Server;
-    const addr = internalServer.address() as http.AddressInfo;
-    const { sessionId, messages, stream } = await connectSSE(addr.port);
-
-    // Initialize
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    });
-    await waitForMessage(messages, (m) => m.id === 1);
-
-    // Send initialized notification
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      method: 'notifications/initialized',
-    });
-
-    // List tools
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      id: 2,
-      method: 'tools/list',
-    });
-
-    const response = await waitForMessage(messages, (m) => m.id === 2);
-    expect(response.result).toBeDefined();
-    expect(response.result.tools).toBeDefined();
-    expect(Array.isArray(response.result.tools)).toBe(true);
-    const toolNames = response.result.tools.map((t: any) => t.name);
-    expect(toolNames).toContain('execute_command');
-    expect(toolNames).toContain('get_config');
-
-    stream.destroy();
-  });
-
-  it('should call get_config tool over SSE and return valid config', async () => {
-    const config = makeSseConfig();
-    cliServer = new CLIServer(config);
-    await cliServer.run();
-
-    const internalServer = (cliServer as any).httpServer as http.Server;
-    const addr = internalServer.address() as http.AddressInfo;
-    const { sessionId, messages, stream } = await connectSSE(addr.port);
-
-    // Initialize
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    });
-    await waitForMessage(messages, (m) => m.id === 1);
-
-    // Initialized notification
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      method: 'notifications/initialized',
-    });
-
-    // Call get_config tool
-    await postMessage(addr.port, sessionId, {
-      jsonrpc: '2.0',
-      id: 3,
-      method: 'tools/call',
-      params: {
-        name: 'get_config',
-        arguments: {},
-      },
-    });
-
-    const response = await waitForMessage(messages, (m) => m.id === 3);
-    expect(response.result).toBeDefined();
-    expect(response.result.content).toBeDefined();
-    expect(response.result.content[0].type).toBe('text');
-    const cfg = JSON.parse(response.result.content[0].text);
-    expect(cfg).toHaveProperty('global');
-    expect(cfg.global).toHaveProperty('security');
-
-    stream.destroy();
-  });
-
-  it('should reject POST to unknown session', async () => {
-    const config = makeSseConfig();
-    cliServer = new CLIServer(config);
-    await cliServer.run();
-
-    const internalServer = (cliServer as any).httpServer as http.Server;
-    const addr = internalServer.address() as http.AddressInfo;
-
-    const result = await postMessage(addr.port, 'nonexistent-session-id', {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    });
     expect(result.statusCode).toBe(404);
   });
 
   it('should handle multiple concurrent SSE sessions with separate servers', async () => {
-    // The MCP SDK Server only supports one transport at a time, so each
-    // SSE session needs its own CLIServer/HTTP server. This test verifies
-    // two independent SSE servers can run concurrently.
-    const config1 = makeSseConfig();
-    const config2 = makeSseConfig();
-    const server1 = new CLIServer(config1);
-    const server2 = new CLIServer(config2);
-    await server1.run();
-    await server2.run();
+    const client1 = await SseTestClient.create();
+    const client2 = await SseTestClient.create();
 
-    const httpServer1 = (server1 as any).httpServer as http.Server;
-    const httpServer2 = (server2 as any).httpServer as http.Server;
-    const addr1 = httpServer1.address() as http.AddressInfo;
-    const addr2 = httpServer2.address() as http.AddressInfo;
+    try {
+      const [resp1, resp2] = await Promise.all([
+        client1.call('initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        }),
+        client2.call('initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        }),
+      ]);
 
-    const session1 = await connectSSE(addr1.port);
-    const session2 = await connectSSE(addr2.port);
-
-    const initReq = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    };
-
-    await postMessage(addr1.port, session1.sessionId, initReq);
-    await postMessage(addr2.port, session2.sessionId, initReq);
-
-    const resp1 = await waitForMessage(session1.messages, (m) => m.id === 1);
-    const resp2 = await waitForMessage(session2.messages, (m) => m.id === 1);
-
-    expect(resp1.result.serverInfo.name).toBe('wcli0');
-    expect(resp2.result.serverInfo.name).toBe('wcli0');
-
-    session1.stream.destroy();
-    session2.stream.destroy();
-    await closeSseServer(httpServer1);
-    await closeSseServer(httpServer2);
+      expect(resp1.result.serverInfo.name).toBe('wcli0');
+      expect(resp2.result.serverInfo.name).toBe('wcli0');
+    } finally {
+      await client1.close();
+      await client2.close();
+    }
   }, 20000);
 });

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -28,13 +28,13 @@ describe('SSE Transport Module', () => {
 
   describe('createSseServer', () => {
     it('should create an HTTP server that listens', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       expect(server).toBeDefined();
       expect(server.listening).toBe(true);
     });
 
     it('should return SSE headers on GET /sse', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -47,7 +47,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 404 for unknown paths', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -58,7 +58,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 400 for POST /messages without sessionId', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -75,7 +75,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 404 for POST /messages with non-existent session', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -91,11 +91,105 @@ describe('SSE Transport Module', () => {
 
       expect(response.statusCode).toBe(404);
     });
+
+    // P1: each SSE connection must get its own MCP server instance, because the
+    // MCP Protocol owns a single transport at a time (connect() overwrites it).
+    it('creates a fresh MCP server per SSE connection (P1)', async () => {
+      let factoryCalls = 0;
+      const created: Server[] = [];
+      server = await createSseServer(
+        () => {
+          factoryCalls++;
+          const s = createTestMcpServer();
+          created.push(s);
+          return s;
+        },
+        '127.0.0.1',
+        0
+      );
+      const addr = server.address() as http.AddressInfo;
+
+      const open = (): Promise<http.IncomingMessage> =>
+        new Promise((resolve, reject) => {
+          http.get(`http://127.0.0.1:${addr.port}/sse`, resolve).on('error', reject);
+        });
+
+      const r1 = await open();
+      const r2 = await open();
+
+      expect(factoryCalls).toBe(2);
+      expect(created[0]).not.toBe(created[1]);
+
+      r1.destroy();
+      r2.destroy();
+    });
+  });
+
+  // P2: reject untrusted Origin headers (DNS-rebinding defense).
+  describe('Origin validation (P2)', () => {
+    function requestWithOrigin(
+      port: number,
+      pathName: string,
+      method: string,
+      origin?: string
+    ): Promise<http.IncomingMessage> {
+      return new Promise((resolve, reject) => {
+        const req = http.request(
+          `http://127.0.0.1:${port}${pathName}`,
+          { method, headers: origin ? { Origin: origin } : {} },
+          resolve
+        );
+        req.on('error', reject);
+        req.end();
+      });
+    }
+
+    it('rejects GET /sse from a disallowed origin with 403', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await requestWithOrigin(addr.port, '/sse', 'GET', 'https://evil.example');
+      expect(res.statusCode).toBe(403);
+      res.destroy();
+    });
+
+    it('rejects POST /messages from a disallowed origin with 403', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await requestWithOrigin(
+        addr.port,
+        '/messages?sessionId=whatever',
+        'POST',
+        'https://evil.example'
+      );
+      expect(res.statusCode).toBe(403);
+      res.destroy();
+    });
+
+    it('allows GET /sse from a loopback origin', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await requestWithOrigin(
+        addr.port,
+        '/sse',
+        'GET',
+        `http://localhost:${addr.port}`
+      );
+      expect(res.statusCode).toBe(200);
+      res.destroy();
+    });
+
+    it('allows GET /sse with no Origin header', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await requestWithOrigin(addr.port, '/sse', 'GET', undefined);
+      expect(res.statusCode).toBe(200);
+      res.destroy();
+    });
   });
 
   describe('closeSseServer', () => {
     it('should close a listening server', async () => {
-      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
       expect(server.listening).toBe(true);
       await closeSseServer(server);
       expect(server.listening).toBe(false);

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach } from '@jest/globals';
 import http from 'http';
 import { createSseServer, closeSseServer } from '../../src/utils/transport.js';
+import { CLIServer } from '../../src/index.js';
+import { DEFAULT_CONFIG } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 
 describe('SSE Transport Module', () => {
   let server: http.Server | null = null;
@@ -12,23 +16,24 @@ describe('SSE Transport Module', () => {
     }
   });
 
-  // Minimal MCP Server stub for testing
-  function createMockMcpServer() {
-    return {
-      connect: async () => {},
-      close: async () => {},
-    } as any;
+  function createTestMcpServer(): Server {
+    return new Server({
+      name: 'test-server',
+      version: '1.0.0',
+    }, {
+      capabilities: {},
+    });
   }
 
   describe('createSseServer', () => {
     it('should create an HTTP server that listens', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       expect(server).toBeDefined();
       expect(server.listening).toBe(true);
     });
 
     it('should return SSE headers on GET /sse', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -41,7 +46,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 404 for unknown paths', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -52,7 +57,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 400 for POST /messages without sessionId', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -69,7 +74,7 @@ describe('SSE Transport Module', () => {
     });
 
     it('should return 404 for POST /messages with non-existent session', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       const addr = server.address() as http.AddressInfo;
 
       const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
@@ -89,7 +94,7 @@ describe('SSE Transport Module', () => {
 
   describe('closeSseServer', () => {
     it('should close a listening server', async () => {
-      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      server = await createSseServer(createTestMcpServer(), '127.0.0.1', 0);
       expect(server.listening).toBe(true);
       await closeSseServer(server);
       expect(server.listening).toBe(false);
@@ -100,5 +105,58 @@ describe('SSE Transport Module', () => {
       const closedServer = http.createServer();
       await expect(closeSseServer(closedServer)).resolves.toBeUndefined();
     });
+  });
+});
+
+describe('CLIServer SSE Integration', () => {
+  let cliServer: CLIServer | null = null;
+  let httpServer: http.Server | null = null;
+
+  afterEach(async () => {
+    if (cliServer) {
+      const internalServer = (cliServer as any).httpServer as http.Server | undefined;
+      if (internalServer) {
+        await closeSseServer(internalServer);
+      }
+    }
+    if (httpServer) {
+      await closeSseServer(httpServer);
+      httpServer = null;
+    }
+    cliServer = null;
+  });
+
+  function makeSseConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
+    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
+    return { ...config, ...overrides };
+  }
+
+  it('should start CLIServer in SSE mode and accept connections', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    expect(internalServer).toBeDefined();
+    expect(internalServer.listening).toBe(true);
+
+    const addr = internalServer.address() as http.AddressInfo;
+    const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${addr.port}/sse`, resolve).on('error', reject);
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toMatch(/text\/event-stream/);
+    response.destroy();
+  });
+
+  it('should use stdio mode when transport is stdio', async () => {
+    const config = makeSseConfig();
+    config.transport = { mode: 'stdio', sseHost: '127.0.0.1', ssePort: 9444 };
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer;
+    expect(internalServer).toBeUndefined();
   });
 });

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -111,20 +111,12 @@ describe('SSE Transport Module', () => {
 
 describe('CLIServer SSE Integration', () => {
   let cliServer: CLIServer | null = null;
-  let httpServer: http.Server | null = null;
 
   afterEach(async () => {
     if (cliServer) {
-      const internalServer = (cliServer as any).httpServer as http.Server | undefined;
-      if (internalServer) {
-        await closeSseServer(internalServer);
-      }
+      await (cliServer as any).cleanup();
+      cliServer = null;
     }
-    if (httpServer) {
-      await closeSseServer(httpServer);
-      httpServer = null;
-    }
-    cliServer = null;
   });
 
   function makeSseConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -123,6 +123,43 @@ describe('SSE Transport Module', () => {
       r1.destroy();
       r2.destroy();
     });
+
+    // P5: a malformed Host header makes `new URL()` throw. Since the request
+    // callback is async that would become an unhandled rejection and crash the
+    // process; the server must return 400 and keep serving instead.
+    it('returns 400 for a malformed Host header and stays alive (P5)', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      const badStatus = await new Promise<number | undefined>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: '127.0.0.1',
+            port: addr.port,
+            path: '/sse',
+            method: 'GET',
+            headers: { Host: '%%%%' },
+          },
+          (res) => {
+            res.resume();
+            resolve(res.statusCode);
+          }
+        );
+        req.on('error', reject);
+        req.end();
+      });
+      expect(badStatus).toBe(400);
+
+      // The server survived the malformed request: a normal request still works.
+      const okStatus = await new Promise<number | undefined>((resolve, reject) => {
+        const r = http.get(`http://127.0.0.1:${addr.port}/unknown`, (res) => {
+          res.resume();
+          resolve(res.statusCode);
+        });
+        r.on('error', reject);
+      });
+      expect(okStatus).toBe(404);
+    });
   });
 
   // P2: reject untrusted Origin headers (DNS-rebinding defense).
@@ -187,6 +224,70 @@ describe('SSE Transport Module', () => {
     });
   });
 
+  // P8: browser clients on an allowed origin but a different port need the
+  // server to echo Access-Control-Allow-Origin and to answer OPTIONS preflight.
+  describe('CORS for allowed origins (P8)', () => {
+    function rawRequest(
+      port: number,
+      pathName: string,
+      method: string,
+      origin?: string
+    ): Promise<http.IncomingMessage> {
+      return new Promise((resolve, reject) => {
+        const req = http.request(
+          `http://127.0.0.1:${port}${pathName}`,
+          { method, headers: origin ? { Origin: origin } : {} },
+          resolve
+        );
+        req.on('error', reject);
+        req.end();
+      });
+    }
+
+    it('answers an OPTIONS preflight from an allowed origin with 204 and CORS headers', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const origin = `http://localhost:${addr.port}`;
+      const res = await rawRequest(addr.port, '/messages?sessionId=x', 'OPTIONS', origin);
+      expect(res.statusCode).toBe(204);
+      expect(res.headers['access-control-allow-origin']).toBe(origin);
+      expect(res.headers['access-control-allow-methods']).toMatch(/POST/);
+      res.destroy();
+    });
+
+    it('echoes Access-Control-Allow-Origin on GET /sse for an allowed origin', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const origin = `http://127.0.0.1:${addr.port}`;
+      const res = await rawRequest(addr.port, '/sse', 'GET', origin);
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe(origin);
+      res.destroy();
+    });
+
+    it('rejects a preflight from a disallowed origin with 403 and no CORS header', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await rawRequest(
+        addr.port,
+        '/messages?sessionId=x',
+        'OPTIONS',
+        'https://evil.example'
+      );
+      expect(res.statusCode).toBe(403);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
+      res.destroy();
+    });
+
+    it('omits CORS headers when no Origin is present (non-browser client)', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+      const res = await rawRequest(addr.port, '/unknown', 'GET', undefined);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
+      res.destroy();
+    });
+  });
+
   describe('closeSseServer', () => {
     it('should close a listening server', async () => {
       server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
@@ -200,6 +301,30 @@ describe('SSE Transport Module', () => {
       const closedServer = http.createServer();
       await expect(closeSseServer(closedServer)).resolves.toBeUndefined();
     });
+
+    // P6: closeAllConnections() only exists on Node >=18.2, but engines.node
+    // allows 18.0/18.1 where it is undefined. With an active SSE stream,
+    // close() would then hang forever; the tracked-socket fallback must still
+    // tear the server down.
+    it('closes with an active stream when closeAllConnections is unavailable (P6)', async () => {
+      server = await createSseServer(() => createTestMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      // Open a long-lived SSE stream so the server has an active socket.
+      const stream = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        const r = http.get(`http://127.0.0.1:${addr.port}/sse`, resolve);
+        r.on('error', reject);
+      });
+
+      // Simulate a Node 18.0/18.1 runtime where the API is missing.
+      (server as unknown as { closeAllConnections?: () => void }).closeAllConnections = undefined;
+
+      await closeSseServer(server);
+      expect(server.listening).toBe(false);
+
+      stream.destroy();
+      server = null;
+    }, 10000);
   });
 });
 

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -160,3 +160,355 @@ describe('CLIServer SSE Integration', () => {
     expect(internalServer).toBeUndefined();
   });
 });
+
+describe('SSE MCP Protocol Integration', () => {
+  let cliServer: CLIServer | null = null;
+
+  afterEach(async () => {
+    if (cliServer) {
+      const internalServer = (cliServer as any).httpServer as http.Server | undefined;
+      if (internalServer) {
+        await closeSseServer(internalServer);
+      }
+    }
+    cliServer = null;
+  });
+
+  function makeSseConfig(): ServerConfig {
+    const config: ServerConfig = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.transport = { mode: 'sse', sseHost: '127.0.0.1', ssePort: 0 };
+    config.global.security.restrictWorkingDirectory = false;
+    return config;
+  }
+
+  async function connectSSE(
+    port: number
+  ): Promise<{ sessionId: string; messages: any[]; stream: http.IncomingMessage }> {
+    const messages: any[] = [];
+    let buffer = '';
+
+    const stream = await new Promise<http.IncomingMessage>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/sse`, resolve).on('error', reject);
+    });
+
+    const sessionId = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        stream.destroy();
+        reject(new Error('Timed out waiting for endpoint event'));
+      }, 5000);
+
+      stream.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString();
+
+        // Parse endpoint event
+        const endpointMatch = buffer.match(/data: \/messages\?sessionId=([^\s\n]+)/);
+        if (endpointMatch) {
+          clearTimeout(timeout);
+          resolve(endpointMatch[1]);
+        }
+
+        // Parse message events
+        parseMessagesFromBuffer();
+      });
+      stream.on('error', reject);
+    });
+
+    function parseMessagesFromBuffer() {
+      const parts = buffer.split('\n\n');
+      for (const part of parts) {
+        const dataMatch = part.match(/^data: (.+)$/m);
+        const eventMatch = part.match(/^event: (.+)$/m);
+        if (dataMatch && eventMatch && eventMatch[1] === 'message') {
+          try {
+            const parsed = JSON.parse(dataMatch[1]);
+            if (!messages.some((m) => JSON.stringify(m) === JSON.stringify(parsed))) {
+              messages.push(parsed);
+            }
+          } catch {
+            // ignore non-JSON data
+          }
+        }
+      }
+    }
+
+    return { sessionId, messages, stream };
+  }
+
+  function postMessage(
+    port: number,
+    sessionId: string,
+    message: object
+  ): Promise<{ statusCode: number | undefined; body: string }> {
+    return new Promise((resolve, reject) => {
+      const body = JSON.stringify(message);
+      const req = http.request(
+        `http://127.0.0.1:${port}/messages?sessionId=${sessionId}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+          res.on('end', () => { resolve({ statusCode: res.statusCode, body: data }); });
+        }
+      );
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  function waitForMessage(messages: any[], predicate: (m: any) => boolean, timeoutMs = 5000): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const found = messages.find(predicate);
+      if (found) { resolve(found); return; }
+
+      const timer = setTimeout(() => {
+        reject(new Error(`Timed out waiting for message. Collected: ${JSON.stringify(messages)}`));
+      }, timeoutMs);
+
+      const check = setInterval(() => {
+        const m = messages.find(predicate);
+        if (m) {
+          clearTimeout(timer);
+          clearInterval(check);
+          resolve(m);
+        }
+      }, 50);
+    });
+  }
+
+  it('should complete MCP initialize handshake over SSE', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    const addr = internalServer.address() as http.AddressInfo;
+    const { sessionId, messages, stream } = await connectSSE(addr.port);
+
+    expect(sessionId).toMatch(/^[0-9a-f-]+$/);
+
+    const initRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    };
+
+    const postResult = await postMessage(addr.port, sessionId, initRequest);
+    expect(postResult.statusCode).toBe(202);
+
+    const response = await waitForMessage(messages, (m) => m.id === 1);
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.id).toBe(1);
+    expect(response.result).toBeDefined();
+    expect(response.result.serverInfo).toBeDefined();
+    expect(response.result.serverInfo.name).toBe('wcli0');
+    expect(response.result.capabilities).toBeDefined();
+
+    stream.destroy();
+  });
+
+  it('should handle initialized notification over SSE', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    const addr = internalServer.address() as http.AddressInfo;
+    const { sessionId, messages, stream } = await connectSSE(addr.port);
+
+    // Initialize first
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+    await waitForMessage(messages, (m) => m.id === 1);
+
+    // Send initialized notification (no id = notification)
+    const postResult = await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+    expect(postResult.statusCode).toBe(202);
+
+    stream.destroy();
+  });
+
+  it('should list tools over SSE after initialization', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    const addr = internalServer.address() as http.AddressInfo;
+    const { sessionId, messages, stream } = await connectSSE(addr.port);
+
+    // Initialize
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+    await waitForMessage(messages, (m) => m.id === 1);
+
+    // Send initialized notification
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    // List tools
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    });
+
+    const response = await waitForMessage(messages, (m) => m.id === 2);
+    expect(response.result).toBeDefined();
+    expect(response.result.tools).toBeDefined();
+    expect(Array.isArray(response.result.tools)).toBe(true);
+    const toolNames = response.result.tools.map((t: any) => t.name);
+    expect(toolNames).toContain('execute_command');
+    expect(toolNames).toContain('get_config');
+
+    stream.destroy();
+  });
+
+  it('should call get_config tool over SSE and return valid config', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    const addr = internalServer.address() as http.AddressInfo;
+    const { sessionId, messages, stream } = await connectSSE(addr.port);
+
+    // Initialize
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+    await waitForMessage(messages, (m) => m.id === 1);
+
+    // Initialized notification
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    // Call get_config tool
+    await postMessage(addr.port, sessionId, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'get_config',
+        arguments: {},
+      },
+    });
+
+    const response = await waitForMessage(messages, (m) => m.id === 3);
+    expect(response.result).toBeDefined();
+    expect(response.result.content).toBeDefined();
+    expect(response.result.content[0].type).toBe('text');
+    const cfg = JSON.parse(response.result.content[0].text);
+    expect(cfg).toHaveProperty('global');
+    expect(cfg.global).toHaveProperty('security');
+
+    stream.destroy();
+  });
+
+  it('should reject POST to unknown session', async () => {
+    const config = makeSseConfig();
+    cliServer = new CLIServer(config);
+    await cliServer.run();
+
+    const internalServer = (cliServer as any).httpServer as http.Server;
+    const addr = internalServer.address() as http.AddressInfo;
+
+    const result = await postMessage(addr.port, 'nonexistent-session-id', {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+    expect(result.statusCode).toBe(404);
+  });
+
+  it('should handle multiple concurrent SSE sessions with separate servers', async () => {
+    // The MCP SDK Server only supports one transport at a time, so each
+    // SSE session needs its own CLIServer/HTTP server. This test verifies
+    // two independent SSE servers can run concurrently.
+    const config1 = makeSseConfig();
+    const config2 = makeSseConfig();
+    const server1 = new CLIServer(config1);
+    const server2 = new CLIServer(config2);
+    await server1.run();
+    await server2.run();
+
+    const httpServer1 = (server1 as any).httpServer as http.Server;
+    const httpServer2 = (server2 as any).httpServer as http.Server;
+    const addr1 = httpServer1.address() as http.AddressInfo;
+    const addr2 = httpServer2.address() as http.AddressInfo;
+
+    const session1 = await connectSSE(addr1.port);
+    const session2 = await connectSSE(addr2.port);
+
+    const initReq = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    };
+
+    await postMessage(addr1.port, session1.sessionId, initReq);
+    await postMessage(addr2.port, session2.sessionId, initReq);
+
+    const resp1 = await waitForMessage(session1.messages, (m) => m.id === 1);
+    const resp2 = await waitForMessage(session2.messages, (m) => m.id === 1);
+
+    expect(resp1.result.serverInfo.name).toBe('wcli0');
+    expect(resp2.result.serverInfo.name).toBe('wcli0');
+
+    session1.stream.destroy();
+    session2.stream.destroy();
+    await closeSseServer(httpServer1);
+    await closeSseServer(httpServer2);
+  }, 20000);
+});

--- a/tests/integration/sse-transport.test.ts
+++ b/tests/integration/sse-transport.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import http from 'http';
+import { createSseServer, closeSseServer } from '../../src/utils/transport.js';
+
+describe('SSE Transport Module', () => {
+  let server: http.Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await closeSseServer(server);
+      server = null;
+    }
+  });
+
+  // Minimal MCP Server stub for testing
+  function createMockMcpServer() {
+    return {
+      connect: async () => {},
+      close: async () => {},
+    } as any;
+  }
+
+  describe('createSseServer', () => {
+    it('should create an HTTP server that listens', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      expect(server).toBeDefined();
+      expect(server.listening).toBe(true);
+    });
+
+    it('should return SSE headers on GET /sse', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        http.get(`http://127.0.0.1:${addr.port}/sse`, resolve).on('error', reject);
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/event-stream/);
+      response.destroy();
+    });
+
+    it('should return 404 for unknown paths', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        http.get(`http://127.0.0.1:${addr.port}/unknown`, resolve).on('error', reject);
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 400 for POST /messages without sessionId', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        const req = http.request(
+          `http://127.0.0.1:${addr.port}/messages`,
+          { method: 'POST' },
+          resolve
+        );
+        req.on('error', reject);
+        req.end();
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 404 for POST /messages with non-existent session', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      const addr = server.address() as http.AddressInfo;
+
+      const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        const req = http.request(
+          `http://127.0.0.1:${addr.port}/messages?sessionId=fake-session-id`,
+          { method: 'POST' },
+          resolve
+        );
+        req.on('error', reject);
+        req.setHeader('Content-Type', 'application/json');
+        req.end(JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }));
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe('closeSseServer', () => {
+    it('should close a listening server', async () => {
+      server = await createSseServer(createMockMcpServer(), '127.0.0.1', 0);
+      expect(server.listening).toBe(true);
+      await closeSseServer(server);
+      expect(server.listening).toBe(false);
+      server = null;
+    });
+
+    it('should handle closing a non-listening server', async () => {
+      const closedServer = http.createServer();
+      await expect(closeSseServer(closedServer)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/server/sessionIsolation.test.ts
+++ b/tests/server/sessionIsolation.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { CLIServer } from '../../src/index.js';
+import type { SessionState } from '../../src/index.js';
+import { buildTestConfig } from '../helpers/testUtils.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+// P7: in SSE mode each connection gets its own MCP server instance, but the
+// handlers still close over the same CLIServer. The active working directory
+// must therefore live in a per-session SessionState rather than a single shared
+// field, so set_current_directory in one client cannot redirect another.
+describe('SSE per-session active directory isolation (P7)', () => {
+  function makeServer(): CLIServer {
+    const config = buildTestConfig({
+      global: {
+        security: { restrictWorkingDirectory: false },
+        paths: { allowedPaths: [] },
+      },
+    });
+    return new CLIServer(config);
+  }
+
+  test('set_current_directory in one session does not affect another', async () => {
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    const server = makeServer();
+    // The primary session is seeded from process.cwd() at construction; capture
+    // it so we can prove the SSE sessions never mutate it.
+    const primaryBefore = (server as any).serverActiveCwd;
+
+    const sessionA: SessionState = { activeCwd: undefined };
+    const sessionB: SessionState = { activeCwd: undefined };
+
+    await server._executeTool(
+      { name: 'set_current_directory', arguments: { path: 'C:\\dirA' } },
+      sessionA
+    );
+    await server._executeTool(
+      { name: 'set_current_directory', arguments: { path: 'C:\\dirB' } },
+      sessionB
+    );
+
+    const a = (await server._executeTool(
+      { name: 'get_current_directory', arguments: {} },
+      sessionA
+    )) as CallToolResult;
+    const b = (await server._executeTool(
+      { name: 'get_current_directory', arguments: {} },
+      sessionB
+    )) as CallToolResult;
+
+    expect(a.content[0].text).toBe('C:\\dirA');
+    expect(b.content[0].text).toBe('C:\\dirB');
+    // The primary (stdio/default) session is untouched by the SSE sessions.
+    expect((server as any).serverActiveCwd).toBe(primaryBefore);
+    expect((server as any).serverActiveCwd).not.toBe('C:\\dirA');
+    expect((server as any).serverActiveCwd).not.toBe('C:\\dirB');
+
+    chdirSpy.mockRestore();
+  });
+
+  test('execute_command uses the calling session cwd, not another session cwd', async () => {
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    const server = makeServer();
+
+    const sessionA: SessionState = { activeCwd: undefined };
+    const sessionB: SessionState = { activeCwd: undefined };
+
+    await server._executeTool(
+      { name: 'set_current_directory', arguments: { path: 'C:\\dirA' } },
+      sessionA
+    );
+    await server._executeTool(
+      { name: 'set_current_directory', arguments: { path: 'C:\\dirB' } },
+      sessionB
+    );
+
+    // Session A still resolves its own directory after B changed B's directory.
+    const a = (await server._executeTool(
+      { name: 'get_current_directory', arguments: {} },
+      sessionA
+    )) as CallToolResult;
+    expect(a.content[0].text).toBe('C:\\dirA');
+
+    chdirSpy.mockRestore();
+  });
+
+  test('the default session maps to serverActiveCwd for stdio/back-compat', async () => {
+    const chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    const server = makeServer();
+
+    await server._executeTool({
+      name: 'set_current_directory',
+      arguments: { path: 'C:\\primary' },
+    });
+
+    expect((server as any).serverActiveCwd).toBe('C:\\primary');
+
+    chdirSpy.mockRestore();
+  });
+});

--- a/tests/server/sessionIsolation.test.ts
+++ b/tests/server/sessionIsolation.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, jest } from '@jest/globals';
 import { CLIServer } from '../../src/index.js';
 import type { SessionState } from '../../src/index.js';
-import { buildTestConfig } from '../helpers/testUtils.js';
+import { buildTestConfig, createWslEmulatorConfig } from '../helpers/testUtils.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 // P7: in SSE mode each connection gets its own MCP server instance, but the
@@ -95,5 +95,80 @@ describe('SSE per-session active directory isolation (P7)', () => {
     expect((server as any).serverActiveCwd).toBe('C:\\primary');
 
     chdirSpy.mockRestore();
+  });
+});
+
+// P11: set_current_directory still calls the process-global process.chdir(), so
+// a relative workingDir handed to spawn({ cwd }) would resolve against whatever
+// directory the most recent session selected. execute_command must anchor a
+// relative workingDir to the calling session's activeCwd so concurrent SSE
+// clients cannot perturb one another's relative paths.
+describe('SSE per-session relative workingDir isolation (P11)', () => {
+  function makeWslServer(): CLIServer {
+    const config = buildTestConfig({
+      global: {
+        security: { restrictWorkingDirectory: false },
+        paths: { allowedPaths: [] },
+      },
+      shells: { wsl: createWslEmulatorConfig() },
+    });
+    return new CLIServer(config);
+  }
+
+  test('a relative workingDir resolves against the calling session, not a shared global cwd', async () => {
+    const server = makeWslServer();
+
+    // Capture the workingDir handed to the spawn step without launching a shell.
+    const captured: string[] = [];
+    jest
+      .spyOn(server as any, 'executeShellCommand')
+      .mockImplementation((...callArgs: unknown[]) => {
+        // executeShellCommand(shellName, shellConfig, command, workingDir, ...)
+        captured.push(callArgs[3] as string);
+        return Promise.resolve({
+          content: [{ type: 'text', text: 'ok' }],
+          isError: false,
+          metadata: {},
+        } as CallToolResult);
+      });
+
+    const sessionA: SessionState = { activeCwd: '/mnt/c/dirA' };
+    const sessionB: SessionState = { activeCwd: '/mnt/c/dirB' };
+
+    await server._executeTool(
+      { name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi', workingDir: 'sub' } },
+      sessionA
+    );
+    await server._executeTool(
+      { name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi', workingDir: 'sub' } },
+      sessionB
+    );
+
+    // Identical relative input, but each session anchors to its own activeCwd.
+    expect(captured[0]).toBe('/mnt/c/dirA/sub');
+    expect(captured[1]).toBe('/mnt/c/dirB/sub');
+  });
+
+  test('an absolute workingDir is left untouched', async () => {
+    const server = makeWslServer();
+    const captured: string[] = [];
+    jest
+      .spyOn(server as any, 'executeShellCommand')
+      .mockImplementation((...callArgs: unknown[]) => {
+        captured.push(callArgs[3] as string);
+        return Promise.resolve({
+          content: [{ type: 'text', text: 'ok' }],
+          isError: false,
+          metadata: {},
+        } as CallToolResult);
+      });
+
+    const session: SessionState = { activeCwd: '/mnt/c/dirA' };
+    await server._executeTool(
+      { name: 'execute_command', arguments: { shell: 'wsl', command: 'echo hi', workingDir: '/mnt/c/other' } },
+      session
+    );
+
+    expect(captured[0]).toBe('/mnt/c/other');
   });
 });

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -1,6 +1,38 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { DEFAULT_CONFIG, applyCliTransport, mergeConfigs } from '../../src/utils/config.js';
 import type { ServerConfig } from '../../src/types/config.js';
+
+// parseArgs test helper - imports the module and parses with given args
+async function parseWithArgs(args: string[]): Promise<any> {
+  // We test parseArgs by calling yargs directly with the same configuration
+  const yargs = (await import('yargs/yargs')).default;
+  const { hideBin } = await import('yargs/helpers');
+
+  // Simulate process.argv for testing
+  const originalArgv = process.argv;
+  process.argv = ['node', 'test.js', ...args];
+  try {
+    const result = await yargs(hideBin(process.argv))
+      .option('transport', {
+        type: 'string',
+        choices: ['stdio', 'sse'],
+        description: 'Transport protocol (default: stdio)'
+      })
+      .option('sse-host', {
+        type: 'string',
+        description: 'Host address for SSE transport (default: 127.0.0.1)'
+      })
+      .option('sse-port', {
+        type: 'number',
+        description: 'Port for SSE transport (default: 9444)'
+      })
+      .help()
+      .parse();
+    return result;
+  } finally {
+    process.argv = originalArgv;
+  }
+}
 
 describe('TransportConfig', () => {
   describe('DEFAULT_CONFIG transport defaults', () => {
@@ -133,5 +165,69 @@ describe('TransportConfig', () => {
       expect(merged.transport!.sseHost).toBe('127.0.0.1');
       expect(merged.transport!.ssePort).toBe(9444);
     });
+  });
+});
+
+describe('Transport CLI Arguments', () => {
+  it('should return undefined transport when no flags given', async () => {
+    const args = await parseWithArgs([]);
+    expect(args.transport).toBeUndefined();
+    expect(args['sse-host']).toBeUndefined();
+    expect(args['sse-port']).toBeUndefined();
+  });
+
+  it('should parse --transport sse', async () => {
+    const args = await parseWithArgs(['--transport', 'sse']);
+    expect(args.transport).toBe('sse');
+  });
+
+  it('should parse --transport stdio', async () => {
+    const args = await parseWithArgs(['--transport', 'stdio']);
+    expect(args.transport).toBe('stdio');
+  });
+
+  it('should parse --sse-host', async () => {
+    const args = await parseWithArgs(['--sse-host', '0.0.0.0']);
+    expect(args['sse-host']).toBe('0.0.0.0');
+  });
+
+  it('should parse --sse-port', async () => {
+    const args = await parseWithArgs(['--sse-port', '3000']);
+    expect(args['sse-port']).toBe(3000);
+  });
+
+  it('should parse all transport flags together', async () => {
+    const args = await parseWithArgs([
+      '--transport', 'sse',
+      '--sse-host', '0.0.0.0',
+      '--sse-port', '3000'
+    ]);
+    expect(args.transport).toBe('sse');
+    expect(args['sse-host']).toBe('0.0.0.0');
+    expect(args['sse-port']).toBe(3000);
+  });
+
+  it('should reject invalid transport value', async () => {
+    const yargs = (await import('yargs/yargs')).default;
+    const { hideBin } = await import('yargs/helpers');
+    const originalArgv = process.argv;
+    process.argv = ['node', 'test.js', '--transport', 'invalid'];
+    try {
+      const result = await yargs(hideBin(process.argv))
+        .exitProcess(false)
+        .option('transport', {
+          type: 'string',
+          choices: ['stdio', 'sse'],
+          description: 'Transport protocol (default: stdio)'
+        })
+        .help()
+        .parse();
+      // If we get here, validation didn't fail - check that transport is undefined or invalid
+      expect(result.transport).toBe('invalid');
+    } catch (e: any) {
+      expect(e.message).toMatch(/Invalid values|choices/i);
+    } finally {
+      process.argv = originalArgv;
+    }
   });
 });

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { DEFAULT_CONFIG, applyCliTransport, mergeConfigs } from '../../src/utils/config.js';
+import { isOriginAllowed } from '../../src/utils/transport.js';
 import type { ServerConfig } from '../../src/types/config.js';
 
 // parseArgs test helper - imports the module and parses with given args
@@ -165,6 +166,40 @@ describe('TransportConfig', () => {
       expect(merged.transport!.sseHost).toBe('127.0.0.1');
       expect(merged.transport!.ssePort).toBe(9444);
     });
+  });
+});
+
+// P2: Origin allowlist for the SSE transport (DNS-rebinding defense).
+describe('isOriginAllowed (P2)', () => {
+  it('allows requests with no Origin header (non-browser clients)', () => {
+    expect(isOriginAllowed(undefined, '127.0.0.1')).toBe(true);
+  });
+
+  it('allows loopback origins regardless of bind host', () => {
+    expect(isOriginAllowed('http://localhost:9444', '127.0.0.1')).toBe(true);
+    expect(isOriginAllowed('http://127.0.0.1:3000', '127.0.0.1')).toBe(true);
+    expect(isOriginAllowed('http://[::1]:9444', '127.0.0.1')).toBe(true);
+  });
+
+  it('allows an origin matching the configured bind host', () => {
+    expect(isOriginAllowed('http://192.168.1.10:3000', '192.168.1.10')).toBe(true);
+  });
+
+  it('rejects a remote origin not in the allowlist', () => {
+    expect(isOriginAllowed('https://evil.example', '127.0.0.1')).toBe(false);
+    expect(isOriginAllowed('http://attacker.test:3000', '127.0.0.1')).toBe(false);
+  });
+
+  it('rejects the literal null origin', () => {
+    expect(isOriginAllowed('null', '127.0.0.1')).toBe(false);
+  });
+
+  it('rejects a malformed origin', () => {
+    expect(isOriginAllowed('not-a-url', '127.0.0.1')).toBe(false);
+  });
+
+  it('is case-insensitive for the origin hostname', () => {
+    expect(isOriginAllowed('http://LOCALHOST:9444', '127.0.0.1')).toBe(true);
   });
 });
 

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from '@jest/globals';
+import { DEFAULT_CONFIG, applyCliTransport, mergeConfigs } from '../../src/utils/config.js';
+import type { ServerConfig } from '../../src/types/config.js';
+
+describe('TransportConfig', () => {
+  describe('DEFAULT_CONFIG transport defaults', () => {
+    it('should have stdio as default transport mode', () => {
+      expect(DEFAULT_CONFIG.transport).toBeDefined();
+      expect(DEFAULT_CONFIG.transport!.mode).toBe('stdio');
+    });
+
+    it('should have default SSE host as 127.0.0.1', () => {
+      expect(DEFAULT_CONFIG.transport!.sseHost).toBe('127.0.0.1');
+    });
+
+    it('should have default SSE port as 9444', () => {
+      expect(DEFAULT_CONFIG.transport!.ssePort).toBe(9444);
+    });
+  });
+
+  describe('applyCliTransport', () => {
+    function makeConfig(): ServerConfig {
+      return {
+        ...DEFAULT_CONFIG,
+        transport: { ...DEFAULT_CONFIG.transport! }
+      };
+    }
+
+    it('should initialize transport config if missing', () => {
+      const config: ServerConfig = { ...DEFAULT_CONFIG, transport: undefined };
+      applyCliTransport(config);
+      expect(config.transport).toEqual({
+        mode: 'stdio',
+        sseHost: '127.0.0.1',
+        ssePort: 9444
+      });
+    });
+
+    it('should set mode to sse when transport=sse', () => {
+      const config = makeConfig();
+      applyCliTransport(config, 'sse');
+      expect(config.transport!.mode).toBe('sse');
+    });
+
+    it('should set mode to stdio when transport=stdio', () => {
+      const config = makeConfig();
+      config.transport!.mode = 'sse';
+      applyCliTransport(config, 'stdio');
+      expect(config.transport!.mode).toBe('stdio');
+    });
+
+    it('should not change mode when transport is undefined', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined);
+      expect(config.transport!.mode).toBe('stdio');
+    });
+
+    it('should override sseHost', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, '0.0.0.0');
+      expect(config.transport!.sseHost).toBe('0.0.0.0');
+    });
+
+    it('should override ssePort', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, 3000);
+      expect(config.transport!.ssePort).toBe(3000);
+    });
+
+    it('should apply all CLI overrides together', () => {
+      const config = makeConfig();
+      applyCliTransport(config, 'sse', '0.0.0.0', 3000);
+      expect(config.transport).toEqual({
+        mode: 'sse',
+        sseHost: '0.0.0.0',
+        ssePort: 3000
+      });
+    });
+
+    it('should ignore invalid ssePort values', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, -1);
+      expect(config.transport!.ssePort).toBe(9444);
+    });
+
+    it('should ignore ssePort of 0', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, 0);
+      expect(config.transport!.ssePort).toBe(9444);
+    });
+
+    it('should ignore ssePort above 65535', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, 70000);
+      expect(config.transport!.ssePort).toBe(9444);
+    });
+
+    it('should ignore empty sseHost', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, '  ');
+      expect(config.transport!.sseHost).toBe('127.0.0.1');
+    });
+
+    it('should trim sseHost whitespace', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, '  0.0.0.0  ');
+      expect(config.transport!.sseHost).toBe('0.0.0.0');
+    });
+  });
+
+  describe('mergeConfigs transport section', () => {
+    it('should use default transport when user config has no transport', () => {
+      const merged = mergeConfigs(DEFAULT_CONFIG, { global: DEFAULT_CONFIG.global });
+      expect(merged.transport).toEqual(DEFAULT_CONFIG.transport);
+    });
+
+    it('should override transport mode from user config', () => {
+      const merged = mergeConfigs(DEFAULT_CONFIG, {
+        global: DEFAULT_CONFIG.global,
+        transport: { mode: 'sse', sseHost: '0.0.0.0', ssePort: 3000 }
+      } as any);
+      expect(merged.transport!.mode).toBe('sse');
+      expect(merged.transport!.sseHost).toBe('0.0.0.0');
+      expect(merged.transport!.ssePort).toBe(3000);
+    });
+
+    it('should merge partial transport config with defaults', () => {
+      const merged = mergeConfigs(DEFAULT_CONFIG, {
+        global: DEFAULT_CONFIG.global,
+        transport: { mode: 'sse' }
+      } as any);
+      expect(merged.transport!.mode).toBe('sse');
+      expect(merged.transport!.sseHost).toBe('127.0.0.1');
+      expect(merged.transport!.ssePort).toBe(9444);
+    });
+  });
+});

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -128,6 +128,18 @@ describe('TransportConfig', () => {
       expect(config.transport!.ssePort).toBe(9444);
     });
 
+    it('P9: should ignore fractional ssePort values', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, 9444.5);
+      expect(config.transport!.ssePort).toBe(9444);
+    });
+
+    it('P9: should ignore NaN ssePort values', () => {
+      const config = makeConfig();
+      applyCliTransport(config, undefined, undefined, Number.NaN);
+      expect(config.transport!.ssePort).toBe(9444);
+    });
+
     it('should ignore empty sseHost', () => {
       const config = makeConfig();
       applyCliTransport(config, undefined, '  ');

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { DEFAULT_CONFIG, applyCliTransport, mergeConfigs } from '../../src/utils/config.js';
+import { DEFAULT_CONFIG, applyCliTransport, mergeConfigs, validateConfig } from '../../src/utils/config.js';
 import { isOriginAllowed } from '../../src/utils/transport.js';
 import type { ServerConfig } from '../../src/types/config.js';
 
@@ -26,6 +26,10 @@ async function parseWithArgs(args: string[]): Promise<any> {
       .option('sse-port', {
         type: 'number',
         description: 'Port for SSE transport (default: 9444)'
+      })
+      .option('sse-allowed-origins', {
+        type: 'string',
+        description: 'Comma-separated browser origins allowed to use the SSE transport'
       })
       .help()
       .parse();
@@ -65,7 +69,8 @@ describe('TransportConfig', () => {
       expect(config.transport).toEqual({
         mode: 'stdio',
         sseHost: '127.0.0.1',
-        ssePort: 9444
+        ssePort: 9444,
+        sseAllowedOrigins: []
       });
     });
 
@@ -106,8 +111,26 @@ describe('TransportConfig', () => {
       expect(config.transport).toEqual({
         mode: 'sse',
         sseHost: '0.0.0.0',
-        ssePort: 3000
+        ssePort: 3000,
+        sseAllowedOrigins: []
       });
+    });
+
+    it('P12: should parse comma-separated sseAllowedOrigins', () => {
+      const config = makeConfig();
+      applyCliTransport(config, 'sse', '0.0.0.0', undefined, 'https://app.example.com, 192.168.1.10');
+      expect(config.transport!.sseAllowedOrigins).toEqual([
+        'https://app.example.com',
+        '192.168.1.10'
+      ]);
+    });
+
+    it('P12: should ignore an sseAllowedOrigins string with only blanks', () => {
+      const config = makeConfig();
+      config.transport!.sseAllowedOrigins = ['https://keep.example'];
+      applyCliTransport(config, undefined, undefined, undefined, ' , , ');
+      // Nothing usable was provided, so the existing value is preserved.
+      expect(config.transport!.sseAllowedOrigins).toEqual(['https://keep.example']);
     });
 
     it('should ignore invalid ssePort values', () => {
@@ -215,6 +238,79 @@ describe('isOriginAllowed (P2)', () => {
   });
 });
 
+// P12: explicit allowed-origin list, required for wildcard binds (0.0.0.0 / ::)
+// where the bind host is not a usable origin and for reverse-proxy hostnames.
+describe('isOriginAllowed allowed-origins list (P12)', () => {
+  it('rejects a LAN browser origin on a wildcard bind when no origins are configured', () => {
+    expect(isOriginAllowed('http://192.168.1.10:9444', '0.0.0.0')).toBe(false);
+    expect(isOriginAllowed('http://192.168.1.10:9444', '0.0.0.0', [])).toBe(false);
+  });
+
+  it('allows an origin whose host is in the configured list (full origin form)', () => {
+    expect(
+      isOriginAllowed('http://192.168.1.10:9444', '0.0.0.0', ['http://192.168.1.10:9444'])
+    ).toBe(true);
+  });
+
+  it('allows an origin whose host is in the configured list (bare host form)', () => {
+    expect(
+      isOriginAllowed('http://192.168.1.10:9444', '0.0.0.0', ['192.168.1.10'])
+    ).toBe(true);
+  });
+
+  it('matches a configured host case-insensitively regardless of port/scheme', () => {
+    expect(
+      isOriginAllowed('https://APP.example.com', '0.0.0.0', ['http://app.example.com:8443'])
+    ).toBe(true);
+  });
+
+  it('still rejects an origin that is not loopback, the bind host, or in the list', () => {
+    expect(
+      isOriginAllowed('https://evil.example', '0.0.0.0', ['192.168.1.10'])
+    ).toBe(false);
+  });
+
+  it('still allows loopback even when an allowed-origins list is configured', () => {
+    expect(
+      isOriginAllowed('http://127.0.0.1:9444', '0.0.0.0', ['192.168.1.10'])
+    ).toBe(true);
+  });
+});
+
+// P12: config-file validation of transport.sseAllowedOrigins.
+describe('validateConfig sseAllowedOrigins (P12)', () => {
+  function configWithOrigins(sseAllowedOrigins: unknown): ServerConfig {
+    return {
+      global: DEFAULT_CONFIG.global,
+      shells: {},
+      transport: {
+        mode: 'sse',
+        sseHost: '0.0.0.0',
+        ssePort: 9444,
+        sseAllowedOrigins
+      }
+    } as unknown as ServerConfig;
+  }
+
+  it('rejects a non-array sseAllowedOrigins', () => {
+    expect(() => validateConfig(configWithOrigins('https://app.example.com'))).toThrow(
+      /sseAllowedOrigins must be an array/
+    );
+  });
+
+  it('rejects empty-string entries', () => {
+    expect(() => validateConfig(configWithOrigins(['https://ok.example', '   ']))).toThrow(
+      /sseAllowedOrigins/
+    );
+  });
+
+  it('accepts a valid array of origins', () => {
+    expect(() =>
+      validateConfig(configWithOrigins(['https://app.example.com', '192.168.1.10']))
+    ).not.toThrow();
+  });
+});
+
 describe('Transport CLI Arguments', () => {
   it('should return undefined transport when no flags given', async () => {
     const args = await parseWithArgs([]);
@@ -252,6 +348,13 @@ describe('Transport CLI Arguments', () => {
     expect(args.transport).toBe('sse');
     expect(args['sse-host']).toBe('0.0.0.0');
     expect(args['sse-port']).toBe(3000);
+  });
+
+  it('P12: should parse --sse-allowed-origins', async () => {
+    const args = await parseWithArgs([
+      '--sse-allowed-origins', 'https://app.example.com,192.168.1.10'
+    ]);
+    expect(args['sse-allowed-origins']).toBe('https://app.example.com,192.168.1.10');
   });
 
   it('should reject invalid transport value', async () => {


### PR DESCRIPTION
## Summary

Adds an HTTP/SSE transport as an alternative to stdio for the MCP server, selectable via CLI flags or config. The stdio path is preserved and unchanged.

## Key changes

- **New transport module** (`src/utils/transport.ts`): `createSseServer()` sets up an HTTP server with `GET /sse` (opens an `SSEServerTransport` stream) and `POST /messages?sessionId=...` (routes to the matching session), plus `closeSseServer()` for clean shutdown.
- **CLI + config**: new `--transport` (`stdio` | `sse`), `--sse-host`, and `--sse-port` flags, a `TransportConfig` type, defaults, and config-file overrides. Documented in the README.
- **CLIServer integration**: `run()` starts SSE when configured; cleanup closes the HTTP server and releases lingering sockets.

## Bug fixes in this branch

- **SSE session leak on client disconnect**: session cleanup was registered on `transport.onclose` before `mcpServer.connect()`, which the MCP SDK overwrites with its own handler. Result: sessions were never removed on disconnect (unbounded `Map` growth), and a POST to a dead session returned `500` instead of `404`. Fixed by registering cleanup after `connect()` and chaining the SDK's handler. See `docs/tasks/http_sse_transport/session-leak-on-disconnect.md`.
- **Worker-exit warnings**: release `process.stdin` on cleanup and remove SIGINT handlers to prevent Jest open-handle leaks.

## Testing

- `npm run lint` (`tsc --noEmit`): clean.
- `npm test`: 918 passed, 24 skipped, 0 failed.
- New integration coverage: SSE tool execution, security scenarios, resources, edge cases (disconnect/reconnect, malformed input), and stdio protocol-handshake tests. A reusable `SseTestClient` helper was added.
- Markdown docs and README pass markdownlint (0 errors).

## Notes

- No stdio regression; the SDK's transport teardown is preserved.
- No linter suppressions.

@codex review
