### PR TITLE
ci: bump checkout and setup-node to v6 for Node 24 runtime

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,9 +16,9 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
       - name: Install dependencies
@@ -36,9 +36,9 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
       - name: Install dependencies
@@ -53,9 +53,9 @@ jobs:
   test-windows-no-bash:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/docs/tasks/bump_gha_action_versions/PRD.md
+++ b/docs/tasks/bump_gha_action_versions/PRD.md
@@ -1,0 +1,101 @@
+# PRD: Bump GitHub Actions to Node 24-Compatible Versions
+
+## Objective
+
+Update the pinned versions of the reusable GitHub Actions used in this
+repository's CI/CD workflows so they run on a supported Action runtime
+(Node 24). This removes the deprecation warnings GitHub now emits for actions
+still bound to the Node 16/20 runtimes and prevents a forced, unmanaged runtime
+migration on 2026-06-16.
+
+## Background
+
+GitHub is retiring older Node runtimes for JavaScript-based actions. Actions
+pinned to deprecated runtimes are scheduled to be force-migrated to Node 24 on
+2026-06-16. The CI logged a non-blocking warning recommending that the action
+versions be bumped before that forced cutover.
+
+The original warning referenced `actions/checkout@v4` and
+`actions/setup-node@v3`. Inspection of the actual workflow files shows the
+repository is, in fact, further behind than the warning implied:
+
+| File | Action | Currently pinned | Occurrences |
+| ---- | ------ | ---------------- | ----------- |
+| `.github/workflows/build-and-test.yml` | `actions/checkout` | `@v3` | 3 |
+| `.github/workflows/build-and-test.yml` | `actions/setup-node` | `@v3` | 3 |
+| `.github/workflows/publish.yml` | `actions/checkout` | `@v4` | 1 |
+| `.github/workflows/publish.yml` | `actions/setup-node` | `@v3` | 1 |
+
+`actions/checkout@v3` and `actions/setup-node@v3` bind to the Node 16 runtime
+(already deprecated); `actions/checkout@v4` binds to Node 20. All of these are
+in scope for the forced Node 24 migration. Bumping each to the latest stable
+major that ships the Node 24 runtime resolves the warning for all jobs.
+
+This is a low-risk maintenance change. It does not alter workflow logic, the
+test matrix, or the application code.
+
+## Requirements
+
+### REQ-1: Upgrade `actions/checkout` to a Node 24 runtime major
+
+All four `actions/checkout` references (three in `build-and-test.yml`, one in
+`publish.yml`) must be pinned to the latest stable major version that runs on
+the Node 24 runtime (currently `@v5`). No `@v3` or `@v4` reference to
+`actions/checkout` may remain.
+
+### REQ-2: Upgrade `actions/setup-node` to a Node 24 runtime major
+
+All four `actions/setup-node` references (three in `build-and-test.yml`, one in
+`publish.yml`) must be pinned to the latest stable major version that runs on
+the Node 24 runtime (currently `@v5`). No `@v3` reference to
+`actions/setup-node` may remain.
+
+### REQ-3: Preserve existing workflow behavior
+
+The bump must be version-only. The `node-version` inputs, job structure, step
+ordering, `with:` parameters (`registry-url`, etc.), triggers, and all custom
+shell steps must remain unchanged. The CI must continue to pass on
+`ubuntu-latest` and `windows-latest` exactly as before.
+
+### REQ-4: No deprecation warnings remain
+
+After the change, a CI run on the updated branch must not emit any
+"deprecated Node version" / runtime-deprecation warnings attributable to
+`actions/checkout` or `actions/setup-node`.
+
+## Non-Requirements
+
+- Bumping the test/build `node-version` (`18.x` / `18`) to a newer LTS. Node 18
+  reaching end-of-life is a separate concern and is intentionally out of scope
+  to keep this PR small; see analysis.md for a noted observation.
+- Adding a Dependabot or other automated action-update configuration.
+- Pinning actions to full commit SHAs (supply-chain hardening) instead of major
+  tags.
+- Refactoring, consolidating, or otherwise restructuring the workflow jobs.
+- Any change to `src/`, tests, or runtime application behavior.
+
+## Acceptance Criteria
+
+1. No occurrence of `actions/checkout@v3` or `actions/checkout@v4` remains in
+   `.github/workflows/`.
+2. No occurrence of `actions/setup-node@v3` remains in `.github/workflows/`.
+3. All `actions/checkout` and `actions/setup-node` references are pinned to the
+   chosen Node 24 runtime major (e.g. `@v5`), consistently across both files.
+4. `node-version` values and all other workflow content are byte-for-byte
+   unchanged except for the action version tags.
+5. The `Build and Test` workflow passes on a PR for `test-linux`,
+   `test-windows`, and `test-windows-no-bash` jobs.
+6. No action-runtime deprecation warnings appear in the updated workflow run.
+7. YAML is valid (parses) and markdown planning docs pass `markdownlint-cli2`.
+
+## Deliverables
+
+| Deliverable | Type |
+| ----------- | ---- |
+| `.github/workflows/build-and-test.yml` | Update |
+| `.github/workflows/publish.yml` | Update |
+| `docs/tasks/bump_gha_action_versions/PRD.md` | Create |
+| `docs/tasks/bump_gha_action_versions/analysis.md` | Create |
+| `docs/tasks/bump_gha_action_versions/implementation_plan.md` | Create |
+| `docs/tasks/bump_gha_action_versions/progress.md` | Create |
+| `docs/tasks/bump_gha_action_versions/verification.md` | Create |

