### PR TITLE
feat(vscode): wcli0.ignoreInheritedProfiles — mask inherited environment profiles

### DIFF
--- a/docs/tasks/ignore_inherited_profiles/PRD.md
+++ b/docs/tasks/ignore_inherited_profiles/PRD.md
@@ -1,59 +1,114 @@
-# PRD: Mask inherited environment profiles (`wcli0.ignoreInheritedProfiles`)
+# PRD: Let a workspace opt out of inherited environment profiles
 
-## Problem
+## Objective
 
-`wcli0.profiles` is read through VS Code's merged object setting, so User and
-Workspace profile maps are deep-merged the same way `wcli0.shells` is. As a result:
+Give the wcli0 configuration form (and the underlying settings model) an explicit way for a
+Workspace scope to ignore the environment profiles (`wcli0.profiles`) inherited from User scope, so a
+project can fully control its effective profile set instead of being permanently stuck with User
+profiles merged in. This mirrors the `ignoreInheritedShells` opt-out and is the deferred P110 review
+item from PR #87.
 
-- A workspace that clears the Profiles textarea cannot remove a profile inherited
-  from User settings — the inherited profile still appears in `readSettings()`.
-- Redefining an inherited profile at Workspace scope with only replacement env keys
-  leaves the inherited env entries in place (deep object merge).
+## Background
 
-These stale, inherited entries are written into the workspace managed config and
-keep the mcp.json export blocked, contradicting the user's intent.
+`wcli0.profiles` is an object-valued setting. When any meaningful profile is configured, the provider
+stops emitting global CLI flags and instead launches the server against an auto-managed `--config`
+file (`hasProfilesConfig` in `vscode-extension/src/settings.ts`), and `.vscode/mcp.json` export is
+blocked. VS Code deep-merges object settings across scopes, so a User-scope `wcli0.profiles` is merged
+into every workspace's effective value.
+
+Today the form cannot express "this workspace wants no inherited profiles":
+
+- Clearing the Profiles textarea produces `{}`, which the host converts to an unset key, removing the
+  Workspace value. VS Code then re-merges the inherited User profiles, so the effective
+  `wcli0.profiles` is unchanged and `hasProfilesConfig` stays true.
+- Redefining an inherited profile at Workspace scope with only replacement env keys leaves the
+  inherited env entries in place (deep object merge), so stale variables survive into the generated
+  managed config.
+
+These stale, inherited entries are written into the workspace managed config and keep the mcp.json
+export blocked, contradicting the user's intent. The empty-textarea state is ambiguous: it could mean
+"inherit from User" (today's behavior) or "do not use profiles here". This task introduces an explicit
+control to disambiguate, plus the host logic to honor the "mask" intent.
 
 Source: Codex review on PR #87, comment P110
-(`vscode-extension/src/settings.ts` around line 209).
+(`vscode-extension/src/settings.ts` around line 209;
+analysis in `docs/tasks/env_profiles/analysis_110_mask_inherited_profiles.md`).
 
-## Goal
+## Requirements
 
-Give profiles the same opt-out / replacement semantics already provided for
-per-shell settings via `ignoreInheritedShells`, so a workspace can fully control
-its effective profile set.
+### REQ-1: Explicit "ignore inherited profiles" control
 
-## Approach (mirror `ignoreInheritedShells`)
+The configuration form exposes a single, discoverable control (form-level toggle,
+`ignoreInheritedProfiles`) that, when enabled at Workspace scope, declares that the workspace must not
+use any environment profile regardless of what User scope defines. The control is only meaningful at
+Workspace scope (User scope has nothing to inherit from), matching the `ignoreInheritedShells` control.
 
-Use the existing `ignoreInheritedShells` implementation as the template. Touch
-points to mirror:
+### REQ-2: Masking representation persisted at Workspace scope
 
-- `vscode-extension/package.json` — add a `wcli0.ignoreInheritedProfiles` boolean
-  setting (resource-scoped), documented as a Workspace-only affordance.
-- `vscode-extension/src/settings.ts` — add `ignoreInheritedProfiles` to
-  `Wcli0Settings` and `buildSettings`; recompute it Workspace-only in
-  `readSettings` (mirror `ignoreInheritedShellsAtWorkspace`, honoring a defined
-  workspace-folder value first per P105); force false for Global in
-  `readSettingsForScope` (P101); add it to `INHERITABLE_SELECT_KEYS`; make
-  `hasProfilesConfig` return false when set.
-- `vscode-extension/src/configFile.ts` — in `buildConfigFile`, treat `profiles` as
-  empty when `ignoreInheritedProfiles` is set (mirror the `shells: {}` masking).
-- `vscode-extension/src/mcpProvider.ts` / `commands.ts` — ensure the
-  managed-config gate and show/export paths respect the opt-out.
-- `vscode-extension/src/webview.ts` — add the form control + scope availability /
-  note (Workspace-only), mirroring the shells control.
-- Tests across `settings.test.cjs`, `configFile.test.cjs`, `webview*.test.cjs`,
-  `commands.test.cjs`, `mcpProvider.test.cjs`, plus integration coverage.
-- `vscode-extension/README.md` — document the new setting.
+When the control is enabled and saved at Workspace scope, the host persists an explicit Workspace-level
+boolean that neutralizes the inherited profiles so the effective (merged) settings the provider reads
+no longer satisfy `hasProfilesConfig`. The representation survives VS Code's deep-merge of
+`wcli0.profiles` (i.e. it cannot rely on clearing or persisting `{}`).
 
-## Out of scope
+### REQ-3: Provider and export honor the mask
 
-- Per-profile (rather than whole-map) masking. The shells precedent is a single
-  opt-out toggle; match it unless review feedback asks for finer control.
+With the mask active, `hasProfilesConfig` evaluates to false for the workspace, so:
 
-## Acceptance
+- the provider (`vscode-extension/src/mcpProvider.ts`) does not force managed `--config` on account of
+  profiles, and
+- the `.vscode/mcp.json` export path (`commands.ts`) is no longer blocked by inherited profiles.
 
-- With `wcli0.ignoreInheritedProfiles: true` at Workspace scope, inherited User
-  profiles do not appear in the effective settings, the generated/pinned config,
-  or the mcp.json export, and the export is no longer blocked by inherited profiles.
-- A Global/User value of the flag does not suppress the user's own profiles.
-- Existing profile behavior is unchanged when the flag is unset.
+The generated/pinned config built by `buildConfigFile` emits no `profiles` when the mask is active.
+
+### REQ-4: Round-trip and clear semantics preserved
+
+Enabling, saving, reloading and disabling the control round-trips losslessly. Disabling the control
+restores today's inherit behavior. Clearing the Profiles textarea WITHOUT enabling the control keeps
+today's "inherit from User" behavior, so existing workflows are unaffected.
+
+### REQ-5: Documentation
+
+`README` / settings documentation and the contributed setting's `markdownDescription` explain the
+inherit-vs-mask distinction and when to use the control.
+
+## Non-Requirements
+
+- No change to how User-scope profiles are authored or merged for users who want inheritance.
+- No per-profile granular masking UI (mask profile A but inherit profile B); the control is
+  all-or-nothing for the workspace in this iteration (matching the shells precedent).
+- No change to the managed-config generation format itself or to the server's `profiles` schema.
+- No change to multi-root folder-scoped (`workspaceFolderValue`) handling beyond what already exists
+  for `ignoreInheritedShells`.
+
+## Acceptance Criteria
+
+1. With User `wcli0.profiles` non-empty and the new control enabled+saved at Workspace scope, the
+   effective settings read by the provider yield `hasProfilesConfig === false`.
+2. The generated config (`buildConfigFile`) emits no `profiles`, and the mcp.json export is no longer
+   blocked by inherited profiles in that state.
+3. A Global/User value of the flag does not suppress the user's own profiles (Workspace-only honoring,
+   mirroring `ignoreInheritedShells` P101).
+4. Disabling the control restores inherited-profiles behavior.
+5. Clearing the Profiles textarea without enabling the control still inherits the User profiles
+   (unchanged).
+6. The control round-trips through save/reload at Workspace scope.
+7. Unit tests cover the settings/host logic; an integration test covers the real VS Code deep-merge
+   behavior end-to-end.
+8. `tsc --noEmit`, the unit suite, the integration suite, and markdownlint all pass.
+
+## Deliverables
+
+| Deliverable | Type |
+| ----------- | ---- |
+| vscode-extension/package.json | Update |
+| vscode-extension/src/settings.ts | Update |
+| vscode-extension/src/configFile.ts | Update |
+| vscode-extension/src/mcpProvider.ts | Update |
+| vscode-extension/src/commands.ts | Update |
+| vscode-extension/src/webview.ts | Update |
+| vscode-extension/test/unit/settings.test.cjs | Update |
+| vscode-extension/test/unit/configFile.test.cjs | Update |
+| vscode-extension/test/unit/webviewProfiles.test.cjs | Update |
+| vscode-extension/test/unit/commands.test.cjs | Update |
+| vscode-extension/test/integration/extension.test.js | Update |
+| vscode-extension/README.md | Update |

