### PR TITLE
fix(vscode): parse a direct wcli0 launch as one server argument list (P105)

### DIFF
--- a/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
@@ -1,0 +1,30 @@
+# Analysis 105 - Parse direct wcli0 arguments as one server argument list
+
+## Decision: Valid — fix applied
+
+For a direct `command: "wcli0"` entry the suffix scan had nothing to look for: every argument is
+already the server's own. Scanning anyway could cut the list in the wrong place. With
+`args: ["--allowAllDirs", "marker", "--no-allowAllDirs"]` the index-0 run failed the purity check on
+the positional `marker`, so the scan moved on and picked the trailing `--no-allowAllDirs` as the
+"server suffix". That left the ENABLING flag in `customArgs` and modeled `allowAllDirs` as false —
+and because a false boolean is simply not emitted, a no-op save wrote back `--allowAllDirs marker`.
+yargs reads that as allowAllDirs TRUE, so an unrelated edit flipped the server from restricted to
+unrestricted directories.
+
+The caller now takes the first of the review's two options: when `isWcli0Command(command)`, the
+whole arg list is handed to `parseServerArgs` (`start = 0`) instead of being scanned. That parser
+already implements yargs' own rules for this list — repeated booleans are last-wins (P89), and the
+`--` separator plus its positionals are preserved verbatim in `extraArgs` (P74) — so the split
+cannot land in the wrong place at all. The scan itself is now wrapper-only, and its dead
+`allowIndexZero` parameter was removed rather than left as an unused branch.
+
+Verified round-trips for a direct `wcli0` launch: `-- --debug` re-emits byte-identically with debug
+still false; `--shell cmd -- --shell bash` re-emits byte-identically; and the reported case now
+emits `marker` alone, which yargs resolves to allowAllDirs=false — the same restricted launch the
+original entry produced, and never the unrestricted rewrite.
+
+**Why:** Parsing beats preserving here because it keeps the entry editable: the flags stay modeled
+in the form, and the round-trip is still faithful because the emitted args resolve to the identical
+yargs result. The one visible change is that a boolean and its negation collapse to the value yargs
+computes for them, which is the same normalization every other modeled field already gets. See
+[[analysis_89_clear_safety_mode_on_later_false]] and [[analysis_75_no_server_suffix_past_double_dash]].

--- a/docs/tasks/autodetect_mcp_source/comment_105_parse_direct_wcli0_arg_list.md
+++ b/docs/tasks/autodetect_mcp_source/comment_105_parse_direct_wcli0_arg_list.md
@@ -1,0 +1,13 @@
+# P105 - Parse direct wcli0 arguments as one server argument list
+
+In `vscode-extension/src/configSource.ts:413` (`serverFlagSuffixStart`), a direct entry containing a
+positional between a boolean and its later negation -- `command: "wcli0", args: ["--allowAllDirs",
+"marker", "--no-allowAllDirs"]` -- fails the index-zero purity check on `marker`, but the loop
+continues and selects the final negation as a separate server suffix; `parseMcpEntry` consequently
+stores the enabling flag in `customArgs` while modeling the suffix as false, and a no-op save omits
+the false value and writes only `--allowAllDirs marker`, changing the server from restricted to
+unrestricted directories. This is distinct from the earlier repeated-boolean parser case because the
+positional causes the split before `parseServerArgs` runs; for a recognized direct wcli0 command the
+complete argument list must be parsed or preserved rather than searching for a later suffix.
+
+Reported in the review of 2026-08-23T19:28:04Z, on thread `PRRT_kwDOO7ppps6bhlg_`.

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -553,3 +553,22 @@ options. All verified against the project's yargs semantics and covered by new u
   `allowedDirectories` key at all. Verified by running the shipped webview script: the posted
   payload is exactly `{"commandTimeout":45}`. Three regression tests added - two client-side, one
   end-to-end - proving `--allowedDir ""` survives an unrelated save)