--- a/docs/tasks/bump_gha_action_versions/analysis.md
+++ b/docs/tasks/bump_gha_action_versions/analysis.md
@@ -1,0 +1,101 @@
+# Analysis: Bump GitHub Actions to Node 24-Compatible Versions
+
+## Goal
+
+Eliminate the GitHub Actions runtime-deprecation warning by pinning
+`actions/checkout` and `actions/setup-node` to the latest stable major that
+ships the Node 24 runtime, ahead of the forced migration on 2026-06-16.
+
+## Current Behavior
+
+The repository has two workflows under `.github/workflows/`:
+
+- `build-and-test.yml` — runs on `push`/`pull_request` (paths-ignore for docs
+  and markdown) and `workflow_dispatch`. Three jobs:
+  - `test-linux` (`ubuntu-latest`): `actions/checkout@v3` (line 19),
+    `actions/setup-node@v3` (line 21), `node-version: 18.x` (line 23).
+  - `test-windows` (`windows-latest`): `actions/checkout@v3` (line 39),
+    `actions/setup-node@v3` (line 41), `node-version: 18.x` (line 43).
+  - `test-windows-no-bash` (`windows-latest`): `actions/checkout@v3` (line 56),
+    `actions/setup-node@v3` (line 57), `node-version: 18.x` (line 59), plus a
+    series of custom `pwsh`/`cmd` steps that strip Git Bash / `ls` from PATH.
+- `publish.yml` — runs on `release: published` and `workflow_dispatch`. One
+  `publish` job (`ubuntu-latest`): `actions/checkout@v4` (line 16),
+  `actions/setup-node@v3` (line 17) with `registry-url`, `node-version: '18'`.
+
+Runtime binding of the currently pinned majors:
+
+| Action / tag | Bundled Node runtime | Status |
+| ------------ | -------------------- | ------ |
+| `actions/checkout@v3` | Node 16 | Deprecated |
+| `actions/checkout@v4` | Node 20 | In scope for forced Node 24 migration |
+| `actions/setup-node@v3` | Node 16 | Deprecated |
+
+The build tooling itself is npm-based (no `make`): `npm run build`
+(`tsc && chmod +x`), `npm run lint` (`tsc --noEmit`), `npm test` (jest via
+`--experimental-vm-modules`), and `npm run test:debug`. These are invoked
+directly by the workflow `run:` steps and are unaffected by the action version
+bump.
+
+## Feasibility
+
+Straightforward and low-risk. The change is a set of version-tag edits on
+`uses:` lines. `actions/checkout` and `actions/setup-node` maintain backward
+compatibility across these majors for the inputs used here (`node-version`,
+`registry-url`), so no `with:` changes are required. The work is mechanical and
+fully validated by an actual CI run on a PR.
+
+## Approach
+
+Pin every `actions/checkout` and `actions/setup-node` reference to the latest
+stable major that runs on Node 24. As of this writing that is `@v5` for both.
+
+Two ways to express the pin were considered:
+
+| Approach | Advantages | Disadvantages |
+| -------- | ---------- | ------------- |
+| Major-tag pin (`@v5`) | Matches the existing repo convention; auto-receives non-breaking patches; minimal diff | Tag is mutable; not supply-chain hardened |
+| Full commit SHA pin | Immutable, supply-chain hardened | Larger diff; needs SHA lookup; diverges from current repo style; out of scope per PRD |
+
+Recommended: **major-tag pin (`@v5`)**. It keeps the diff minimal, matches how
+the repo already pins actions, and directly satisfies the deprecation fix. SHA
+pinning is explicitly a non-requirement.
+
+The implementer must confirm the latest stable major at PR time on the upstream
+release pages (`actions/checkout`, `actions/setup-node`); if a newer major than
+`v5` has shipped and bundles Node 24, prefer it, applying the same tag
+consistently in both files.
+
+## Implementation Notes
+
+- Total edits: 4 `checkout` references (3x `@v3`, 1x `@v4`) and 4 `setup-node`
+  references (4x `@v3`). All converge to the same target major.
+- Keep `node-version: 18.x` and `node-version: '18'` exactly as-is (REQ-3).
+- Keep the `registry-url: 'https://registry.npmjs.org'` input on the publish
+  job's `setup-node` step.
+- The original warning text named `checkout@v4`, but `build-and-test.yml`
+  actually pins `checkout@v3`. Search for both `@v3` and `@v4` so no stale pin
+  is missed.
+- `publish.yml` cannot be exercised by a normal PR (it triggers on release).
+  Validate it by YAML parse and visual diff; the runtime change is identical to
+  the build workflow, which the PR does exercise.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| A newer major changed default behavior of an input we rely on | Inputs used (`node-version`, `registry-url`) are stable across these majors; a PR CI run confirms green before merge |
+| Missing a reference (e.g. the lone `@v4` in publish.yml) | Grep for both `actions/checkout@` and `actions/setup-node@` across `.github/workflows/`; assert zero `@v3`/`@v4` remain |
+| `publish.yml` change cannot be tested by PR CI | Validate via YAML parse + diff review; behavior mirrors the validated build workflow |
+| Node 18 EOL surfaces as a separate failure later | Out of scope here; recorded as an observation for a future follow-up, not blocking this PR |
+
+## Test Strategy
+
+No application code changes, so unit/integration coverage is unaffected. The
+verification is workflow-level:
+
+- Static: grep assertions that no `@v3`/`@v4` action pins remain; YAML validity
+  check; markdown lint on the planning docs.
+- Dynamic: open the PR and confirm `test-linux`, `test-windows`, and
+  `test-windows-no-bash` all pass, and that the run log contains no
+  action-runtime deprecation warnings.