--- a/docs/tasks/ignore_inherited_profiles/analysis.md
+++ b/docs/tasks/ignore_inherited_profiles/analysis.md
@@ -1,0 +1,110 @@
+# Analysis: Let a workspace opt out of inherited environment profiles
+
+## Goal
+
+Allow a Workspace scope to deterministically escape inherited profiles when User scope defines
+`wcli0.profiles`, by adding an explicit "ignore inherited profiles" control and the host logic to honor
+it. Resolves the deferred P110 item from PR #87.
+
+## Current Behavior
+
+- `vscode-extension/src/settings.ts`
+  - `isMeaningfulProfile(p)` returns true if a profile has a non-dropped `allowedShells` and at least
+    one non-empty, string-valued env key that still resolves after extension-owned-token expansion
+    (mirrors every `buildProfiles` drop condition).
+  - `hasProfilesConfig(s)` returns true if any profile with a non-blank name is meaningful. The
+    provider uses this (alongside `hasPerShellConfig`) to choose managed config vs CLI flags, and the
+    export command uses it to block `.vscode/mcp.json`.
+  - `readSettings(scope)` reads the MERGED effective value (`config.get(key, def)`), which is what the
+    provider launches from. For `ignoreInheritedShells`, `readSettings` overrides the merged read with
+    a Workspace-only recompute (`ignoreInheritedShellsAtWorkspace`) so a stray User-scope value cannot
+    suppress the user's own config everywhere (P101).
+  - `readSettingsForScope(target, scope)` reads only the value stored at one scope (via `inspect`) to
+    populate the form; it forces `ignoreInheritedShells = false` for Global.
+  - `INHERITABLE_SELECT_KEYS` lists keys (including `ignoreInheritedShells`) where an explicit value at
+    a scope masks the other scope; `explicitlySetSelectKeys` reports which are set.
+- `vscode-extension/src/configFile.ts`
+  - `buildConfigFile(sInput)` already masks shells when `ignoreInheritedShells` is set
+    (`s = sInput.ignoreInheritedShells ? { ...sInput, shells: {} } : sInput`) before building, and
+    calls `buildProfiles(s.profiles)` to emit the sanitized `profiles` block.
+- `vscode-extension/src/mcpProvider.ts`
+  - `provideMcpServerDefinitions` branches on `hasPerShellConfig(settings) || hasProfilesConfig(settings)`
+    to decide managed-config vs CLI-flag launch.
+- `vscode-extension/src/commands.ts`
+  - The show/export paths gate on `hasPerShellConfig(settings) || hasProfilesConfig(settings)`.
+- `vscode-extension/package.json`
+  - `wcli0.profiles` is a `"type": "object"` setting with `scope: "resource"`. VS Code deep-merges such
+    settings across User/Workspace/Folder. `wcli0.ignoreInheritedShells` is the boolean precedent.
+
+## Feasibility
+
+Feasible and well-bounded: this is the profiles twin of `ignoreInheritedShells`, which already
+stabilized over review rounds P87–P105. VS Code's deep-merge of object settings means a Workspace value
+cannot "remove" an inherited profile — it can only add or override keys, and any override is itself
+meaningful to `isMeaningfulProfile`. The mask must therefore be carried by a SEPARATE boolean setting,
+not by mutating `wcli0.profiles`.
+
+## Approach
+
+Introduce a new boolean setting, `wcli0.ignoreInheritedProfiles` (scope `resource`), honored
+Workspace-only, that the effective settings reader consults. When true, `hasProfilesConfig` treats
+`wcli0.profiles` as empty and `buildConfigFile` masks `profiles` to `{}`, so the provider does not
+force managed mode on account of profiles and the mcp.json export is unblocked.
+
+| Advantages | Disadvantages |
+| ---------- | ------------- |
+| Survives VS Code deep-merge: a Workspace boolean cleanly overrides a User boolean | Adds a new setting key to the schema and form |
+| No need to mutate or mask the `wcli0.profiles` object itself | Behavior is all-or-nothing, not per-profile |
+| Backward compatible: default false preserves today's inherit behavior | Two settings (`profiles` + the flag) now jointly determine the launch path |
+| Reuses the proven `ignoreInheritedShells` mechanism end-to-end (read, mask, form, gating) | A user setting the flag globally would be ignored (Workspace-only), which must be documented |
+
+### Rejected approach: persist `{}` or per-profile replacement masks
+
+Persisting `{}` does not work (deep-merge re-adds User profiles). Writing a Workspace profile that
+redefines an inherited one only deep-merges env keys, leaving stale inherited keys. Rejected as
+incorrect.
+
+## Implementation Notes
+
+- Add `wcli0.ignoreInheritedProfiles` (boolean, default false, `scope: "resource"`) to `package.json`
+  with a `markdownDescription` explaining inherit-vs-mask, mirroring `ignoreInheritedShells`.
+- Extend the normalized settings (`buildSettings`/`Wcli0Settings`) with the flag; read it via
+  `g<boolean>('ignoreInheritedProfiles', false)`.
+- In `readSettings`, recompute it Workspace-only via a new `ignoreInheritedProfilesAtWorkspace(c)`
+  helper (clone of `ignoreInheritedShellsAtWorkspace`, honoring a defined workspace-folder value
+  before the workspace value), so a stray User/Global value does not suppress the user's own profiles.
+- In `readSettingsForScope`, force the flag to `false` for Global (mirror `ignoreInheritedShells`).
+- Add `'ignoreInheritedProfiles'` to `INHERITABLE_SELECT_KEYS` so the form's set/clear detection
+  covers it.
+- Make `hasProfilesConfig(s)` return `false` when `s.ignoreInheritedProfiles` is true (single
+  authoritative gate, so the provider, show, and export paths all honor it).
+- In `buildConfigFile`, treat `profiles` as empty when `ignoreInheritedProfiles` is set (mirror the
+  existing `shells: {}` masking), so the generated/pinned config emits no `profiles`.
+- Form (`webview.ts`): add the toggle to the field model and the Profiles tab, render it as a
+  Workspace-relevant tri-state/boolean control with hint text, and drive the isolation chip
+  (`hasProfilesConfig` mirror) from it.
+- Verify the provider/commands sites all branch on `hasProfilesConfig` (no direct `s.profiles`
+  inspection that would bypass the gate).
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| New setting interacts subtly with deep-merge precedence | Honor it Workspace-only via the dedicated recompute; add an integration test for real merge |
+| Users confused by inherit-vs-mask | Clear `markdownDescription` and README section; hint text in the form |
+| Flag set at User scope unexpectedly disables profiles everywhere | Honor only at Workspace scope (mirror P101); document |
+| Unit stub models replace, not deep-merge | Add an integration test that sets User + Workspace values in a real VS Code host |
+| A site inspects `s.profiles` directly instead of `hasProfilesConfig` | Audit provider/commands/webview; route all launch/export decisions through `hasProfilesConfig` |
+
+## Test Strategy
+
+- Unit (`settings.test.cjs`): `hasProfilesConfig` returns false when the flag is set even with a
+  non-empty `profiles`; true when the flag is false; the Workspace-only recompute ignores a
+  Global-only value.
+- Unit (`configFile.test.cjs`): `buildConfigFile` emits no `profiles` key when the flag is set.
+- Unit (`webviewProfiles.test.cjs`): the toggle round-trips through save/collect; saving the flag
+  persists the boolean and does not clear `wcli0.profiles`.
+- Unit (`commands.test.cjs`): the export path is not blocked by inherited profiles when the flag is set.
+- Integration (`extension.test.js`): set User `wcli0.profiles` + Workspace
+  `wcli0.ignoreInheritedProfiles` in a real host; assert the effective config drops out of profiles
+  mode (the deep-merge case the unit stub cannot model), then unset and assert it returns.

--- a/docs/tasks/ignore_inherited_profiles/implementation_plan.md
+++ b/docs/tasks/ignore_inherited_profiles/implementation_plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Let a workspace opt out of inherited environment profiles
+
+## Overview
+
+Add a new boolean setting `wcli0.ignoreInheritedProfiles` that gates `hasProfilesConfig` and masks
+`profiles` in `buildConfigFile`, wire it through the normalized settings model (honored Workspace-only),
+surface it in the configuration form's Profiles tab, and document it. The work is layered: settings
+model first (the authoritative gate), then config-file masking and provider/export behavior, then the
+form, then docs, with an integration test validating the real VS Code deep-merge case. It mirrors the
+shipped `ignoreInheritedShells` feature throughout.
+
+```mermaid
+flowchart TB
+    P1["Phase 1: Setting + settings model"] --> P2["Phase 2: Config masking + gate"]
+    P1 --> P3["Phase 3: Form control"]
+    P2 --> P4["Phase 4: Integration test + docs"]
+    P3 --> P4
+```
+
+## Affected Files
+
+| File | Change Type | Description |
+| ---- | ----------- | ----------- |
+| vscode-extension/package.json | Update | Add `wcli0.ignoreInheritedProfiles` boolean setting |
+| vscode-extension/src/settings.ts | Update | Add flag to `Wcli0Settings`/`buildSettings`; Workspace-only recompute; force false for Global; add to `INHERITABLE_SELECT_KEYS`; gate `hasProfilesConfig` |
+| vscode-extension/src/configFile.ts | Update | Mask `profiles` to `{}` in `buildConfigFile` when the flag is set |
+| vscode-extension/src/mcpProvider.ts | Verify | No logic change if gating lives in `hasProfilesConfig`; confirm launch path |
+| vscode-extension/src/commands.ts | Verify | Confirm show/export branch on `hasProfilesConfig` |
+| vscode-extension/src/webview.ts | Update | Add the flag to the field model, render the toggle on the Profiles tab, wire collect/populate, drive the isolation chip |
+| vscode-extension/test/unit/settings.test.cjs | Update | `hasProfilesConfig` gate + Workspace-only recompute tests |
+| vscode-extension/test/unit/configFile.test.cjs | Update | `buildConfigFile` masks `profiles` when flag set |
+| vscode-extension/test/unit/webviewProfiles.test.cjs | Update | Form collect/populate + round-trip of the toggle |
+| vscode-extension/test/unit/commands.test.cjs | Update | Export not blocked by inherited profiles when flag set |
+| vscode-extension/test/integration/extension.test.js | Update | Real deep-merge end-to-end test |
+| vscode-extension/README.md | Update | Document inherit-vs-mask for profiles |
+
+## Phase 1: Setting and settings model
+
+### Implementation Work (settings model)
+
+- Add `wcli0.ignoreInheritedProfiles` (boolean, default false, `scope: "resource"`) to `package.json`
+  with a `markdownDescription` explaining inherit-vs-mask (clone the `ignoreInheritedShells` entry).
+- Add `ignoreInheritedProfiles: boolean` to `Wcli0Settings` and read it in `buildSettings`
+  (`g<boolean>('ignoreInheritedProfiles', false)`).
+- Add `ignoreInheritedProfilesAtWorkspace(c)` (clone of `ignoreInheritedShellsAtWorkspace`) and use it
+  in `readSettings` to override the merged read Workspace-only.
+- In `readSettingsForScope`, force `s.ignoreInheritedProfiles = false` for Global.
+- Add `'ignoreInheritedProfiles'` to `INHERITABLE_SELECT_KEYS`.
+- Gate `hasProfilesConfig(s)`: return `false` when `s.ignoreInheritedProfiles` is true.
+
+### Test Work (settings model)
+
+- `settings.test.cjs`: assert `hasProfilesConfig` is false when the flag is set with a non-empty
+  `profiles`, and true when the flag is false with the same `profiles`; assert a Global-only flag value
+  does not suppress the user's profiles (Workspace-only honoring).
+
+### Verification (settings model)
+
+- `npx tsc --noEmit` clean.
+- `node --require ./test/stubs/hook.cjs --test test/unit/settings.test.cjs` passes.
+
+## Phase 2: Config masking and gate
+
+### Implementation Work (config masking)
+
+- In `buildConfigFile`, when `ignoreInheritedProfiles` is set, build from `{ ...sInput, profiles: {} }`
+  (mirror the existing `shells: {}` masking) so no `profiles` are emitted into the generated/pinned
+  config.
+- Confirm `provideMcpServerDefinitions` and the export commands branch on `hasProfilesConfig`, so
+  gating there is sufficient; adjust any site that inspects `s.profiles` directly.
+
+### Test Work (config masking)
+
+- `configFile.test.cjs`: with the flag set and a non-empty `profiles`, the generated config has no
+  `profiles` key.
+- `commands.test.cjs`: with the flag set, the `.vscode/mcp.json` export is not blocked by inherited
+  profiles.
+
+### Verification (config masking)
+
+- Config/commands unit tests pass; the generated config omits `profiles` under the mask.
+
+## Phase 3: Form control
+
+### Implementation Work (form control)
+
+- Add `ignoreInheritedProfiles` to the form's field model in `webview.ts`.
+- Render a labeled tri-state/boolean control on the Profiles tab with hint text ("Ignore environment
+  profiles inherited from User settings"); show it as Workspace-relevant (disabled/hidden at User
+  scope, mirroring the shells control).
+- Wire it in the collect (save) and populate (init) paths following the existing scoped-boolean
+  pattern, and drive the Profiles isolation chip from the same gate.
+
+### Test Work (form control)
+
+- `webviewProfiles.test.cjs`: the toggle populates from init and is collected on save; saving the flag
+  persists the boolean and does NOT clear `wcli0.profiles`.
+
+### Verification (form control)
+
+- Unit suite passes.
+
+## Phase 4: Integration test and documentation
+
+### Implementation Work (integration and docs)
+
+- Update `README.md` with an inherit-vs-mask section for profiles (next to the shells equivalent).
+
+### Test Work (integration and docs)
+
+- `extension.test.js`: set User `wcli0.profiles` (non-empty) and Workspace
+  `wcli0.ignoreInheritedProfiles = true` in the real host; assert the effective config is NOT in
+  profiles mode (no managed `--config` forced by profiles; export unblocked), then unset the flag and
+  assert it returns to profiles mode.
+
+### Verification (integration and docs)
+
+- `npx tsc --noEmit`, full unit suite, `npx vscode-test`, and `markdownlint-cli2` all pass.
+
+## Dependency Graph
+
+```mermaid
+flowchart TB
+    G1["Phase 1: Setting + model"] --> G2["Phase 2: Config masking + gate"]
+    G1 --> G3["Phase 3: Form control"]
+    G2 --> G4["Phase 4: Integration + docs"]
+    G3 --> G4
+```
+
+## Estimated Scope
+
+| Phase | Source Files | Test Files | Effort |
+| ----- | ------------ | ---------- | ------ |
+| Phase 1 | 2 | 1 | Small |
+| Phase 2 | 3 | 2 | Small |
+| Phase 3 | 1 | 1 | Medium |
+| Phase 4 | 1 | 1 | Medium |