+
+## Post-merge follow-ups (PR #89 was merged with unresolved threads)
+
+The task-loop's thread query used `reviewThreads(first: 100)` with no pagination while the PR had
+106 threads, so the six newest findings were never returned and the PR was merged over them. They
+are addressed on follow-up branches.
+
+- [x] P105: Parse direct wcli0 arguments as one server argument list (P1 - fixed - a direct
+  `command: "wcli0"` entry now hands its WHOLE arg list to `parseServerArgs` instead of scanning for
+  a suffix. A positional between a boolean and its negation (`--allowAllDirs marker
+  --no-allowAllDirs`) made the scan split at the wrong place, leaving the enabling flag in
+  `customArgs` and modeling false, so a no-op save wrote `--allowAllDirs marker` and flipped the
+  server to UNRESTRICTED directories. The scan is now wrapper-only and its dead `allowIndexZero`
+  parameter was removed)
+- [ ] P106: Keep valueless scalar flags ahead of following positionals (P2, configSource.ts:969)
+- [ ] P107: Reject delimiters in edited transport hosts (P2, commands.ts:830)
+- [ ] P108: Exclude attached negations from modeled suffix evidence (P2, configSource.ts:249)
+- [ ] P109: Preserve valueless array flags before later positionals (P2, configSource.ts:943)
+- [ ] P110: Reject incompatible concurrent launch-method changes (P2, webview.ts:439)

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -362,18 +362,15 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * launcher options whose names collide with wcli0 flags (a wrapper's `--config`, node's
  * `--inspect`) in the launcher portion (P15).
  *
- * `allowIndexZero` is true only when the command IS the wcli0 binary, so an index-0 run
- * really is server flags. For a non-wcli0 (wrapper) command an index-0 flag run is
- * ambiguous — `mywrapper --transport fast` is the wrapper's own option, not a wcli0 flag
- * (P-wrapperflags) — so scanning starts at index 1: the leading token stays in the
- * launcher portion and the scan still finds a LATER modeled-flag suffix, e.g. the
- * `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
+ * Only ever used for a WRAPPER command; a direct wcli0 launch parses its whole arg list instead
+ * (P105). An index-0 flag run is ambiguous for a wrapper — `mywrapper --transport fast` is the
+ * wrapper's own option, not a wcli0 flag (P-wrapperflags) — so scanning starts at index 1: the
+ * leading token stays in the launcher portion and the scan still finds a LATER modeled-flag
+ * suffix, e.g. the `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
  *
- * A wrapper scan additionally requires the suffix to contain a modeled wcli0 flag
- * (`requireModeled`), so an unknown-only run such as the wrapper's own `--verbose` in
- * `wrapper target --verbose` is NOT mistaken for a server-flag suffix and stays in the
- * launcher portion (P56). The wcli0 binary itself (allowIndexZero) does not require this: its
- * args are genuinely wcli0's, including unknown-only extraArgs.
+ * The suffix must also contain a modeled wcli0 flag (`requireModeled` in the run check), so an
+ * unknown-only run such as the wrapper's own `--verbose` in `wrapper target --verbose` is NOT
+ * mistaken for a server-flag suffix and stays in the launcher portion (P56).
  *
  * The scan stops at a `--` options separator, because yargs treats everything after one as
  * positionals, so no server-flag suffix can begin there (P75). The single exception is a
@@ -386,8 +383,8 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * server would never read it (P83). `stdio` is forwarded to the run check so a stdio entry's
  * transport flags do not count as modeled evidence (P77).
  */
-function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = false): number {
-  for (let i = allowIndexZero ? 0 : 1; i < args.length; i++) {
+function serverFlagSuffixStart(args: string[], stdio = false): number {
+  for (let i = 1; i < args.length; i++) {
     if (args[i] === '--') {
       // An options separator: yargs treats every following token as a positional, so no
       // server-flag suffix can begin at or after it (P75). Stop -- unless this is a wrapper
@@ -398,10 +395,7 @@ function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = 
       // program) keeps its remainder in the launcher portion, so a positional is never modeled as
       // an active flag and a saved flag is never appended behind a separator the server ignores
       // (P83). A second `--` after the wrapped binary is that binary's own separator and stops
-      // the scan, exactly as it does for a direct wcli0 launch.
-      if (allowIndexZero) {
-        break;
-      }
+      // the scan, exactly as parseServerArgs stops at it for a direct wcli0 launch.
       const wrappedBinaryAt = args.findIndex((t, j) => j > i && isWcli0Command(t));
       if (wrappedBinaryAt === -1) {
         break;
@@ -409,7 +403,7 @@ function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = 
       i = wrappedBinaryAt; // resume scanning at the token AFTER the wrapped wcli0 binary
       continue;
     }
-    if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), !allowIndexZero, stdio)) {
+    if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), true, stdio)) {
       return i;
     }
   }