--- a/docs/tasks/bump_gha_action_versions/implementation_plan.md
+++ b/docs/tasks/bump_gha_action_versions/implementation_plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Bump GitHub Actions to Node 24-Compatible Versions
+
+## Overview
+
+A two-phase, version-only maintenance change. Phase 1 edits the action pins in
+both workflow files and statically verifies the edits. Phase 2 validates the
+change against a real CI run on a pull request and confirms the deprecation
+warning is gone.
+
+```mermaid
+flowchart TB
+    P1["Phase 1: Edit + static checks"] --> P2["Phase 2: CI validation on PR"]
+```
+
+## Affected Files
+
+| File | Change Type | Description |
+| ---- | ----------- | ----------- |
+| `.github/workflows/build-and-test.yml` | Update | Bump 3x `checkout@v3` and 3x `setup-node@v3` to the Node 24 major (`@v5`) |
+| `.github/workflows/publish.yml` | Update | Bump `checkout@v4` and `setup-node@v3` to the Node 24 major (`@v5`) |
+
+## Phase 1: Bump action versions
+
+### Implementation Work (Phase 1)
+
+- Confirm the latest stable major of `actions/checkout` and `actions/setup-node`
+  that bundles the Node 24 runtime (expected `@v5`). Use the same target tag for
+  both files.
+- In `.github/workflows/build-and-test.yml`:
+  - `test-linux`: change `actions/checkout@v3` (line 19) and
+    `actions/setup-node@v3` (line 21) to the target major.
+  - `test-windows`: change `actions/checkout@v3` (line 39) and
+    `actions/setup-node@v3` (line 41).
+  - `test-windows-no-bash`: change `actions/checkout@v3` (line 56) and
+    `actions/setup-node@v3` (line 57).
+- In `.github/workflows/publish.yml`:
+  - `publish`: change `actions/checkout@v4` (line 16) and
+    `actions/setup-node@v3` (line 17).
+- Do not touch `node-version`, `registry-url`, job structure, triggers, or any
+  custom `pwsh`/`cmd` steps.
+
+### Test Work (Phase 1)
+
+- No code tests to add. Add static guards:
+  - Grep `.github/workflows/` for `actions/checkout@v3`, `actions/checkout@v4`,
+    and `actions/setup-node@v3`; expect zero matches.
+  - Grep for the target tag; expect 4 `checkout` and 4 `setup-node` matches.
+
+### Verification (Phase 1)
+
+- Run the static grep assertions (see verification.md).
+- Validate YAML parses (e.g. parse each file with a YAML loader, or rely on
+  `actionlint` if available).
+- Confirm the only diff lines are the eight `uses:` version tags.
+
+## Phase 2: Validate on CI
+
+### Implementation Work (Phase 2)
+
+- Push the branch and open a pull request (the path-ignore filters skip docs-only
+  changes, so ensure the workflow file edits are in the PR to trigger
+  `Build and Test`).
+
+### Test Work (Phase 2)
+
+- None beyond observing the triggered workflow run.
+
+### Verification (Phase 2)
+
+- Confirm `test-linux`, `test-windows`, and `test-windows-no-bash` all pass.
+- Inspect the run logs and confirm no action-runtime / "deprecated Node version"
+  warnings remain.
+- For `publish.yml` (not triggerable by PR), confirm via diff review and YAML
+  parse that the change matches the build workflow's runtime bump.
+
+## Dependency Graph
+
+```mermaid
+flowchart TB
+    P1["Phase 1: Bump action versions"] --> P2["Phase 2: Validate on CI"]
+```
+
+## Estimated Scope
+
+| Phase | Source Files | Test Files | Effort |
+| ----- | ------------ | ---------- | ------ |
+| Phase 1 | 2 | 0 | Small |
+| Phase 2 | 0 | 0 | Small |