--- a/docs/tasks/ignore_inherited_profiles/progress.md
+++ b/docs/tasks/ignore_inherited_profiles/progress.md
@@ -40,36 +40,43 @@ feature (`docs/tasks/mask_inherited_per_shell_config/`).
 
 ## Phase 1: Setting and settings model
 
-- [ ] Add `wcli0.ignoreInheritedProfiles` to package.json
-- [ ] Add flag to `Wcli0Settings` and `buildSettings`
-- [ ] Workspace-only recompute in `readSettings` (folder value precedence)
-- [ ] Force false for Global in `readSettingsForScope`
-- [ ] Add to `INHERITABLE_SELECT_KEYS`
-- [ ] Gate `hasProfilesConfig` on the flag
-- [ ] settings.test.cjs gate + Workspace-only recompute tests
-- [ ] Verify tsc + settings unit test
+- [x] Add `wcli0.ignoreInheritedProfiles` to package.json
+- [x] Add flag to `Wcli0Settings` and `buildSettings`
+- [x] Workspace-only recompute in `readSettings` (folder value precedence)
+- [x] Force false for Global in `readSettingsForScope`
+- [x] Add to `INHERITABLE_SELECT_KEYS`
+- [x] Gate `hasProfilesConfig` on the flag
+- [x] settings.test.cjs gate + Workspace-only recompute tests (gate, set-key,
+  P101 Global-not-honored, P105 folder precedence)
+- [x] Verify tsc + settings unit test
 
 ## Phase 2: Config masking and gate
 
-- [ ] Mask `profiles` to `{}` in `buildConfigFile` when the flag is set
-- [ ] Confirm provider / show / export branch on `hasProfilesConfig`
-- [ ] configFile.test.cjs: generated config omits `profiles` when flag set
-- [ ] commands.test.cjs: export not blocked by inherited profiles when flag set
-- [ ] Verify config/commands unit tests
+- [x] Mask `profiles` to `{}` in `buildConfigFile` when the flag is set
+- [x] Confirm provider / show / export branch on `hasProfilesConfig` (no direct
+  `s.profiles` inspection — gating in `hasProfilesConfig` suffices)
+- [x] configFile.test.cjs: generated config omits `profiles` when flag set
+- [x] commands.test.cjs: export not blocked by inherited profiles when flag set
+- [x] Verify config/commands unit tests
 
 ## Phase 3: Form control
 
-- [ ] Add `ignoreInheritedProfiles` to the form field model
-- [ ] Render the toggle with hint text on the Profiles tab (Workspace-relevant)
-- [ ] Wire collect/populate; drive the Profiles isolation chip
-- [ ] webviewProfiles.test.cjs round-trip; save does not clear `wcli0.profiles`
-- [ ] Verify unit suite
+- [x] Add `ignoreInheritedProfiles` to the form field model (`FIELD_KEYS`,
+  `triBoolFields`, `inheritTriFields`)
+- [x] Render the toggle with hint text on the Profiles tab (Workspace-relevant)
+- [x] Wire collect/populate (generic tri-bool machinery); drive the Profiles
+  isolation chip; Workspace-only scope availability + user note
+- [x] webviewProfiles.test.cjs round-trip; save does not clear `wcli0.profiles`;
+  isolation + scope-availability
+- [x] Verify unit suite (392 pass)
 
 ## Phase 4: Integration test and documentation
 
-- [ ] README inherit-vs-mask section for profiles
-- [ ] extension.test.js deep-merge end-to-end test
-- [ ] Verify tsc + unit + integration + markdownlint
+- [x] README inherit-vs-mask section for profiles
+- [x] CHANGELOG entry; extension version date-bumped to `0.20260620.1`
+- [x] extension.test.js deep-merge end-to-end test (added; runs in CI — the
+  sandbox cannot download the VS Code test host)
+- [~] Verify tsc + unit + markdownlint locally; integration deferred to CI
 
 ## Review Feedback
 

--- a/docs/tasks/ignore_inherited_profiles/progress.md
+++ b/docs/tasks/ignore_inherited_profiles/progress.md
@@ -1,31 +1,76 @@
-# Progress: Mask inherited environment profiles
+# Progress: Let a workspace opt out of inherited environment profiles
 
 ## Status Legend
 
-| Marker | Meaning                   |
-| ------ | ------------------------- |
-| `[ ]`  | Not started               |
-| `[x]`  | Complete                  |
-| `[~]`  | In progress               |
-| `[!]`  | Blocked or needs decision |
-| `[-]`  | Skipped / not applicable  |
+| Marker | Meaning |
+| ------ | ------- |
+| `[ ]` | Not started |
+| `[x]` | Complete |
+| `[~]` | In progress |
+| `[!]` | Blocked or needs decision |
+| `[-]` | Skipped / not applicable |
 
 ## Origin
 
 Deferred from PR #87 Codex review comment P110 (see
-`docs/tasks/env_profiles/analysis_110_mask_inherited_profiles.md`).
+`docs/tasks/env_profiles/analysis_110_mask_inherited_profiles.md`). The P110 review thread is left
+unresolved upstream with a reply pointing to this task. Mirrors the shipped `ignoreInheritedShells`
+feature (`docs/tasks/mask_inherited_per_shell_config/`).
 
-## Checklist
+## Planning Checklist
 
-- [ ] Add `wcli0.ignoreInheritedProfiles` setting to package.json
-- [ ] Wire `ignoreInheritedProfiles` into `Wcli0Settings` / `buildSettings`
-- [ ] Recompute Workspace-only in `readSettings` (folder value precedence)
+- [x] Analyze current behavior.
+- [x] Create analysis.md
+- [x] Create PRD.md
+- [x] Create implementation_plan.md
+- [x] Create verification.md
+- [x] Create progress.md
+
+## Open Decisions
+
+- [x] Carry the mask via a separate boolean (`wcli0.ignoreInheritedProfiles`) rather than mutating
+  `wcli0.profiles`. Resolved: VS Code deep-merge means a Workspace object value cannot remove an
+  inherited profile, so a separate boolean is required (matches `ignoreInheritedShells`).
+- [x] Scope at which the flag is honored. Resolved: honored Workspace-only via a dedicated recompute in
+  `readSettings` (mirror `ignoreInheritedShellsAtWorkspace`/P101), so a stray User/Global value does
+  not suppress the user's own profiles everywhere.
+- [ ] Precedence when the flag is true AND the workspace sets its own non-empty `wcli0.profiles`.
+  Proposed for v1: the flag suppresses profiles mode entirely for the scope (all-or-nothing), as
+  documented; revisit own-vs-inherited precedence only if review asks.
+
+## Phase 1: Setting and settings model
+
+- [ ] Add `wcli0.ignoreInheritedProfiles` to package.json
+- [ ] Add flag to `Wcli0Settings` and `buildSettings`
+- [ ] Workspace-only recompute in `readSettings` (folder value precedence)
 - [ ] Force false for Global in `readSettingsForScope`
 - [ ] Add to `INHERITABLE_SELECT_KEYS`
-- [ ] Gate `hasProfilesConfig` off when set
-- [ ] Mask `profiles` in `buildConfigFile` when set
-- [ ] Respect opt-out in provider / show / export paths
-- [ ] Add webview form control + Workspace-only scope availability
-- [ ] Unit + integration tests
-- [ ] Update README.md
-- [ ] Verify `tsc --noEmit`, unit suites, markdown lint
+- [ ] Gate `hasProfilesConfig` on the flag
+- [ ] settings.test.cjs gate + Workspace-only recompute tests
+- [ ] Verify tsc + settings unit test
+
+## Phase 2: Config masking and gate
+
+- [ ] Mask `profiles` to `{}` in `buildConfigFile` when the flag is set
+- [ ] Confirm provider / show / export branch on `hasProfilesConfig`
+- [ ] configFile.test.cjs: generated config omits `profiles` when flag set
+- [ ] commands.test.cjs: export not blocked by inherited profiles when flag set
+- [ ] Verify config/commands unit tests
+
+## Phase 3: Form control
+
+- [ ] Add `ignoreInheritedProfiles` to the form field model
+- [ ] Render the toggle with hint text on the Profiles tab (Workspace-relevant)
+- [ ] Wire collect/populate; drive the Profiles isolation chip
+- [ ] webviewProfiles.test.cjs round-trip; save does not clear `wcli0.profiles`
+- [ ] Verify unit suite
+
+## Phase 4: Integration test and documentation
+
+- [ ] README inherit-vs-mask section for profiles
+- [ ] extension.test.js deep-merge end-to-end test
+- [ ] Verify tsc + unit + integration + markdownlint
+
+## Review Feedback
+
+(Added when PR review feedback arrives. Each comment gets a checkbox.)

--- a/docs/tasks/ignore_inherited_profiles/verification.md
+++ b/docs/tasks/ignore_inherited_profiles/verification.md
@@ -1,0 +1,75 @@
+# Verification Plan: Let a workspace opt out of inherited environment profiles
+
+## Purpose
+
+Verify that the new `wcli0.ignoreInheritedProfiles` setting lets a Workspace scope escape inherited
+profiles when User scope defines `wcli0.profiles`, without regressing existing behavior, and that the
+real VS Code deep-merge case is covered.
+
+## Pre-Implementation Verification
+
+Run from `vscode-extension/`.
+
+### Existing Tests Pass
+
+```bash
+npx tsc --noEmit -p ./
+node --require ./test/stubs/hook.cjs --test test/unit/*.test.cjs
+npx vscode-test
+```
+
+Expected: all pass (current baseline is 380 unit + 14 integration).
+
+### Coverage Baseline (Before)
+
+| Module | Baseline Coverage | After Coverage | Delta |
+| ------ | ----------------- | -------------- | ----- |
+| settings.ts | -- % | -- % | -- % |
+| configFile.ts | -- % | -- % | -- % |
+| webview.ts | -- % | -- % | -- % |
+
+## Post-Implementation Verification
+
+### Per-Phase Verification
+
+- Phase 1: `npx tsc --noEmit` clean; `settings.test.cjs` shows `hasProfilesConfig` false when the flag
+  is set with non-empty `profiles`, true when unset, and a Global-only flag value does not suppress the
+  user's profiles.
+- Phase 2: `configFile.test.cjs` shows the generated config omits `profiles` when the flag is set;
+  `commands.test.cjs` shows the mcp.json export is not blocked by inherited profiles.
+- Phase 3: `webviewProfiles.test.cjs` round-trips the toggle; saving the flag persists the boolean and
+  leaves `wcli0.profiles` untouched.
+- Phase 4: `extension.test.js` shows the deep-merge case escapes profiles mode with the flag set and
+  returns when unset.
+
+### Linter
+
+```bash
+npx tsc --noEmit -p ./
+npx markdownlint-cli2 "docs/tasks/ignore_inherited_profiles/*.md"
+```
+
+Expected: 0 errors.
+
+### Regression Check
+
+```bash
+node --require ./test/stubs/hook.cjs --test test/unit/*.test.cjs
+npx vscode-test
+```
+
+Expected: all previously-passing tests still pass; new tests pass.
+
+## Final Acceptance Verification
+
+The feature can be accepted when all items are true:
+
+- [ ] With User `wcli0.profiles` non-empty and the flag set at Workspace, the effective settings yield
+  `hasProfilesConfig === false`.
+- [ ] The generated config (`buildConfigFile`) emits no `profiles`, and the mcp.json export is no
+  longer blocked by inherited profiles in that state.
+- [ ] A Global/User value of the flag does not suppress the user's own profiles.
+- [ ] Disabling the flag restores inherited-profiles behavior.
+- [ ] Clearing the Profiles textarea without the flag still inherits the User profiles.
+- [ ] The control round-trips through save/reload at Workspace scope.
+- [ ] Unit and integration suites pass; markdownlint passes; `tsc --noEmit` clean.

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -12,6 +12,15 @@
   workspace cannot otherwise remove). When enabled, inherited profiles no longer
   force the auto-managed `--config` launch or block the `.vscode/mcp.json` export.
   Mirrors `wcli0.ignoreInheritedShells`; exposed on the **Profiles** tab.