@@ -1145,16 +1139,23 @@ export function parseMcpEntry(entry: Record<string, unknown>): ParsedEntry {
     // `--config`/`--transport`, node's `--inspect`, uvx's `--from`) stays in customArgs
     // and a load/save round-trip preserves the command order (P15).
     //
-    // Only trust an index-0 boundary when the command IS the wcli0 binary (its args really
-    // are server flags). For a wrapper command an index-0 flag run is ambiguous —
-    // `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so the scan
-    // skips index 0 and keeps looking for a later modeled-flag suffix, so the `--shell` in
-    // `wrapper --no-cache --shell bash` is still recovered instead of stranded in customArgs
-    // (P-wrapperflags / P43).
+    // When the command IS the wcli0 binary there is nothing to split: every arg is the server's
+    // own, so the WHOLE list is parsed as one server argument list. Scanning it for a suffix could
+    // cut it in the wrong place — for `wcli0 --allowAllDirs marker --no-allowAllDirs` the index-0
+    // run failed the purity check on the positional `marker`, so the scan picked the trailing
+    // negation as the suffix, left the ENABLING flag in customArgs and modeled allowAllDirs=false;
+    // a no-op save then emitted `--allowAllDirs marker` and flipped the server from restricted to
+    // UNRESTRICTED directories (P105). parseServerArgs handles the `--` separator itself, keeping
+    // it and its positionals verbatim in extraArgs (P74), so the round-trip stays exact.
+    //
+    // For a wrapper command the split is still needed and still starts at index 1: an index-0 flag
+    // run is ambiguous — `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so
+    // the scan keeps looking for a later modeled-flag suffix, recovering the `--shell` in
+    // `wrapper --no-cache --shell bash` instead of stranding it (P-wrapperflags / P43).
     // This branch only ever parses a stdio entry (http/sse return earlier), so pass stdio=true:
     // a transport flag in the args must not "prove" a server-flag suffix that reorders a wrapper's
     // own options on save, since stdio leaves transport flags in extraArgs verbatim (P77).
-    const start = serverFlagSuffixStart(args, isWcli0Command(command), true);
+    const start = isWcli0Command(command) ? 0 : serverFlagSuffixStart(args, true);
     s.customArgs = args.slice(0, start);
     serverArgs = args.slice(start);
   }

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1572,9 +1572,12 @@ test('P74: a plain node entry does not model server flags after a `--` separator
   assert.deepEqual(settings.extraArgs, ['--', '--shell', 'cmd']);
 });
 