--- a/docs/tasks/bump_gha_action_versions/progress.md
+++ b/docs/tasks/bump_gha_action_versions/progress.md
@@ -1,0 +1,46 @@
+# Progress: Bump GitHub Actions to Node 24-Compatible Versions
+
+## Status Legend
+
+| Marker | Meaning |
+| ------ | ------- |
+| `[ ]` | Not started |
+| `[x]` | Complete |
+| `[~]` | In progress |
+| `[!]` | Blocked or needs decision |
+| `[-]` | Skipped / not applicable |
+
+## Planning Checklist
+
+- [x] Analyze current behavior.
+- [x] Create analysis.md
+- [x] Create PRD.md
+- [x] Create implementation_plan.md
+- [x] Create verification.md
+- [x] Create progress.md
+
+## Phase 1: Bump action versions
+
+- [x] Confirm latest Node 24 major for `actions/checkout` and
+      `actions/setup-node`. Confirmed: `@v6` is the latest stable major for both
+      and bundles Node 24 (v5 also bundles Node 24; v6 preferred per plan).
+- [x] `build-and-test.yml` `test-linux`: bump `checkout` + `setup-node`.
+- [x] `build-and-test.yml` `test-windows`: bump `checkout` + `setup-node`.
+- [x] `build-and-test.yml` `test-windows-no-bash`: bump `checkout` + `setup-node`.
+- [x] `publish.yml` `publish`: bump `checkout@v4` + `setup-node@v3`.
+- [x] Grep: zero `@v3`/`@v4` references remain.
+- [x] Grep: 4 `checkout` + 4 `setup-node` references at target tag (`@v6`).
+- [x] YAML parses; diff is version-tags-only.
+
+## Phase 2: Validate on CI
+
+- [ ] Open PR with the workflow edits.
+- [ ] `test-linux` passes.
+- [ ] `test-windows` passes.
+- [ ] `test-windows-no-bash` passes.
+- [ ] No action-runtime deprecation warnings in the run logs.
+- [ ] `publish.yml` change confirmed by diff + YAML parse.
+
+## Review Feedback
+
+(Section populated when PR review feedback arrives.)