+- `.vscode/mcp.json` export now succeeds for a profiles/shells workspace when a
+  loadable `wcli0.configFile` is referenced (the entry pins it as `--config`,
+  carrying the settings); it still refuses only when nothing can represent them.
+- `Show Resolved Launch Command` now states explicitly that an http/sse command
+  cannot carry shells/profiles (the auto-managed config is stdio-only) instead of
+  printing a command that silently omits them.
+- The configuration form's isolation indicator now mirrors the server's profile
+  drop rules (invalid/non-array `allowedShells`, and env values whose
+  `${workspaceFolder}` cannot resolve), so it no longer over-reports "Isolated".
 - The configuration form now loads and compares values per selected scope (User
   vs Workspace) via `inspect`, so editing one scope never surfaces or re-writes
   the other scope's values.

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -7,6 +7,11 @@
   `config.json`, and an auto-managed `--config` launch whenever any profile is
   configured (profiles cannot be passed as CLI flags). `.vscode/mcp.json` export
   refuses while profiles are configured, mirroring per-shell settings.
+- Added `wcli0.ignoreInheritedProfiles`: a Workspace-only opt-out that masks
+  environment profiles inherited from User scope (which VS Code deep-merges and a
+  workspace cannot otherwise remove). When enabled, inherited profiles no longer
+  force the auto-managed `--config` launch or block the `.vscode/mcp.json` export.
+  Mirrors `wcli0.ignoreInheritedShells`; exposed on the **Profiles** tab.
 - The configuration form now loads and compares values per selected scope (User
   vs Workspace) via `inspect`, so editing one scope never surfaces or re-writes
   the other scope's values.

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -14,13 +14,16 @@
   Mirrors `wcli0.ignoreInheritedShells`; exposed on the **Profiles** tab.
 - `.vscode/mcp.json` export now succeeds for a profiles/shells workspace when a
   loadable `wcli0.configFile` is referenced (the entry pins it as `--config`,
-  carrying the settings); it still refuses only when nothing can represent them.
+  carrying the settings), after a confirmation warning that the file is not
+  verified against the current settings; it still refuses when nothing can
+  represent them.
 - `Show Resolved Launch Command` now states explicitly that an http/sse command
   cannot carry shells/profiles (the auto-managed config is stdio-only) instead of
   printing a command that silently omits them.
 - The configuration form's isolation indicator now mirrors the server's profile
-  drop rules (invalid/non-array `allowedShells`, and env values whose
-  `${workspaceFolder}` cannot resolve), so it no longer over-reports "Isolated".
+  drop rules — invalid/non-array `allowedShells`, and env values whose
+  `${workspaceFolder}` / `${workspaceFolder:name}` token cannot resolve against the
+  actually-open folders — so it no longer over-reports "Isolated".
 - The configuration form now loads and compares values per selected scope (User
   vs Workspace) via `inspect`, so editing one scope never surfaces or re-writes
   the other scope's values.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -151,6 +151,27 @@ rejects it). `${workspaceFolder}` and `${userHome}` in a value are resolved when
 the config is generated; server-resolved tokens such as `${PATH}` are left intact.
 **Restart the MCP server** to apply changes.
 
+#### Ignoring inherited profiles (`wcli0.ignoreInheritedProfiles`)
+
+`wcli0.profiles` is an object setting, so VS Code **deep-merges** it across scopes
+just like `wcli0.shells`. A profile set in **User** settings is merged into every
+workspace's effective value, and a workspace **cannot remove** an inherited
+profile by clearing the Profiles editor — clearing only drops the workspace's own
+override, leaving the inherited User profile in effect (so the workspace stays in
+auto-managed mode and `.vscode/mcp.json` export stays blocked).
+
+To let a single project opt out, enable `wcli0.ignoreInheritedProfiles` at the
+**Workspace** scope (the **Profiles** tab of the Configure panel). It is a
+separate boolean — not part of the merged `wcli0.profiles` object — so it cleanly
+overrides the inherited value. When set, the extension ignores profiles for that
+workspace: they no longer force the auto-managed `--config` launch and no longer
+block the `.vscode/mcp.json` export.
+
+Leave it off (the default) to inherit and use profiles as before. The flag is
+all-or-nothing for the scope, and is honored only at the Workspace scope (a User
+value would suppress your own profiles everywhere, so the form disables the
+control there).
+
 ### User vs. workspace
 
 Set machine-wide defaults in **User** settings (e.g. launch method, package

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wcli0-vscode",
-  "version": "0.20260620.1",
+  "version": "0.20260620.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wcli0-vscode",
-      "version": "0.20260620.1",
+      "version": "0.20260620.2",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wcli0-vscode",
-  "version": "0.20260619.1",
+  "version": "0.20260620.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wcli0-vscode",
-      "version": "0.20260619.1",
+      "version": "0.20260620.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "wcli0-vscode",
   "displayName": "wcli0 — MCP Server",
   "description": "Configure and run the wcli0 MCP server with simple user- and workspace-level settings.",
-  "version": "0.20260619.1",
+  "version": "0.20260620.1",
   "publisher": "s2005",
   "license": "MIT",
   "engines": {
@@ -338,6 +338,12 @@
             ],
             "additionalProperties": false
           }