-test('P75: a `--` separator keeps the remainder with the launcher, not a server suffix', () => {
+test('P75/P105: a `--` separator in a direct wcli0 launch keeps its positionals inert', () => {
   // `command: "wcli0", args: ["--", "--debug"]`: yargs treats `--debug` as a positional after the
-  // separator, so the suffix scan must not split it out and let a no-op save enable debug.
+  // separator, so it must not be modeled and a no-op save must not enable debug. Since P105 the
+  // whole arg list is parsed as the server's own, so the separator and its remainder are held by
+  // parseServerArgs in extraArgs rather than by the launcher split -- the emitted args are
+  // identical either way, which is what the round-trip assertion below pins.
   const { settings } = parseMcpEntry({
     type: 'stdio',
     command: 'wcli0',
@@ -1582,9 +1585,66 @@ test('P75: a `--` separator keeps the remainder with the launcher, not a server 
   });
   assert.equal(settings.launchMethod, 'custom');
   assert.equal(settings.customCommand, 'wcli0');
-  assert.deepEqual(settings.customArgs, ['--', '--debug']);
   assert.equal(settings.debug, false, 'debug stays default; --debug after -- is positional');
-  assert.deepEqual(settings.extraArgs, []);
+  assert.deepEqual(settings.extraArgs, ['--', '--debug']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(spec.command, 'wcli0');
+  assert.deepEqual(spec.args, ['--', '--debug'], 'a no-op save round-trips the entry verbatim');
+});
+
+test('P105: a positional cannot split a direct wcli0 arg list at the wrong place', () => {
+  // `wcli0 --allowAllDirs marker --no-allowAllDirs` is last-wins false to yargs (marker is a
+  // positional), so the server runs RESTRICTED. The suffix scan used to fail its purity check on
+  // `marker`, pick the trailing negation as the "server suffix", and leave the ENABLING flag in
+  // customArgs -- so the form modeled allowAllDirs=false while a no-op save wrote
+  // `--allowAllDirs marker`, flipping the server to UNRESTRICTED directories.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--allowAllDirs', 'marker', '--no-allowAllDirs'],
+  });
+  assert.deepEqual(settings.customArgs, [], 'every arg belongs to the server list');
+  assert.equal(settings.allowAllDirs, false, 'last-wins, as yargs resolves it');
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(
+    spec.args.includes('--allowAllDirs'),
+    false,
+    'the save never re-enables unrestricted directories',
+  );
+  // The pair collapses to the value yargs computes for it; the launch is unchanged.
+  assert.deepEqual(spec.args, ['marker']);
+});
+
+test('P105: a direct wcli0 launch still models its flags and keeps unknown ones', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--shell', 'cmd', '--futureFlag', 'x'],
+  });
+  assert.deepEqual(settings.customArgs, []);
+  assert.equal(settings.shell, 'cmd', 'modeled flags stay editable');
+  assert.deepEqual(settings.extraArgs, ['--futureFlag', 'x'], 'unknown flags round-trip');
+});
+
+test('P105: a wrapper command is still split at its server-flag suffix', () => {
+  // The scan is unchanged for anything that is not the wcli0 binary itself.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['--no-cache', '--shell', 'bash'],
+  });
+  assert.deepEqual(settings.customArgs, ['--no-cache'], "the wrapper's own option stays put");
+  assert.equal(settings.shell, 'bash');
+});
+
+test('P105: a wcli0 binary behind a wrapper separator is still a pass-through', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--package=wcli0', '--', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.deepEqual(settings.customArgs, ['--package=wcli0', '--', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
 });
 
 test('P76: an attached boolean flag proves a wcli0 server suffix for a wrapper', () => {


### PR DESCRIPTION
Fixes the **P1** Codex reported on #89 at 2026-08-23T19:28:04Z ([thread](https://github.com/s2005/wcli0/pull/89#discussion_r3839389939)), which reached `main` because that PR was merged before the finding was seen — the task loop's thread query was capped at `reviewThreads(first: 100)` while #89 had 106 threads, so the six newest findings were never returned.

## The bug

For a direct `command: "wcli0"` entry, `serverFlagSuffixStart` scanned for a server-flag suffix even though every argument is already the server's own. With:

```json
{ "command": "wcli0", "args": ["--allowAllDirs", "marker", "--no-allowAllDirs"] }
```

the index-0 run failed the purity check on the positional `marker`, so the scan moved on and picked the trailing `--no-allowAllDirs` as the "suffix". That left the **enabling** flag in `customArgs` and modeled `allowAllDirs: false` — and since a false boolean is not emitted, a no-op save wrote back `--allowAllDirs marker`. yargs reads that as `allowAllDirs: true`, so an unrelated edit flipped the server from **restricted to unrestricted directories**.

## The fix

When `isWcli0Command(command)`, the whole arg list goes to `parseServerArgs` (`start = 0`) instead of being scanned. That parser already implements yargs' rules for this list — repeated booleans are last-wins (P89), and `--` plus its positionals are preserved verbatim in `extraArgs` (P74) — so the split cannot land in the wrong place. The scan is now wrapper-only and its dead `allowIndexZero` parameter was removed rather than left as an unused branch.

## Verification

Round-trips for a direct `wcli0` launch:

| entry args | emitted on a no-op save |
| --- | --- |
| `-- --debug` | `-- --debug` (debug still false) |
| `--shell cmd -- --shell bash` | `--shell cmd -- --shell bash` |
| `--allowAllDirs marker --no-allowAllDirs` | `marker` — allowAllDirs false, i.e. the same restricted launch yargs computes for the original; never the unrestricted rewrite |

`tsc --noEmit` clean, 646/646 unit tests pass. Five new tests; two of them fail against the pre-fix source (the other three pin the wrapper and pass-through paths that must not change).

## Still outstanding on main

Five **P2** findings from the same missed page of #89 are recorded as unchecked follow-ups in `docs/tasks/autodetect_mcp_source/progress.md` (P106–P110). This PR deliberately covers the P1 only.