--- a/docs/tasks/bump_gha_action_versions/progress.md
+++ b/docs/tasks/bump_gha_action_versions/progress.md
@@ -34,12 +34,16 @@
 
 ## Phase 2: Validate on CI
 
-- [ ] Open PR with the workflow edits.
-- [ ] `test-linux` passes.
-- [ ] `test-windows` passes.
-- [ ] `test-windows-no-bash` passes.
-- [ ] No action-runtime deprecation warnings in the run logs.
-- [ ] `publish.yml` change confirmed by diff + YAML parse.
+- [x] Open PR with the workflow edits. (PR #85, branch
+      `ci/bump-gha-actions-node24`.)
+- [x] `test-linux` passes. (Run 26680802088 - success.)
+- [x] `test-windows` passes. (Run 26680802088 - success.)
+- [x] `test-windows-no-bash` passes. (Run 26680802088 - success.)
+- [x] No action-runtime deprecation warnings in the run logs. Only annotation
+      is an unrelated `notice`: `windows-latest` runner redirect to
+      `windows-2025` (runner-image migration, not action Node runtime).
+- [x] `publish.yml` change confirmed by diff + YAML parse. (Identical runtime
+      bump to the build workflow; release-triggered, not exercised by PR.)
 
 ## Review Feedback
 

--- a/docs/tasks/bump_gha_action_versions/verification.md
+++ b/docs/tasks/bump_gha_action_versions/verification.md
@@ -97,10 +97,11 @@ Expected: all pass, unchanged from baseline.
 
 The feature can be accepted when all items are true:
 
-- [ ] No `actions/checkout@v3` or `actions/checkout@v4` in `.github/workflows/`.
-- [ ] No `actions/setup-node@v3` in `.github/workflows/`.
-- [ ] All 4 `checkout` and 4 `setup-node` refs pinned to the Node 24 major.
-- [ ] `node-version` and all other workflow content unchanged.
-- [ ] `Build and Test` passes for all three jobs on the PR.
-- [ ] No action-runtime deprecation warnings in the run logs.
-- [ ] Planning docs pass `markdownlint-cli2`.
+- [x] No `actions/checkout@v3` or `actions/checkout@v4` in `.github/workflows/`.
+- [x] No `actions/setup-node@v3` in `.github/workflows/`.
+- [x] All 4 `checkout` and 4 `setup-node` refs pinned to the Node 24 major
+      (`@v6`).
+- [x] `node-version` and all other workflow content unchanged.
+- [x] `Build and Test` passes for all three jobs on the PR (run 26680802088).
+- [x] No action-runtime deprecation warnings in the run logs.
+- [x] Planning docs pass `markdownlint-cli2`.