+        },
+        "wcli0.ignoreInheritedProfiles": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Ignore environment profiles (`#wcli0.profiles#`) inherited from a wider scope. VS Code deep-merges object settings, so a Workspace cannot remove a `#wcli0.profiles#` entry set at the User scope by clearing the Profiles editor. Enable this at the Workspace scope to opt out of inherited profiles entirely: they no longer force the auto-managed `--config` launch or block the `.vscode/mcp.json` export. Leave it off (the default) to inherit and use profiles as before.",
+          "scope": "resource"
         },
         "wcli0.allowedDirectories": {
           "type": "array",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "wcli0-vscode",
   "displayName": "wcli0 — MCP Server",
   "description": "Configure and run the wcli0 MCP server with simple user- and workspace-level settings.",
-  "version": "0.20260620.1",
+  "version": "0.20260620.2",
   "publisher": "s2005",
   "license": "MIT",
   "engines": {

--- a/vscode-extension/src/commands.ts
+++ b/vscode-extension/src/commands.ts
@@ -184,13 +184,22 @@ export async function writeWorkspaceMcpJson(
   // launch settings (method, allowed dirs) are irrelevant and only the port
   // matters — otherwise a valid external endpoint couldn't be written.
   if (settings.transportMode === 'stdio') {
+    // A referenced wcli0.configFile becomes the entry's `--config`; validate it can
+    // actually be loaded so the exported entry does not silently fall back to an
+    // implicit config the server discovers instead (P85).
+    const cfgPath = resolvedConfigFilePath(settings);
+    const cfgLoadable = !cfgPath || configFileLoadable(cfgPath);
+    const hasLoadableConfigFile = !!cfgPath && cfgLoadable;
     // Per-shell settings (wcli0.shells) and environment profiles (wcli0.profiles)
-    // cannot be expressed as the CLI flags a committed mcp.json carries; the
-    // auto-provider launches them via a managed --config file instead. Writing a
-    // stdio entry here would silently ignore them (different enabled shells /
-    // weaker restrictions / missing profiles), so refuse rather than emit a
-    // mismatched entry.
-    if (hasPerShellConfig(settings) || hasProfilesConfig(settings)) {
+    // cannot be expressed as the CLI flags a committed mcp.json carries. A referenced
+    // (loadable) wcli0.configFile IS pinned as the entry's --config below and DOES
+    // carry them, so the exported entry is self-consistent; only refuse when there is
+    // no config file to represent them, where a plain stdio entry would silently drop
+    // them (different enabled shells / weaker restrictions / missing profiles).
+    // (The provider prefers its auto-managed config over wcli0.configFile when both are
+    // set — keep the referenced file in sync with settings, or clear the settings, to
+    // match the provider exactly.)
+    if ((hasPerShellConfig(settings) || hasProfilesConfig(settings)) && !hasLoadableConfigFile) {
       void vscode.window.showErrorMessage(
         'wcli0: per-shell settings (wcli0.shells) and environment profiles (wcli0.profiles) cannot be ' +
           'represented in .vscode/mcp.json. Generate a config file (wcli0: Generate Config File) and ' +
@@ -198,11 +207,6 @@ export async function writeWorkspaceMcpJson(
       );
       return;
     }
-    // A referenced wcli0.configFile becomes the entry's `--config`; validate it can
-    // actually be loaded so the exported entry does not silently fall back to an
-    // implicit config the server discovers instead (P85).
-    const cfgPath = resolvedConfigFilePath(settings);
-    const cfgLoadable = !cfgPath || configFileLoadable(cfgPath);
     const blocking = validateLaunchSpec(settings, false, false, cfgLoadable).filter(
       (p) => p.blocking,
     );
@@ -366,10 +370,12 @@ export async function showLaunchCommand(
   const settings = readExportSettings(asScope(formScopeArg), scope);
   // Mirror the provider: when shells are configured individually OR environment
   // profiles are defined, the server is launched against an auto-managed config
-  // file, not the global CLI flags.
-  const perShell =
-    (hasPerShellConfig(settings) || hasProfilesConfig(settings)) &&
-    settings.transportMode === 'stdio';
+  // file, not the global CLI flags. The auto-managed config is stdio-only
+  // (buildManagedServerArgs forces --transport stdio), so this path is gated on stdio;
+  // for http/sse the command can't carry shells/profiles and says so explicitly below
+  // rather than silently omitting them.
+  const shellsOrProfilesConfigured = hasPerShellConfig(settings) || hasProfilesConfig(settings);
+  const perShell = shellsOrProfilesConfigured && settings.transportMode === 'stdio';
   // Also mirror the provider's pinning: a plain stdio launch with no per-shell
   // config and no wcli0.configFile is launched against a generated config when the
   // server would otherwise discover an implicit config that overrides the displayed
@@ -457,6 +463,24 @@ export async function showLaunchCommand(
       );
       output.appendLine('~/.win-cli-mcp/config.json) cannot override these settings.');
     }
+  }
+  // Shells/profiles can only be carried by the stdio auto-managed config, so an
+  // http/sse command above does NOT include them. Say so explicitly rather than let
+  // the user copy a command that silently runs without the configured shells/profiles.
+  if (shellsOrProfilesConfigured && settings.transportMode !== 'stdio') {
+    output.appendLine('');
+    output.appendLine(
+      'Note: shells (wcli0.shells) or environment profiles (wcli0.profiles) are configured but',
+    );
+    output.appendLine(
+      `cannot be expressed in a ${settings.transportMode} launch command (they require the stdio`,
+    );
+    output.appendLine(
+      'auto-managed config). Generate a config file (wcli0: Generate Config File) and start the',
+    );
+    output.appendLine(
+      'server with --config to apply them, or use stdio transport for the auto-managed launch.',
+    );
   }
   // Show the cwd the server actually runs in. With no wcli0.launch.cwd set, the
   // provider does NOT inherit the caller's directory: it launches from a private

--- a/vscode-extension/src/commands.ts
+++ b/vscode-extension/src/commands.ts
@@ -214,6 +214,25 @@ export async function writeWorkspaceMcpJson(
       void vscode.window.showErrorMessage(`wcli0: ${blocking.map((p) => p.message).join(' ')}`);
       return;
     }
+    // When shells/profiles are configured the entry relies entirely on the referenced
+    // configFile to carry them, but the export cannot confirm that file is in sync with
+    // the current settings (it may be stale or hand-written) and the provider would
+    // launch from its own settings-derived auto-managed config. Warn so a stale/divergent
+    // file is a deliberate choice, not a silent loss of profiles/per-shell restrictions.
+    if (hasPerShellConfig(settings) || hasProfilesConfig(settings)) {
+      const pick = await vscode.window.showWarningMessage(
+        `wcli0: the exported entry pins wcli0.configFile (${cfgPath}) to carry wcli0.shells / ` +
+          'wcli0.profiles, but the extension does not verify that file matches your current ' +
+          'settings. If it is stale, the committed entry will launch with different ' +
+          'shells/profiles than the form shows (the provider builds its own config from ' +
+          'settings). Regenerate it via "wcli0: Generate Config File" if unsure.',
+        { modal: true },
+        'Write anyway',
+      );
+      if (pick !== 'Write anyway') {
+        return;
+      }
+    }
     // A stdio entry with no explicit wcli0.configFile carries plain CLI flags but no
     // --config, so the server's loadConfig still discovers <cwd>/config.json — where
     // <cwd> is the configured wcli0.launch.cwd if set, otherwise the workspace folder

--- a/vscode-extension/src/configFile.ts
+++ b/vscode-extension/src/configFile.ts
@@ -428,7 +428,17 @@ export function buildConfigFile(sInput: Wcli0Settings): Record<string, unknown> 
   // executables/security overrides would silently take effect despite the opt-out
   // (P95). Treat shells as empty so every shell entry is built from its defaults
   // plus the legacy single-shell selector and the global security/limits.
-  const s: Wcli0Settings = sInput.ignoreInheritedShells ? { ...sInput, shells: {} } : sInput;
+  //
+  // The inherited-profiles mask (ignoreInheritedProfiles) is the profiles twin:
+  // when set, the generated/pinned config must emit NO `profiles`, otherwise an
+  // inherited User-scope profile would silently survive into the workspace config
+  // even though hasProfilesConfig has opted the launch out. Treat profiles as empty
+  // for the same reason (mirrors the shells masking).
+  const s: Wcli0Settings = {
+    ...sInput,
+    ...(sInput.ignoreInheritedShells ? { shells: {} } : {}),
+    ...(sInput.ignoreInheritedProfiles ? { profiles: {} } : {}),
+  };
   // Resolve the path values that will actually be emitted first, so downstream
   // decisions reflect what ends up in the file (an unresolved ${workspaceFolder}
   // entry is dropped and must not count as "configured").

--- a/vscode-extension/src/settings.ts
+++ b/vscode-extension/src/settings.ts
@@ -105,6 +105,15 @@ export interface Wcli0Settings {
    * and return to the global CLI-flag launch path (see hasPerShellConfig).
    */
   ignoreInheritedShells: boolean;
+  /**
+   * Whether this scope opts out of inherited environment profiles entirely. Like
+   * {@link ignoreInheritedShells}, VS Code deep-merges object settings, so a
+   * Workspace cannot remove a `profiles` entry inherited from User scope by
+   * clearing the Profiles textarea. This separate, non-merged boolean lets the
+   * workspace mask the inherited profiles so they no longer force managed
+   * `--config` mode or block the mcp.json export (see hasProfilesConfig).
+   */
+  ignoreInheritedProfiles: boolean;
   allowedDirectories: string[];
   initialDir: string;
   commandTimeout: number | null;
@@ -208,6 +217,7 @@ function buildSettings(g: Getter): Wcli0Settings {
     shells: g<ShellsConfig>('shells', {}),
     profiles: g<ProfilesConfig>('profiles', {}),
     ignoreInheritedShells: g<boolean>('ignoreInheritedShells', false),
+    ignoreInheritedProfiles: g<boolean>('ignoreInheritedProfiles', false),
     allowedDirectories: g<string[]>('allowedDirectories', []),
     initialDir: g<string>('initialDir', ''),
     commandTimeout: num(g<number | null>('commandTimeout', null)),
@@ -354,8 +364,16 @@ function isMeaningfulProfile(p: ProfileConfig | undefined): boolean {
  * {@link hasPerShellConfig}, a true result forces the extension to launch the
  * server with an auto-managed `--config` file: profiles are a config-file-only
  * concept with no CLI flag, so they cannot be expressed via launch flags.
+ *
+ * When `ignoreInheritedProfiles` is set, the scope has explicitly opted out of
+ * profiles (it cannot remove a User-scope `profiles` entry via deep-merge), so
+ * treat `profiles` as empty and return false — the single authoritative gate the
+ * provider, showLaunchCommand and writeWorkspaceMcpJson all consult.
  */
 export function hasProfilesConfig(s: Wcli0Settings): boolean {
+  if (s.ignoreInheritedProfiles) {
+    return false;
+  }
   const profiles = s.profiles ?? {};
   return Object.keys(profiles).some((name) => name.trim() !== '' && isMeaningfulProfile(profiles[name]));
 }
@@ -375,6 +393,10 @@ export function readSettings(scope?: vscode.Uri): Wcli0Settings {
   // even with no workspace open — contrary to the documented behavior. Honor it only
   // when it is explicitly set at Workspace (or workspace-folder) scope. (P101)
   s.ignoreInheritedShells = ignoreInheritedShellsAtWorkspace(c);
+  // The inherited-profiles mask is Workspace-only for the same reason (P101): a
+  // resource-scoped boolean set in User Settings would otherwise suppress the user's
+  // own wcli0.profiles in every workspace via the merged effective read.
+  s.ignoreInheritedProfiles = ignoreInheritedProfilesAtWorkspace(c);
   return s;
 }
 
@@ -394,6 +416,25 @@ function ignoreInheritedShellsAtWorkspace(c: vscode.WorkspaceConfiguration): boo
   // on for a folder that explicitly opted back into per-shell config (folder=false
   // over workspace=true). Honor the defined folder value first; a Global value is
   // still ignored (the mask is a Workspace-only affordance, see P101). (P105)
+  if (info.workspaceFolderValue !== undefined) {
+    return info.workspaceFolderValue === true;
+  }
+  return info.workspaceValue === true;
+}
+
+/**
+ * Whether `ignoreInheritedProfiles` is explicitly opted in at Workspace (or
+ * workspace-folder) scope. The profiles twin of {@link ignoreInheritedShellsAtWorkspace}:
+ * a Global/User value is deliberately ignored so a User setting cannot suppress
+ * profiles everywhere (the mask is a Workspace-only affordance, see {@link readSettings}).
+ */
+function ignoreInheritedProfilesAtWorkspace(c: vscode.WorkspaceConfiguration): boolean {
+  const info = c.inspect<boolean>('ignoreInheritedProfiles');
+  if (!info) {
+    return false;
+  }
+  // A workspace-folder value takes precedence over the workspace value for that
+  // resource (mirrors P105 for the shells mask); a Global value is still ignored.
   if (info.workspaceFolderValue !== undefined) {
     return info.workspaceFolderValue === true;
   }
@@ -425,6 +466,7 @@ export function readSettingsForScope(target: ConfigScope, scope?: vscode.Uri): W
   // effective read in {@link readSettings}. (P101)
   if (target === 'Global') {
     s.ignoreInheritedShells = false;
+    s.ignoreInheritedProfiles = false;
   }
   return s;
 }
@@ -461,6 +503,7 @@ export const INHERITABLE_SELECT_KEYS = [
   'allowAllDirs',
   'debug',
   'ignoreInheritedShells',
+  'ignoreInheritedProfiles',
 ] as const;
 
 /**

--- a/vscode-extension/src/webview.ts
+++ b/vscode-extension/src/webview.ts
@@ -689,6 +689,9 @@ function renderHtml(webview: vscode.Webview): string {
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
   const $ = (id) => document.getElementById(id);
+  // Whether a workspace folder is open (sent on every init). Used to approximate the
+  // host's workspaceFolder-token resolution when deciding if a profile isolates (P110).
+  let currentHasWorkspace = true;
   const numberFields = ['commandTimeout','maxCommandLength','maxOutputLines','transport.port'];
   // Booleans rendered as tri-state selects (Inherit / enabled / disabled). Selecting
   // Inherit submits null, which applySettings maps to undefined -> clears the value
@@ -853,16 +856,43 @@ function renderHtml(webview: vscode.Webview): string {
       return null;
     }
   }
-  // Whether a parsed profiles object has at least one profile with a non-empty env
-  // of string values under a non-blank key. Mirrors the host's isMeaningfulProfile
-  // so the isolation chip matches the provider's managed-launch decision.
+  // Whether a parsed profiles object has at least one profile the host would emit.
+  // Mirrors the host's isMeaningfulProfile/buildProfiles so the isolation chip matches
+  // the provider's managed-launch decision, including the drop conditions that make a
+  // profile non-isolating: a present-but-non-array allowedShells, a non-empty
+  // allowedShells with no valid shell name, and an env value whose extension-owned
+  // token cannot resolve.
+  const PROFILE_SHELL_NAMES = SHELL_DEFS.map((d) => d.name);
+  // The host drops an env value when, after resolving the extension-owned tokens
+  // (workspaceFolder / userHome), one is still unresolved. The webview has no resolver,
+  // so approximate from the known workspace state: a userHome token always resolves,
+  // while a workspaceFolder token (plain or named) resolves only when a workspace
+  // folder is open. This keeps the chip from OVER-reporting isolation for a value the
+  // host drops. (The token literal is written escaped so the surrounding template
+  // string does not interpolate it.)
+  function profileEnvValueUsable(v) {
+    if (typeof v !== 'string') return false;
+    if (!currentHasWorkspace && v.indexOf('\${workspaceFolder') !== -1) return false;
+    return true;
+  }
   function hasMeaningfulProfiles(p) {
     if (!p || typeof p !== 'object') return false;
     return Object.keys(p).some((name) => {
       if (!name.trim()) return false;
-      const env = p[name] && p[name].env;
+      const prof = p[name];
+      if (!prof || typeof prof !== 'object') return false;
+      // Mirror buildProfiles' allowedShells drops (P107): a present-but-non-array
+      // value, or a non-empty array with no valid shell, drops the whole profile.
+      const allowed = prof.allowedShells;
+      if (allowed !== undefined) {
+        if (!Array.isArray(allowed)) return false;
+        if (allowed.length > 0 && !allowed.some((sh) => PROFILE_SHELL_NAMES.includes(sh))) {
+          return false;
+        }
+      }
+      const env = prof.env;
       if (!env || typeof env !== 'object' || Array.isArray(env)) return false;
-      return Object.keys(env).some((k) => k.trim() !== '' && typeof env[k] === 'string');
+      return Object.keys(env).some((k) => k.trim() !== '' && profileEnvValueUsable(env[k]));
     });
   }
   // Refresh the inline parse-error message; returns true when the JSON is valid.
@@ -1280,6 +1310,7 @@ function renderHtml(webview: vscode.Webview): string {
   // no-workspace hint. When the folder is gone, force the Global radio so the form
   // never keeps Workspace selected against a non-existent target.
   function applyWorkspaceAvailability(hasWorkspace) {
+    currentHasWorkspace = !!hasWorkspace;
     const ws = document.querySelector('input[name=scope][value=Workspace]');
     const gl = document.querySelector('input[name=scope][value=Global]');
     if (hasWorkspace) {

--- a/vscode-extension/src/webview.ts
+++ b/vscode-extension/src/webview.ts
@@ -95,6 +95,9 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
       type: 'init',
       external,
       hasWorkspace: !!primaryWorkspaceFolder(),
+      // The open folder names, so the form can resolve ${workspaceFolder:name} tokens
+      // exactly as the host does when deciding whether a profile isolates (P110).
+      workspaceFolderNames: (vscode.workspace.workspaceFolders ?? []).map((f) => f.name),
       scope: currentScope,
       settings: readSettingsForScope(currentScope, scope),
       // Which optional-string keys are explicitly set at this scope, so the form
@@ -689,9 +692,11 @@ function renderHtml(webview: vscode.Webview): string {
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
   const $ = (id) => document.getElementById(id);
-  // Whether a workspace folder is open (sent on every init). Used to approximate the
-  // host's workspaceFolder-token resolution when deciding if a profile isolates (P110).
+  // Whether a workspace folder is open, and the open folder names (sent on every
+  // init). Used to resolve workspaceFolder tokens the way the host does when deciding
+  // if a profile isolates (P110).
   let currentHasWorkspace = true;
+  let currentWorkspaceFolderNames = [];
   const numberFields = ['commandTimeout','maxCommandLength','maxOutputLines','transport.port'];
   // Booleans rendered as tri-state selects (Inherit / enabled / disabled). Selecting
   // Inherit submits null, which applySettings maps to undefined -> clears the value
@@ -863,17 +868,24 @@ function renderHtml(webview: vscode.Webview): string {
   // allowedShells with no valid shell name, and an env value whose extension-owned
   // token cannot resolve.
   const PROFILE_SHELL_NAMES = SHELL_DEFS.map((d) => d.name);
-  // The host drops an env value when, after resolving the extension-owned tokens
-  // (workspaceFolder / userHome), one is still unresolved. The webview has no resolver,
-  // so approximate from the known workspace state: a userHome token always resolves,
-  // while a workspaceFolder token (plain or named) resolves only when a workspace
-  // folder is open. This keeps the chip from OVER-reporting isolation for a value the
-  // host drops. (The token literal is written escaped so the surrounding template
-  // string does not interpolate it.)
+  // The host drops an env value when, after resolving the extension-owned tokens, one
+  // is still unresolved (the server would expand the leftover to empty). Mirror the
+  // host's resolveVariables exactly: a named workspaceFolder:NAME token resolves only
+  // when a folder of that name is open, a plain workspaceFolder token resolves when any
+  // folder is open, and userHome always resolves. Then drop the value if any
+  // extension-owned token remains. (Regex sources are built from escaped strings so
+  // the surrounding template literal never sees a literal dollar-brace to interpolate.)
   function profileEnvValueUsable(v) {
     if (typeof v !== 'string') return false;
-    if (!currentHasWorkspace && v.indexOf('\${workspaceFolder') !== -1) return false;
-    return true;
+    var resolved = v
+      .replace(/\\$\\{workspaceFolder:([^}]+)\\}/g, function (m, name) {
+        return currentWorkspaceFolderNames.indexOf(name) !== -1 ? 'x' : m;
+      })
+      .replace(/\\$\\{workspaceFolder\\}/g, function (m) {
+        return currentHasWorkspace ? 'x' : m;
+      })
+      .replace(/\\$\\{userHome\\}/g, 'x');
+    return !/\\$\\{workspaceFolder(?::[^}]+)?\\}|\\$\\{userHome\\}/.test(resolved);
   }
   function hasMeaningfulProfiles(p) {
     if (!p || typeof p !== 'object') return false;
@@ -1376,6 +1388,9 @@ function renderHtml(webview: vscode.Webview): string {
       // controls. It deliberately does NOT switch a dirty form's selected scope (see
       // applyWorkspaceAvailability, P89), so apply it before the dirty guard.
       applyWorkspaceAvailability(msg.hasWorkspace);
+      currentWorkspaceFolderNames = Array.isArray(msg.workspaceFolderNames)
+        ? msg.workspaceFolderNames
+        : [];
       // A background configuration change must not discard unsaved edits, nor silently
       // retarget the save scope. While the form is dirty, skip BOTH the field refresh
       // and the scope-radio switch on an external reload, so the loaded scope

--- a/vscode-extension/src/webview.ts
+++ b/vscode-extension/src/webview.ts
@@ -25,6 +25,7 @@ const FIELD_KEYS = [
   'shells',
   'profiles',
   'ignoreInheritedShells',
+  'ignoreInheritedProfiles',
   'allowedDirectories',
   'initialDir',
   'commandTimeout',
@@ -591,6 +592,15 @@ function renderHtml(webview: vscode.Webview): string {
     extension writes an auto-managed config file and launches the server with <code>--config</code>
     (profiles cannot be passed as CLI flags). Restart the MCP server to apply changes.
   </div>
+
+  <label>Inherited profiles <span class="hint">when set at Workspace scope, ignore environment profiles (wcli0.profiles) inherited from User scope</span></label>
+  <select id="ignoreInheritedProfiles">
+    <option value="default">Inherit (use profiles)</option>
+    <option value="enabled">Ignore inherited profiles</option>
+    <option value="disabled">Do not ignore (explicit)</option>
+  </select>
+  <div class="hint" style="margin-top:4px">VS Code merges <code>wcli0.profiles</code> across scopes, so a Workspace cannot drop a User-scope profile by clearing it. Choose <strong>Ignore</strong> to opt this workspace out of inherited profiles &mdash; they no longer force the managed <code>--config</code> launch or block the <code>.vscode/mcp.json</code> export.</div>
+  <div class="hint" id="ignoreInheritedProfilesUserNote" style="display:none;margin-top:4px;color:var(--vscode-charts-yellow,#d7a930)">This opt-out applies to Workspace scope only. At User scope it would suppress your own profiles everywhere, so it is disabled here &mdash; switch to Workspace to use it.</div>
   <label>Profiles <span class="hint">JSON object keyed by profile name</span></label>
   <textarea id="profilesJson" spellcheck="false" style="min-height:200px" placeholder='{
   "ora19": {
@@ -683,9 +693,10 @@ function renderHtml(webview: vscode.Webview): string {
   // Booleans rendered as tri-state selects (Inherit / enabled / disabled). Selecting
   // Inherit submits null, which applySettings maps to undefined -> clears the value
   // at the target scope so a previous override can be removed from the form.
-  // ignoreInheritedShells uses the same value scheme (its options carry the
-  // default/enabled/disabled values) so it round-trips through this machinery.
-  const triBoolFields = ['allowAllDirs','debug','ignoreInheritedShells'];
+  // ignoreInheritedShells / ignoreInheritedProfiles use the same value scheme (their
+  // options carry the default/enabled/disabled values) so they round-trip through
+  // this machinery.
+  const triBoolFields = ['allowAllDirs','debug','ignoreInheritedShells','ignoreInheritedProfiles'];
   const arrayFields = ['allowedDirectories'];
   const stringFields = ['launch.packageSpec','launch.nodeScriptPath','launch.customCommand','launch.cwd','configFile','shell','initialDir','logDirectory','enableTruncation','enableLogResources','safetyMode','launch.method','transport.host','transport.mode'];
   // Optional string settings where an explicit empty value is a meaningful
@@ -706,7 +717,7 @@ function renderHtml(webview: vscode.Webview): string {
   // the control to Inherit so an unset value is not shown as an explicit default.
   // Mirrors INHERITABLE_SELECT_KEYS on the host.
   const inheritSelectFields = ['launch.method','shell','safetyMode','enableTruncation','enableLogResources','transport.mode'];
-  const inheritTriFields = ['allowAllDirs','debug','ignoreInheritedShells'];
+  const inheritTriFields = ['allowAllDirs','debug','ignoreInheritedShells','ignoreInheritedProfiles'];
 
   // Per-shell configuration (wcli0.shells). Mirrors PER_SHELL_DEFS on the host.
   const SHELL_DEFS = [
@@ -1131,10 +1142,14 @@ function renderHtml(webview: vscode.Webview): string {
       isolated = !masked && Object.keys(collectShells()).length > 0;
     }
     // Any meaningful environment profile also isolates the launch: the provider
-    // writes a managed --config when profiles are configured (they are not subject
-    // to the inherited-shell mask). Mirror the host's hasProfilesConfig.
+    // writes a managed --config when profiles are configured. Mirror the host's
+    // hasProfilesConfig — including the inherited-profiles mask: when "Ignore
+    // inherited profiles" is enabled the host returns false (profiles no longer
+    // force the managed launch), so they must not isolate here either.
     if (!isolated) {
-      isolated = hasMeaningfulProfiles(parseProfiles());
+      const ignProf = $('ignoreInheritedProfiles');
+      const profMasked = !!(ignProf && ignProf.value === 'enabled');
+      isolated = !profMasked && hasMeaningfulProfiles(parseProfiles());
     }
     chip.className = 'statuschip ' + (isolated ? 'sc-ok' : 'sc-warn');
     chip.textContent = isolated ? 'Isolated' : 'Overridable';
@@ -1154,6 +1169,10 @@ function renderHtml(webview: vscode.Webview): string {
   // isolates the launch, so refresh the header chip when it changes.
   const ignoreShellsEl = $('ignoreInheritedShells');
   if (ignoreShellsEl) ignoreShellsEl.addEventListener('change', updateIsolation);
+  // Toggling "Ignore inherited profiles" flips whether profiles isolate the launch,
+  // so refresh the header chip when it changes (mirrors the shells mask above).
+  const ignoreProfilesEl = $('ignoreInheritedProfiles');
+  if (ignoreProfilesEl) ignoreProfilesEl.addEventListener('change', updateIsolation);
   // Refresh the isolation status as the user types in ANY per-shell field, not only
   // the segmented enable buttons and configFile. Without this the chip would lag when
   // an executable command/args, an override or a WSL option is edited (P84). The
@@ -1288,18 +1307,29 @@ function renderHtml(webview: vscode.Webview): string {
     }
   }
 
-  // The inherited-shell mask (ignoreInheritedShells) is a Workspace-only opt-out from
-  // User-scope per-shell config. A Global value would suppress the User scope's OWN
-  // wcli0.shells everywhere (hasPerShellConfig treats any effective true as
-  // authoritative), so disable the control while editing User scope and show why,
-  // preventing the form from ever persisting it globally (P97).
+  // The inherited-config masks (ignoreInheritedShells / ignoreInheritedProfiles) are
+  // Workspace-only opt-outs from User-scope shells/profiles. A Global value would
+  // suppress the User scope's OWN wcli0.shells / wcli0.profiles everywhere (the
+  // has*Config gates treat any effective true as authoritative), so disable each
+  // control while editing User scope and show why, preventing the form from ever
+  // persisting them globally (P97).
   function applyScopeAvailability(scope) {
-    const ign = $('ignoreInheritedShells');
-    if (!ign) return;
     const isUser = scope === 'Global';
-    ign.disabled = isUser;
-    const note = $('ignoreInheritedShellsUserNote');
-    if (note) note.style.display = isUser ? '' : 'none';
+    const ign = $('ignoreInheritedShells');
+    if (ign) {
+      ign.disabled = isUser;
+      const note = $('ignoreInheritedShellsUserNote');
+      if (note) note.style.display = isUser ? '' : 'none';
+    }
+    // The inherited-profiles mask is Workspace-only for the same reason (a Global
+    // value would suppress the user's own profiles everywhere), so disable it while
+    // editing User scope and show why.
+    const ignProf = $('ignoreInheritedProfiles');
+    if (ignProf) {
+      ignProf.disabled = isUser;
+      const noteProf = $('ignoreInheritedProfilesUserNote');
+      if (noteProf) noteProf.style.display = isUser ? '' : 'none';
+    }
   }
 
   window.addEventListener('message', (e) => {

--- a/vscode-extension/test/integration/extension.test.js
+++ b/vscode-extension/test/integration/extension.test.js
@@ -85,6 +85,29 @@ describe('wcli0 extension', function () {
     }
   });
 
+  it('ignoreInheritedProfiles opts a workspace out of inherited profiles (deep-merge)', async function () {
+    const cfg = () => vscode.workspace.getConfiguration('wcli0');
+    // A User-scope profile is deep-merged into the workspace's effective value; the
+    // workspace cannot remove it by clearing wcli0.profiles.
+    await cfg().update(
+      'profiles',
+      { ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } } },
+      vscode.ConfigurationTarget.Global,
+    );
+    try {
+      assert.equal(hasProfilesConfig(readSettings()), true, 'inherits managed profiles mode');
+      // The separate boolean survives the deep-merge and flips the effective gate.
+      await cfg().update('ignoreInheritedProfiles', true, vscode.ConfigurationTarget.Workspace);
+      assert.equal(hasProfilesConfig(readSettings()), false, 'masked -> CLI-flag path');
+      // Unsetting the flag restores managed (inherited) profiles mode.
+      await cfg().update('ignoreInheritedProfiles', undefined, vscode.ConfigurationTarget.Workspace);
+      assert.equal(hasProfilesConfig(readSettings()), true, 'restored managed mode');
+    } finally {
+      await cfg().update('profiles', undefined, vscode.ConfigurationTarget.Global);
+      await cfg().update('ignoreInheritedProfiles', undefined, vscode.ConfigurationTarget.Workspace);
+    }
+  });
+
   it('round-trips a per-shell configuration at the global scope', async function () {
     const shells = {
       cmd: { enabled: true },

--- a/vscode-extension/test/unit/commands.test.cjs
+++ b/vscode-extension/test/unit/commands.test.cjs
@@ -233,10 +233,10 @@ test('P110: ignoreInheritedProfiles unblocks the mcp.json export', async () => {
   assert.equal(vscode.__state.calls.error.length, 0);
 });
 
-test('writeWorkspaceMcpJson exports profiles via a referenced loadable configFile', async () => {
+test('writeWorkspaceMcpJson exports profiles via a referenced loadable configFile after confirmation', async () => {
   // Profiles in settings normally block the export, but a referenced loadable
-  // wcli0.configFile is pinned as --config and carries them, so the entry is
-  // self-consistent and the export proceeds rather than refusing.
+  // wcli0.configFile is pinned as --config and carries them. The export warns that the
+  // file is not verified against settings, then proceeds once the user confirms.
   vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
     ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
   });
@@ -245,15 +245,35 @@ test('writeWorkspaceMcpJson exports profiles via a referenced loadable configFil
     'wcli0.configFile',
     '${workspaceFolder}/wcli0.json',
   );
+  vscode.__state.calls.warnReturn = 'Write anyway';
   // Inject a loadable check so the referenced file counts as loadable (P85).
   await writeWorkspaceMcpJson(undefined, () => true);
   assert.equal(vscode.__state.calls.error.length, 0, 'not refused');
+  assert.ok(
+    vscode.__state.calls.warn.some((w) => /does not verify that file matches/.test(w.message)),
+    'warns the configFile is not verified against settings',
+  );
   assert.ok(vscode.__state.files.has('/ws/.vscode/mcp.json'), 'entry written');
   const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
   assert.ok(
     parsed.servers.wcli0.args.includes('--config'),
     'entry pins --config carrying the profiles',
   );
+});
+
+test('writeWorkspaceMcpJson aborts the profiles+configFile export when the warning is dismissed', async () => {
+  // Declining the stale-file warning must not write a possibly-divergent entry.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
+  });
+  vscode.__setConfig(
+    vscode.ConfigurationTarget.Workspace,
+    'wcli0.configFile',
+    '${workspaceFolder}/wcli0.json',
+  );
+  vscode.__state.calls.warnReturn = undefined; // user cancels the modal
+  await writeWorkspaceMcpJson(undefined, () => true);
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
 });
 
 test('writeWorkspaceMcpJson still refuses profiles export when no configFile is referenced', async () => {

--- a/vscode-extension/test/unit/commands.test.cjs
+++ b/vscode-extension/test/unit/commands.test.cjs
@@ -146,6 +146,20 @@ test('P26/P73/P93: showLaunchCommand writes a separate display config, not the l
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
+test('showLaunchCommand notes that http mode cannot carry profiles instead of omitting them silently', async () => {
+  // The auto-managed config is stdio-only, so an http command can't include profiles.
+  // showLaunchCommand must say so explicitly rather than show a profile-less command.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.transport.mode', 'http');
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
+  });
+  const output = vscode.window.createOutputChannel('t');
+  await showLaunchCommand(output);
+  const text = output.lines.join('\n');
+  assert.match(text, /cannot be expressed in a http launch command/);
+  assert.match(text, /wcli0\.profiles/);
+});
+
 test('P98: showing commands for different settings uses distinct display config files', async () => {
   const { Wcli0McpProvider } = require('../../dist/mcpProvider.js');
   const fs = require('node:fs');
@@ -217,6 +231,40 @@ test('P110: ignoreInheritedProfiles unblocks the mcp.json export', async () => {
   await writeWorkspaceMcpJson();
   assert.ok(vscode.__state.files.has('/ws/.vscode/mcp.json'), 'export written with profiles masked');
   assert.equal(vscode.__state.calls.error.length, 0);
+});
+
+test('writeWorkspaceMcpJson exports profiles via a referenced loadable configFile', async () => {
+  // Profiles in settings normally block the export, but a referenced loadable
+  // wcli0.configFile is pinned as --config and carries them, so the entry is
+  // self-consistent and the export proceeds rather than refusing.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
+  });
+  vscode.__setConfig(
+    vscode.ConfigurationTarget.Workspace,
+    'wcli0.configFile',
+    '${workspaceFolder}/wcli0.json',
+  );
+  // Inject a loadable check so the referenced file counts as loadable (P85).
+  await writeWorkspaceMcpJson(undefined, () => true);
+  assert.equal(vscode.__state.calls.error.length, 0, 'not refused');
+  assert.ok(vscode.__state.files.has('/ws/.vscode/mcp.json'), 'entry written');
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.ok(
+    parsed.servers.wcli0.args.includes('--config'),
+    'entry pins --config carrying the profiles',
+  );
+});
+
+test('writeWorkspaceMcpJson still refuses profiles export when no configFile is referenced', async () => {
+  // Without a config file to carry them, a plain stdio entry would drop the profiles,
+  // so the export must still refuse.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
+  });
+  await writeWorkspaceMcpJson(undefined, () => true);
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false);
+  assert.ok(vscode.__state.calls.error.some((m) => /wcli0\.profiles/i.test(m)));
 });
 
 test('P72: writeWorkspaceMcpJson warns before exporting over a workspace config.json', async () => {

--- a/vscode-extension/test/unit/commands.test.cjs
+++ b/vscode-extension/test/unit/commands.test.cjs
@@ -207,6 +207,18 @@ test('writeWorkspaceMcpJson refuses to export when environment profiles are conf
   assert.ok(vscode.__state.calls.error.some((m) => /wcli0\.profiles/i.test(m)));
 });
 
+test('P110: ignoreInheritedProfiles unblocks the mcp.json export', async () => {
+  // Inherited profiles would normally block the export, but the Workspace opt-out
+  // masks them (hasProfilesConfig is false), so a plain stdio entry can be written.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } },
+  });
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', true);
+  await writeWorkspaceMcpJson();
+  assert.ok(vscode.__state.files.has('/ws/.vscode/mcp.json'), 'export written with profiles masked');
+  assert.equal(vscode.__state.calls.error.length, 0);
+});
+
 test('P72: writeWorkspaceMcpJson warns before exporting over a workspace config.json', async () => {
   // A committed <workspace>/config.json would override the exported (configFile-less)
   // stdio entry; the export must warn and respect a cancel.

--- a/vscode-extension/test/unit/configFile.test.cjs
+++ b/vscode-extension/test/unit/configFile.test.cjs
@@ -698,6 +698,29 @@ test('P95: without ignoreInheritedShells the per-shell overrides are still appli
   assert.deepEqual(cfg.shells.cmd.executable.args, ['/k']);
 });
 
+test('P110: ignoreInheritedProfiles strips profiles from a pinned/generated config', () => {
+  // A workspace opts out of inherited profiles, but a home/cwd config.json still forces
+  // the provider to pin via buildConfigFile. The inherited profile must NOT leak into
+  // the pinned config, mirroring the ignoreInheritedShells masking.
+  const cfg = buildConfigFile(
+    defaults({
+      ignoreInheritedProfiles: true,
+      profiles: { ora19: { env: { ORACLE_HOME: '/opt/oracle/19' } } },
+    }),
+  );
+  assert.equal('profiles' in cfg, false);
+});
+
+test('P110: without ignoreInheritedProfiles the profile is still emitted', () => {
+  const cfg = buildConfigFile(
+    defaults({
+      ignoreInheritedProfiles: false,
+      profiles: { ora19: { env: { ORACLE_HOME: '/opt/oracle/19' } } },
+    }),
+  );
+  assert.deepEqual(cfg.profiles.ora19, { env: { ORACLE_HOME: '/opt/oracle/19' } });
+});
+
 test('profiles: no profiles key emitted when none configured', () => {
   const cfg = buildConfigFile(defaults());
   assert.equal('profiles' in cfg, false);

--- a/vscode-extension/test/unit/settings.test.cjs
+++ b/vscode-extension/test/unit/settings.test.cjs
@@ -304,6 +304,70 @@ test('P105: a workspace-folder false overrides a workspace-true shell mask', () 
   assert.equal(readSettings().ignoreInheritedShells, true, 'folder true wins over workspace false');
 });
 
+// ---- ignoreInheritedProfiles (the profiles twin of the shell mask, P110) ----
+
+test('ignoreInheritedProfiles gates hasProfilesConfig off even with non-empty profiles', () => {
+  // A meaningful profile normally selects managed mode.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    p: { env: { A: 'b' } },
+  });
+  assert.equal(hasProfilesConfig(readSettings()), true);
+  // With the opt-out flag set, the scope drops out of profiles mode even though the
+  // (deep-merged) profiles value is non-empty — the workspace cannot remove the
+  // inherited entry, so this separate boolean is the escape hatch.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', true);
+  assert.equal(hasProfilesConfig(readSettings()), false);
+  // Clearing the flag restores managed mode.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', false);
+  assert.equal(hasProfilesConfig(readSettings()), true);
+});
+
+test('ignoreInheritedProfiles is an inheritable select key reported when set at a scope', () => {
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', true);
+  const ws = explicitlySetSelectKeys('Workspace');
+  assert.ok(ws.includes('ignoreInheritedProfiles'), 'reported set at workspace');
+  // Unset at Global -> not reported, so the form shows Inherit there.
+  assert.ok(!explicitlySetSelectKeys('Global').includes('ignoreInheritedProfiles'));
+});
+
+test('P101: a Global-scoped ignoreInheritedProfiles does not mask profiles', () => {
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    p: { env: { A: 'b' } },
+  });
+  // The mask set ONLY at User/Global scope (e.g. typed into settings.json, bypassing
+  // the form which disables the control there) must NOT suppress the user's own
+  // profiles: the opt-out is Workspace-only.
+  vscode.__setConfig(vscode.ConfigurationTarget.Global, 'wcli0.ignoreInheritedProfiles', true);
+  assert.equal(readSettings().ignoreInheritedProfiles, false, 'Global value not honored');
+  assert.equal(hasProfilesConfig(readSettings()), true, 'profiles still active');
+  // A Global-scope form read also reports it false (a Global export must not mask).
+  assert.equal(readSettingsForScope('Global').ignoreInheritedProfiles, false);
+  // Setting it at Workspace scope is the supported opt-out and IS honored.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', true);
+  assert.equal(readSettings().ignoreInheritedProfiles, true);
+  assert.equal(hasProfilesConfig(readSettings()), false);
+});
+
+test('P105: a workspace-folder false overrides a workspace-true profiles mask', () => {
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.profiles', {
+    p: { env: { A: 'b' } },
+  });
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', true);
+  assert.equal(readSettings().ignoreInheritedProfiles, true, 'workspace value honored');
+  // A workspace-folder value explicitly opts BACK IN; resource precedence wins.
+  vscode.__setConfig(
+    vscode.ConfigurationTarget.WorkspaceFolder,
+    'wcli0.ignoreInheritedProfiles',
+    false,
+  );
+  assert.equal(readSettings().ignoreInheritedProfiles, false, 'folder value wins over workspace');
+  assert.equal(hasProfilesConfig(readSettings()), true, 'profiles re-enabled for folder');
+  // A workspace-folder true also wins over a workspace false.
+  vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.ignoreInheritedProfiles', false);
+  vscode.__setConfig(vscode.ConfigurationTarget.WorkspaceFolder, 'wcli0.ignoreInheritedProfiles', true);
+  assert.equal(readSettings().ignoreInheritedProfiles, true, 'folder true wins over workspace false');
+});
+
 test('P23: the LICENSE retains the MIT copyright notice', () => {
   const fs = require('node:fs');
   const path = require('node:path');

--- a/vscode-extension/test/unit/webviewProfiles.test.cjs
+++ b/vscode-extension/test/unit/webviewProfiles.test.cjs
@@ -211,6 +211,30 @@ test('a profile whose only env value needs an unavailable ${workspaceFolder} doe
   assert.equal(h.els.get('isolationChip').textContent, 'Isolated');
 });
 
+test('a named ${workspaceFolder:name} value only isolates when a folder of that name is open', () => {
+  // The host resolves ${workspaceFolder:name} only against a folder of that exact name,
+  // so a window with other folders open still drops the value (and the profile). The
+  // chip must check the actual folder names, not merely that some workspace is open.
+  const h = makeHarness();
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: true,
+    workspaceFolderNames: ['app'],
+    scope: 'Workspace',
+    settings: { shells: {}, profiles: { p: { env: { ONLY: '${workspaceFolder:client}/bin' } } } },
+  });
+  assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
+  // Once a folder named "client" is open the token resolves and the profile isolates.
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: true,
+    workspaceFolderNames: ['app', 'client'],
+    scope: 'Workspace',
+    settings: { shells: {}, profiles: { p: { env: { ONLY: '${workspaceFolder:client}/bin' } } } },
+  });
+  assert.equal(h.els.get('isolationChip').textContent, 'Isolated');
+});
+
 test('a profiles round-trip through save persists into settings', async () => {
   vscode.__reset();
   vscode.__state.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];

--- a/vscode-extension/test/unit/webviewProfiles.test.cjs
+++ b/vscode-extension/test/unit/webviewProfiles.test.cjs
@@ -194,3 +194,73 @@ test('an empty profiles object clears the setting rather than persisting {}', as
   const cfg = vscode.workspace.getConfiguration('wcli0');
   assert.deepEqual(cfg.get('profiles', 'CLEARED'), 'CLEARED');
 });
+
+// ---- ignoreInheritedProfiles mask control (P110) ----
+
+test('turning on the ignoreInheritedProfiles toggle persists it without touching profiles', () => {
+  const h = makeHarness();
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: true,
+    scope: 'Workspace',
+    settings: { profiles: PROFILES },
+  });
+  // The control starts at Inherit; the user enables the mask.
+  assert.equal(h.els.get('ignoreInheritedProfiles').value, 'default');
+  h.els.get('ignoreInheritedProfiles').value = 'enabled';
+  h.clickSave();
+  const save = h.captured.find((m) => m.type === 'save');
+  assert.ok(save, 'save posted');
+  assert.equal(save.values.ignoreInheritedProfiles, true, 'mask persisted');
+  // Only the changed field is submitted: the untouched profiles are NOT re-written
+  // (so enabling the mask never clears the inherited profiles setting).
+  assert.equal('profiles' in save.values, false, 'profiles left untouched');
+});
+
+test('an unset ignoreInheritedProfiles renders as Inherit, and switching back clears it', () => {
+  const h = makeHarness();
+  // Loaded with the mask explicitly enabled at this scope...
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: true,
+    scope: 'Workspace',
+    settings: { profiles: {}, ignoreInheritedProfiles: true },
+    setSelectKeys: ['ignoreInheritedProfiles'],
+  });
+  assert.equal(h.els.get('ignoreInheritedProfiles').value, 'enabled');
+  // ...the user switches it back to Inherit, which clears the override on save.
+  h.els.get('ignoreInheritedProfiles').value = 'default';
+  h.clickSave();
+  const save = h.captured.find((m) => m.type === 'save');
+  assert.equal(save.values.ignoreInheritedProfiles, null, 'Inherit emits null (clears the override)');
+});
+
+test('an unset ignoreInheritedProfiles is forced to the Inherit state on load', () => {
+  const h = makeHarness();
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Workspace', settings: { profiles: {} } });
+  // Not in setSelectKeys -> rendered as Inherit ('default'), not an explicit value.
+  assert.equal(h.els.get('ignoreInheritedProfiles').value, 'default');
+});
+
+test('enabling the mask makes a configured profile no longer isolate the launch', () => {
+  const h = makeHarness();
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Workspace', settings: { shells: {} } });
+  h.els.get('profilesJson').value = JSON.stringify(PROFILES);
+  h.input('profilesJson');
+  assert.equal(h.els.get('isolationChip').textContent, 'Isolated', 'profile isolates by default');
+  // Turning on the mask flips the launch back to overridable (mirrors hasProfilesConfig).
+  h.els.get('ignoreInheritedProfiles').value = 'enabled';
+  h.input('profilesJson');
+  assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
+});
+
+test('the mask control is Workspace-only (disabled with a note at User scope)', () => {
+  const h = makeHarness();
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Global', settings: { profiles: {} } });
+  assert.equal(h.els.get('ignoreInheritedProfiles').disabled, true, 'disabled at User scope');
+  assert.equal(h.els.get('ignoreInheritedProfilesUserNote').style.display, '', 'note shown');
+  // Reloading at Workspace scope re-enables it and hides the note.
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Workspace', settings: { profiles: {} } });
+  assert.equal(h.els.get('ignoreInheritedProfiles').disabled, false, 'enabled at Workspace scope');
+  assert.equal(h.els.get('ignoreInheritedProfilesUserNote').style.display, 'none', 'note hidden');
+});

--- a/vscode-extension/test/unit/webviewProfiles.test.cjs
+++ b/vscode-extension/test/unit/webviewProfiles.test.cjs
@@ -172,6 +172,45 @@ test('a profile with an empty env does not isolate the launch', () => {
   assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
 });
 
+test('a profile the host drops (all-invalid allowedShells) does not isolate', () => {
+  // buildProfiles drops a profile whose non-empty allowedShells has no valid shell,
+  // so the chip must not report Isolated for it (it would mislead about pinning).
+  const h = makeHarness();
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Workspace', settings: { shells: {} } });
+  h.els.get('profilesJson').value = JSON.stringify({ p: { allowedShells: ['fish'], env: { A: 'b' } } });
+  h.input('profilesJson');
+  assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
+});
+
+test('a profile with a non-array allowedShells does not isolate', () => {
+  const h = makeHarness();
+  h.dispatch({ type: 'init', hasWorkspace: true, scope: 'Workspace', settings: { shells: {} } });
+  h.els.get('profilesJson').value = JSON.stringify({ p: { allowedShells: 'cmd', env: { A: 'b' } } });
+  h.input('profilesJson');
+  assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
+});
+
+test('a profile whose only env value needs an unavailable ${workspaceFolder} does not isolate', () => {
+  // With no workspace open the host drops the ${workspaceFolder} value (it cannot
+  // resolve), leaving an empty env the server rejects — so it must not isolate.
+  const h = makeHarness();
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: false,
+    scope: 'Global',
+    settings: { shells: {}, profiles: { p: { env: { ONLY: '${workspaceFolder}/bin' } } } },
+  });
+  assert.equal(h.els.get('isolationChip').textContent, 'Overridable');
+  // The same profile DOES isolate once a workspace is open (the token resolves).
+  h.dispatch({
+    type: 'init',
+    hasWorkspace: true,
+    scope: 'Workspace',
+    settings: { shells: {}, profiles: { p: { env: { ONLY: '${workspaceFolder}/bin' } } } },
+  });
+  assert.equal(h.els.get('isolationChip').textContent, 'Isolated');
+});
+
 test('a profiles round-trip through save persists into settings', async () => {
   vscode.__reset();
   vscode.__state.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];


### PR DESCRIPTION
## Summary

Implements the deferred **"mask inherited environment profiles"** feature (PR #87 Codex review item **P110**): a new Workspace-only `wcli0.ignoreInheritedProfiles` boolean that lets a workspace opt out of environment profiles inherited from User scope. It mirrors the shipped `wcli0.ignoreInheritedShells` mechanism end to end.

This PR contains both the **task planning docs** (the `docs/tasks/ignore_inherited_profiles/` set) and the **implementation**.

## Why

`wcli0.profiles` is an object setting, so VS Code **deep-merges** it across scopes. A profile set in User settings is merged into every workspace, and a workspace **cannot remove** it by clearing the Profiles editor — so it stays in auto-managed `--config` mode and `.vscode/mcp.json` export stays blocked. A separate, non-merged boolean is the only way to cleanly override the inherited value.

## Changes

**Settings (`settings.ts`)**
- `ignoreInheritedProfiles` on `Wcli0Settings`/`buildSettings`.
- Honored **Workspace-only** via `ignoreInheritedProfilesAtWorkspace` (workspace-folder precedence; Global ignored — P101/P105); forced `false` for Global in `readSettingsForScope`; added to `INHERITABLE_SELECT_KEYS`.
- `hasProfilesConfig` returns `false` when set — the single authoritative gate the provider, `showLaunchCommand`, and the mcp.json export all consult.

**Config (`configFile.ts`)**
- `buildConfigFile` masks `profiles` to `{}` when set, so no inherited profile leaks into a pinned/generated config (mirrors the existing `shells: {}` masking).

**Form (`webview.ts`)**
- New tri-state control on the **Profiles** tab, wired through the generic tri-bool machinery; drives the isolation chip; Workspace-only scope availability with a user-scope note.

**Schema/docs**
- New `wcli0.ignoreInheritedProfiles` setting in `package.json`; README inherit-vs-mask section; CHANGELOG entry; version date-bumped to `0.20260620.1`.

## Testing

- `tsc --noEmit` clean (both packages).
- Extension unit suite **392 pass / 0 fail** (added settings gate + P101/P105, configFile masking, commands export-unblock, and webviewProfiles round-trip / isolation / scope-availability cases).
- Added a deep-merge **integration** test mirroring the shells one; it runs in CI (the sandbox can't download the VS Code test host).

## Notes

- All-or-nothing for the scope (matches the shells precedent); no per-profile masking.
- Resolves the open P110 thread on PR #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)