--- a/docs/tasks/bump_gha_action_versions/verification.md
+++ b/docs/tasks/bump_gha_action_versions/verification.md
@@ -1,0 +1,106 @@
+# Verification Plan: Bump GitHub Actions to Node 24-Compatible Versions
+
+## Purpose
+
+Verify that all `actions/checkout` and `actions/setup-node` references are
+pinned to a Node 24 runtime major, that no other workflow content changed, and
+that CI passes without runtime-deprecation warnings.
+
+## Pre-Implementation Verification
+
+### Existing Tests Pass
+
+```bash
+npm run lint
+npm test
+```
+
+Expected: lint (`tsc --noEmit`) and the jest suite pass. (Baseline only — this
+task does not change application code, so these are unaffected by the bump.)
+
+### Baseline Action Pins (Before)
+
+```bash
+grep -rnE 'actions/(checkout|setup-node)@v[0-9]+' .github/workflows/
+```
+
+Expected baseline matches:
+
+| File | Action | Tag | Count |
+| ---- | ------ | --- | ----- |
+| `build-and-test.yml` | `actions/checkout` | `@v3` | 3 |
+| `build-and-test.yml` | `actions/setup-node` | `@v3` | 3 |
+| `publish.yml` | `actions/checkout` | `@v4` | 1 |
+| `publish.yml` | `actions/setup-node` | `@v3` | 1 |
+
+### Coverage Baseline (Before)
+
+| Module | Baseline Coverage | After Coverage | Delta |
+| ------ | ----------------- | -------------- | ----- |
+| N/A (no source changes) | -- % | -- % | -- % |
+
+## Post-Implementation Verification
+
+### Per-Phase Verification
+
+Phase 1 — no stale pins remain:
+
+```bash
+grep -rnE 'actions/(checkout@v[34]|setup-node@v3)' .github/workflows/
+```
+
+Expected: no matches (exit code 1 / empty output).
+
+Phase 1 — target pins present and consistent:
+
+```bash
+grep -rnE 'actions/checkout@v6' .github/workflows/    # expect 4 matches
+grep -rnE 'actions/setup-node@v6' .github/workflows/  # expect 4 matches
+```
+
+(Target major confirmed as `v6` — the latest stable major bundling Node 24 at
+implementation time. `v5` also bundles Node 24; `v6` was preferred per the
+implementation plan's "prefer the newest Node 24 major" guidance.)
+
+Phase 1 — only version tags changed:
+
+```bash
+git diff -- .github/workflows/
+```
+
+Expected: every changed line is a `uses:` action version tag; no changes to
+`node-version`, `with:` inputs, triggers, or shell steps.
+
+Phase 2 — CI run on the PR:
+
+- `test-linux`, `test-windows`, `test-windows-no-bash` all green.
+- Run logs contain no "deprecated Node version" / runtime-deprecation warnings.
+
+### Linter
+
+```bash
+npm run lint
+npx markdownlint-cli2 "docs/tasks/bump_gha_action_versions/*.md"
+```
+
+Expected: both pass.
+
+### Regression Check
+
+```bash
+npm test
+```
+
+Expected: all pass, unchanged from baseline.
+
+## Final Acceptance Verification
+
+The feature can be accepted when all items are true:
+
+- [ ] No `actions/checkout@v3` or `actions/checkout@v4` in `.github/workflows/`.
+- [ ] No `actions/setup-node@v3` in `.github/workflows/`.
+- [ ] All 4 `checkout` and 4 `setup-node` refs pinned to the Node 24 major.
+- [ ] `node-version` and all other workflow content unchanged.
+- [ ] `Build and Test` passes for all three jobs on the PR.
+- [ ] No action-runtime deprecation warnings in the run logs.
+- [ ] Planning docs pass `markdownlint-cli2`.


### PR DESCRIPTION
## Summary

Bumps the pinned GitHub Actions to the latest stable major that bundles the
**Node 24** runtime, removing the runtime-deprecation warnings GitHub emits for
actions still bound to Node 16/20 and avoiding the forced, unmanaged migration.

| File | Action | Before | After |
| ---- | ------ | ------ | ----- |
| `build-and-test.yml` | `actions/checkout` | `@v3` (x3) | `@v6` |
| `build-and-test.yml` | `actions/setup-node` | `@v3` (x3) | `@v6` |
| `publish.yml` | `actions/checkout` | `@v4` | `@v6` |
| `publish.yml` | `actions/setup-node` | `@v3` | `@v6` |

`@v6` is the latest stable major for both actions and bundles Node 24. Its
breaking changes do not affect this repo: `checkout@v6` changes credential
persistence (we do a plain checkout with no inputs), and `setup-node@v6` limits
automatic caching to npm (we do not use the `cache` input).

## What did not change

Version-only bump. `node-version` (`18.x` / `'18'`), `registry-url`, job
structure, triggers, and all custom `pwsh`/`cmd` PATH-stripping steps are
unchanged.

## Verification

- Static: no `@v3`/`@v4` pins remain; exactly 4 `checkout@v6` and 4
  `setup-node@v6` across both workflows; YAML parses; diff is the 8 `uses:`
  tags only.
- Local: `npm run lint` (tsc) clean; full jest suite green (1049 passed,
  24 skipped).
- CI: this PR exercises `test-linux`, `test-windows`, and `test-windows-no-bash`
  on the bumped actions. `publish.yml` (release-triggered, not exercised by PR)
  receives the identical runtime bump.

Task docs: `docs/tasks/bump_gha_action_versions/`.
