### PR TITLE
feat(vscode): editable .vscode/mcp.json configuration source (re-land of #89, all review findings fixed)

### DIFF
--- a/docs/tasks/autodetect_mcp_source/PRD.md
+++ b/docs/tasks/autodetect_mcp_source/PRD.md
@@ -1,0 +1,139 @@
+# PRD: Auto-detect and load .vscode/mcp.json as an editable configuration source
+
+## Objective
+
+Let the wcli0 configuration panel detect an existing workspace `.vscode/mcp.json` that already defines a
+`servers.wcli0` entry, surface a one-click banner to load it, and let the user edit it and save the
+changes back to that file. This adds a `load -> edit -> save` round trip alongside today's write-only
+`new -> export` path, anchored by a new "configuration source" switcher that always makes clear what the
+form is editing and where Save will write. Scope is the mockup 02 (auto-detect on open) and the minimal
+mockup 03 (edit/save the detected file) needed to make detection useful.
+
+## Background
+
+The extension is settings-driven today. The webview form (`vscode-extension/src/webview.ts`) only ever
+edits VS Code settings (`wcli0.*`) at the User or Workspace scope, and files are produced one-way by the
+Export tab: `wcli0: Write .vscode/mcp.json` (`writeWorkspaceMcpJson` in
+`vscode-extension/src/commands.ts`) and `wcli0: Generate config.json` (`generateConfigFile`). There is
+no way to open an existing `.vscode/mcp.json`, see it in the form, edit it, and save it back. A team that
+already committed an `mcp.json` cannot round-trip it through the panel.
+
+The mockups in `vscode-extension/docs/mockups/` propose a "configuration source bar": a header that
+names the active source (VS Code Settings, the workspace `.vscode/mcp.json`, or a file opened
+explicitly) and routes Save to that source. Mockup 02 (`02-autodetect-mcp-json.html`) covers the
+detection banner and the source switcher menu; mockup 03 (`03-editing-mcp-json.html`) covers editing the
+file and saving back.
+
+The existing writer already contains the hard parts of safe `mcp.json` editing: JSONC parse
+(`parseJsonc`), preserve other `servers.*` entries, refuse a non-object root or non-object `servers`,
+and warn before dropping comments. What is missing is the reverse direction (parse an `mcp.json`
+`servers.wcli0` entry back into the form's settings model) and the UI to drive load/save against a file
+rather than a settings scope.
+
+Source: feature request to support `load -> edit -> export` for `.vscode/mcp.json`; mockup set in
+`vscode-extension/docs/mockups/` (the `index.html` source table). Side-by-side simultaneous
+settings + file editing is explicitly deferred to a future task.
+
+## Requirements
+
+### REQ-1: Configuration source model and switcher
+
+Introduce a "configuration source" concept the form edits one at a time. The source bar shows the active
+source (kind + path) and a switcher listing: VS Code Settings, the detected workspace `.vscode/mcp.json`
+(when present), and explicit actions. The current behavior (editing settings, with the
+User/Workspace scope radio) becomes the `settings` source and remains the default when nothing is
+detected.
+
+### REQ-2: Auto-detect .vscode/mcp.json with a wcli0 entry
+
+On panel open, the host reads `${workspaceFolder}/.vscode/mcp.json` (tolerating JSONC via `parseJsonc`)
+and reports whether `servers.wcli0` exists. When it does, the form shows a detection banner offering a
+one-click "Load & edit .vscode/mcp.json". Detection never mutates the file and never blocks the panel
+when the file is absent, unreadable, or malformed.
+
+### REQ-3: Load a mcp.json wcli0 entry into the form
+
+Loading the detected source parses the `servers.wcli0` entry back into the settings model that drives the
+form: `type` -> transport mode; `command`/`args` -> launch method, package spec / node script / custom
+command, and the recognized server flags (`--shell`, repeated `--allowedDir`, `--commandTimeout`,
+`--maxCommandLength`, `--safetyMode` equivalents, transport flags, `--config`, etc.); `cwd` and `env` ->
+the launch cwd / env. Flags the form does not model are preserved verbatim in `extraArgs` so a save does
+not silently drop them. After load, every tab reflects the file's values and the source bar shows the
+file path and the `servers.wcli0` pointer.
+
+### REQ-4: Save edits back to the same file
+
+When the source is the `.vscode/mcp.json` file, Save writes the edited `servers.wcli0` entry back into
+that file using the existing safe-merge rules (preserve other servers, refuse a non-object root /
+`servers`, warn before discarding comments) rather than writing VS Code settings. Saving the file source
+does not modify any `wcli0.*` setting. A dirty indicator reflects unsaved edits, and Revert reloads from
+disk.
+
+### REQ-5: The existing export path is preserved
+
+"New config from current settings" stays available as an explicit switcher action and behaves exactly
+like today's Export tab (`writeWorkspaceMcpJson` / `generateConfigFile`). Switching the source back to
+VS Code Settings restores the scope radio and the settings save behavior unchanged.
+
+### REQ-6: Global home config is read-only, never a silent save target
+
+The server's implicit `~/.win-cli-mcp/config.json` is listed in the switcher as a read-only preview only.
+It can never be selected as an editable/save source, so a save can never silently overwrite the user's
+global config.
+
+### REQ-7: Unsaved-changes guard on source switch
+
+Switching the source (or loading a file) while the form has unsaved edits prompts for confirmation
+before discarding them, mirroring the existing scope-switch guard (`scopeChangeRequest` in `webview.ts`).
+
+### REQ-8: Documentation
+
+`README.md` and any relevant `markdownDescription` text explain the source switcher, auto-detection, and
+the `load -> edit -> save` round trip for `.vscode/mcp.json`.
+
+## Non-Requirements
+
+- Side-by-side / simultaneous settings + file editing (a future task; explicitly out of scope now).
+- Editing arbitrary user-picked files via a Browse dialog (mockup 04) beyond the detected workspace
+  `.vscode/mcp.json`; the "Open another file..." action may appear but its full browse behavior is
+  deferred.
+- Editing the richer wcli0 `--config` `config.json` format in place (mockup 05), including per-shell and
+  profiles round-trip into a file source. When a detected entry references a `--config` file carrying
+  per-shell/profiles, the form surfaces a note that those are not editable here rather than editing them.
+- Any change to the MCP server definition provider's launch behavior or to the server's schema.
+- Multi-root: only the primary workspace folder's `.vscode/mcp.json` is detected (matching
+  `primaryWorkspaceFolder()` usage elsewhere).
+
+## Acceptance Criteria
+
+1. Opening the panel in a workspace whose `.vscode/mcp.json` has a `servers.wcli0` entry shows the
+   detection banner; opening it without such a file (or with no workspace) shows no banner and the
+   settings source is active.
+2. Clicking "Load & edit" populates every form tab from the parsed entry, and the source bar shows the
+   file path and `servers.wcli0` pointer.
+3. A round trip `buildLaunchSpec(settings) -> parseMcpEntry -> settings` reproduces the modeled fields
+   for representative stdio/http/sse settings; unmodeled flags survive in `extraArgs`.
+4. With the file source active, Save writes the edited entry back to `.vscode/mcp.json`, preserves other
+   `servers.*` entries, and leaves `wcli0.*` settings untouched.
+5. A malformed or absent `.vscode/mcp.json` does not break detection or the panel; a malformed file is
+   never overwritten on save (refused, matching today's writer).
+6. `~/.win-cli-mcp/config.json` appears only as a read-only preview and cannot be chosen as a save target.
+7. Switching source / loading a file with unsaved edits prompts before discarding.
+8. The existing settings-scope editing and Export-tab behaviors are unchanged when the settings source is
+   active.
+9. `tsc --noEmit`, the unit suite, the integration suite, and markdownlint all pass.
+
+## Deliverables
+
+| Deliverable | Type |
+| ----------- | ---- |
+| vscode-extension/src/configSource.ts | Create |
+| vscode-extension/src/argsBuilder.ts | Update |
+| vscode-extension/src/commands.ts | Update |
+| vscode-extension/src/webview.ts | Update |
+| vscode-extension/src/extension.ts | Update |
+| vscode-extension/test/unit/configSource.test.cjs | Create |
+| vscode-extension/test/unit/commands.test.cjs | Update |
+| vscode-extension/test/unit/webview.test.cjs | Update |
+| vscode-extension/test/integration/mcpJson.test.js | Update |
+| vscode-extension/README.md | Update |

--- a/docs/tasks/autodetect_mcp_source/analysis.md
+++ b/docs/tasks/autodetect_mcp_source/analysis.md
@@ -1,0 +1,125 @@
+# Analysis: Auto-detect and load .vscode/mcp.json as an editable configuration source
+
+## Goal
+
+Add a `load -> edit -> save` round trip for the workspace `.vscode/mcp.json` to the configuration panel,
+fronted by a configuration-source switcher and an auto-detection banner, without regressing the current
+settings-driven editing and one-way export.
+
+## Current Behavior
+
+- The webview (`vscode-extension/src/webview.ts`) edits one settings scope at a time. `setupWebview`
+  tracks `currentScope` (`Global`/`Workspace`), posts an `init` message with values from
+  `readSettingsForScope` plus the `setKeys` / `setSelectKeys` / `setArrayKeys` "explicitly set" hints,
+  and handles inbound messages: `ready`, `scopeChange`, `scopeChangeRequest` (the dirty-edit guard via
+  `vscode.window.showWarningMessage({modal:true})`), `save`, and the export triggers `generateConfig` /
+  `writeMcpJson` / `showCommand`.
+- The sticky header renders a `Save to: Workspace / User` radio and an "Overridable" isolation chip
+  (`webview.ts` lines ~469-497). There is no notion of a non-settings source.
+- Settings <-> CLI args is one-directional. `buildServerArgs` / `buildLaunchSpec`
+  (`vscode-extension/src/argsBuilder.ts`) turn a `Wcli0Settings` into a launcher command + flags. There
+  is no inverse (args -> settings).
+- `writeWorkspaceMcpJson` (`vscode-extension/src/commands.ts`) already does the safe write half of the
+  round trip: reads the file, parses JSONC via `parseJsonc`, refuses a non-object root or non-object
+  `servers`, warns before discarding comments, sets `servers.wcli0 = entry`, and writes back. It derives
+  the entry from settings read for the form scope (`readExportSettings`).
+- The provider (`vscode-extension/src/mcpProvider.ts`) registers the server from settings only; it never
+  reads the committed `mcp.json`. Detection helpers exist for related concerns: `homeConfigExists`,
+  `cwdConfigExists`, `configFileIsLoadable`.
+
+## Feasibility
+
+Feasible and well-scaffolded. The write half (REQ-4) reuses `writeWorkspaceMcpJson`'s existing logic
+nearly verbatim. The detection (REQ-2) is a small read + `parseJsonc` + `servers.wcli0` presence check.
+The genuinely new piece is the reverse parser (REQ-3): turning an `mcp.json` entry's
+`command`/`args`/`cwd`/`env` back into a `Wcli0Settings`. Because the extension owns the forward mapping
+(`buildServerArgs`), a paired inverse is tractable and round-trip testable; unknown flags fall through to
+`extraArgs` so nothing is lost. The UI work (REQ-1, REQ-5..REQ-7) extends the existing message protocol
+and sticky header rather than rebuilding the form.
+
+## Approach
+
+Add a small source model and a reverse parser, then extend the webview protocol so the host can drive the
+form from either a settings scope or a file.
+
+### Approach A (recommended): source model + paired reverse parser
+
+A new `src/configSource.ts` defines the source kinds (`settings` | `mcpJson`), detection
+(`detectWorkspaceMcpJson(folder)` returning `{ uri, hasWcli0 }`), and the reverse parser
+`parseMcpEntry(entry): Wcli0Settings` built on a `parseServerArgs(args)` inverse of `buildServerArgs`.
+The webview gains source state alongside `currentScope`; `init` carries the active source, the detected
+sources, and (for a file source) values produced by `parseMcpEntry`. Save routes to a refactored
+`writeMcpJsonFromSettings(settings, folder, ...)` extracted from `writeWorkspaceMcpJson`.
+
+| Advantages | Disadvantages |
+| ---------- | ------------- |
+| Reuses the existing safe-merge writer and dirty-guard patterns | A reverse arg parser is new surface with edge cases (`--opt=value`, repeated flags, negations) |
+| Round-trippable and unit-testable against `buildServerArgs` | Hand-written `mcp.json` may use flags the form cannot model (mitigated by `extraArgs` passthrough) |
+| Keeps one-source-at-a-time, so "where does Save go" stays unambiguous | Webview message protocol grows (new message types) |
+
+### Approach B: open mcp.json as a text document only
+
+Skip the form entirely for files; just open `.vscode/mcp.json` in a text editor with a banner.
+
+| Advantages | Disadvantages |
+| ---------- | ------------- |
+| Minimal code; no reverse parser | Does not satisfy "edit it in the form" / the mockups; no validation or guided editing |
+
+### Approach C: full source framework now (files of any kind, config.json too)
+
+Build the whole mockup set (04 browse, 05 config.json) in one task.
+
+| Advantages | Disadvantages |
+| ---------- | ------------- |
+| One cohesive delivery of the source concept | Much larger; config.json reverse-map (per-shell/profiles) is a separate hard problem; contradicts the requested mockup-02 scope |
+
+Approach A is recommended: it delivers the requested auto-detect + round trip on a model that later tasks
+(browse, config.json) can extend.
+
+## Implementation Notes
+
+- Reverse parser must mirror the quirks `buildServerArgs` emits: `--option=value` form for dash-prefixed
+  values (`pushOption`), repeated `--allowedDir` / `--blockedCommand` / etc., `--no-enableTruncation`
+  negations, `--yolo` / `--unsafe` -> `safetyMode`, transport flags (`--transport`, `--http-host`,
+  `--http-port`, `--sse-*`), and the npx prefix `-y <packageSpec>`. Anything unrecognized accumulates in
+  `extraArgs` (round-trips through the existing forward path).
+- Launch method inference: `command === 'npx'` with a leading `-y` -> `npx`; `command === 'node'` ->
+  `node` (first arg is the script path); otherwise `custom` (command + leading non-flag args ->
+  `customArgs`, until the first recognized server flag).
+- A detected entry that references a `--config` file (or whose form maps to per-shell/profiles) cannot be
+  fully represented; surface a non-blocking note and keep `--config` in `configFile` / `extraArgs`.
+  Editing that referenced file is the future mockup-05 task.
+- Save path: extract the body of `writeWorkspaceMcpJson` after settings-resolution into
+  `writeMcpJsonFromSettings(settings, folder, configFileLoadable?)`; the existing command builds settings
+  from scope and calls it (no behavior change), the file-source save builds settings from the form
+  payload (like `applySettings` collects) and calls it. The file save must NOT call `config.update`.
+- Source state lives next to `currentScope` in `setupWebview`. The `init` payload gains
+  `source: { kind, uri?, label }` and `detected: ConfigSource[]`. New inbound messages: `selectSource`
+  / `loadSource` (with dirty guard, reusing the `scopeChangeRequest` modal pattern) and `saveToFile`.
+- `onDidChangeConfiguration` re-post (`post(true)`) must not clobber a file source: when the active
+  source is a file, an external settings change should not reload the form from settings.
+- Keep the home config strictly read-only: include it in `detected` with a `readOnly: true` flag the UI
+  renders disabled; never accept it as a `loadSource`/`saveToFile` target on the host side.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Reverse parser drops or mangles flags a hand-written mcp.json uses | Unmodeled flags pass through to `extraArgs`; round-trip unit tests; a note when `--config`/per-shell is referenced |
+| Save overwrites a user's hand-formatted/commented mcp.json | Reuse existing refuse-and-warn logic (`parseJsonc`, comment warning, non-object guards) unchanged |
+| Source/scope state divergence causes a stale post to overwrite edits | Mirror existing dirty-guard discipline; gate external re-posts when a file source is active |
+| Home config accidentally editable | Host-side guard rejects it as a load/save target regardless of UI |
+| Webview protocol growth breaks existing tests | Add new message types additively; keep `ready`/`save`/export messages working |
+
+## Test Strategy
+
+- Unit (`test/unit/configSource.test.cjs`): detection on present/absent/malformed/no-`wcli0` files;
+  `parseServerArgs` / `parseMcpEntry` for npx/node/custom, stdio/http/sse, repeated and `=`-form flags,
+  negations, and unknown-flag passthrough to `extraArgs`; round-trip against `buildLaunchSpec`.
+- Unit (`test/unit/commands.test.cjs`): `writeMcpJsonFromSettings` preserves other servers, refuses a
+  non-object root/`servers`, warns on comments; never calls `config.update`.
+- Unit (`test/unit/webview.test.cjs`): `init` carries detected sources; banner shown only when a wcli0
+  entry exists; `selectSource`/`loadSource` populate from a file; `saveToFile` routes to the file writer;
+  dirty guard fires on source switch; home config not offered as a save target.
+- Integration (`test/integration/mcpJson.test.js`): with a fixture `.vscode/mcp.json` containing
+  `servers.wcli0`, the extension detects it and a save-back round trip preserves a second server entry.

--- a/docs/tasks/autodetect_mcp_source/analysis_100_preserve_unsupported_shell_names.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_100_preserve_unsupported_shell_names.md
@@ -1,0 +1,24 @@
+# Analysis 100 - Preserve unsupported shell names
+
+## Decision: Valid — fix applied
+
+P96 diverted the exact value `all` because the form's shell control uses it as an omission
+sentinel. The review is right that the same reasoning covers every value the control cannot hold:
+the shell field is a fixed `<select>` offering Inherit, `all`, and the five real shell names
+(`SHELL_NAMES`). Assigning `fish` to it leaves the select on its empty value, the form immediately
+counts as dirty, and a save drops `--shell` entirely — so an entry the server matched to NO shell
+(nothing is named `fish`) becomes one running every default shell. Exactly the P96 escalation, one
+step wider.
+
+`divertShellAll` is now `divertShellValue`: a `--shell` value is modeled only when it is one of the
+five names the select offers, and anything else (`all`, `fish`, `zsh`, `ALL`) is preserved verbatim
+in `extraArgs` for both the space and attached spellings. The five real names stay fully editable,
+and choosing one in the form still strips the preserved copy (P61) so the edit wins.
+
+**Why:** The rule "model only what the control can represent" is what P96 established; keying it to
+`SHELL_NAMES` — the list the select is built from — makes it structural instead of a special case,
+so a new shell name added to the enum stays modelable automatically and everything else is preserved
+without further review rounds. See [[analysis_96_preserve_explicit_shell_all]] and
+[[analysis_61_strip_preserved_value_flags]].
+
+**Commit:** f03b33f - fix(vscode): round-23 codex review follow-ups for PR #89 (P100-P102)

--- a/docs/tasks/autodetect_mcp_source/analysis_101_revalidate_file_after_prompts.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_101_revalidate_file_after_prompts.md
@@ -1,0 +1,32 @@
+# Analysis 101 - Revalidate the file after save-time prompts
+
+## Decision: Valid — fix applied
+
+P69 made the save take ONE full-file snapshot up front so a concurrent delete/recreate could not
+drop the file's other servers. But that snapshot is taken before the awaited modals — the
+environment prompt and the JSONC-comment warning — so a write landing while a prompt is open was
+serialized away: the file went back to its pre-modal contents, including any other server the
+concurrent editor had changed. P95 closed the equivalent gap between the webview read and the
+snapshot; this is the same race one stage later, and the wider one, because it can discard edits to
+entries this form never touches.
+
+The save now re-reads the file immediately before writing and compares the raw bytes with the
+snapshot it serialized from; a mismatch (an edit, or a delete) reports that the file changed and
+writes nothing.
+
+This deliberately supersedes the write-anyway half of P69 and P46, and their tests were updated to
+the new contract. Their actual guarantees are intact and are now met more strictly: P69 asked that
+a concurrent delete never drop the other servers — refusing writes nothing at all, so nothing is
+dropped and the deleted file is not resurrected either; P46 asked that a stale generated env never
+be merged onto a freshly re-read base — there is no merge, and the external edit survives untouched.
+A save on an unchanged file is unaffected.
+
+**Why:** Byte comparison is the strongest check available through the `vscode.workspace.fs` API
+(there is no ETag or document version for a file this extension does not open as a TextDocument),
+and it is strictly conservative: it can only refuse a save, never corrupt one. Refusing is also the
+honest outcome — the alternative, re-merging onto the newer file, would silently re-run every
+preservation decision against content the user never saw. See
+[[analysis_69_file_source_single_snapshot]], [[analysis_46_merge_from_single_snapshot]] and
+[[analysis_95_single_snapshot_for_file_saves]].
+
+**Commit:** f03b33f - fix(vscode): round-23 codex review follow-ups for PR #89 (P100-P102)

--- a/docs/tasks/autodetect_mcp_source/analysis_102_match_yargs_negative_numbers.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_102_match_yargs_negative_numbers.md
@@ -1,0 +1,26 @@
+# Analysis 102 - Match yargs when recognizing negative numeric tokens
+
+## Decision: Valid — fix applied
+
+P93's predicate accepted more shapes than yargs actually consumes. Verified against the installed
+parser: `-1`, `-1.5`, `-.5`, `-0` and `-01` ARE taken as the preceding option's value, but `-1e2`,
+`-1e-2` and `-1.` are NOT — yargs reads `--shell -1e2` as an empty shell plus the short options `1`
+and `e`. Accepting the exponent and trailing-dot forms modeled a value the server never sees, and
+the save then rebuilt it as `--shell=-1e2`, which really would disable every known shell. The regex
+is now `-(?:\d+(?:\.\d+)?|\.\d+)` — exactly the consumed forms, with no exponent and no trailing dot.
+
+Writing the test for this surfaced a second, related mismatch of my own from P98. That change
+counted a scalar occurrence on presence, which is right for a string option (`--shell --debug
+--shell bash` => `['', 'bash']`) but wrong for a NUMBER option: yargs drops a valueless numeric
+option entirely, so `--commandTimeout --commandTimeout 5` is just `5`, not an array. Counting it as
+a duplicate preserved a pair the server resolves to one value and left the form showing no timeout.
+The pre-scan now counts a number option only when a value token actually follows, and keeps
+counting string/csv options on presence.
+
+**Why:** Both halves are the same discipline these rounds have converged on — read the rule off the
+installed parser rather than inferring it from what the token looks like. The narrower regex also
+fails safe: a form yargs does not consume now stays a separate token and round-trips verbatim,
+which is the outcome that cannot change a launch. See [[analysis_93_count_negative_numeric_values]]
+and [[analysis_98_count_valueless_scalar_flags]].
+
+**Commit:** f03b33f - fix(vscode): round-23 codex review follow-ups for PR #89 (P100-P102)

--- a/docs/tasks/autodetect_mcp_source/analysis_103_preserve_empty_allowed_dir.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_103_preserve_empty_allowed_dir.md
@@ -1,0 +1,27 @@
+# Analysis 103 - Preserve empty allowed-directory entries
+
+## Decision: Valid — fix applied
+
+`--allowedDir ""` is not a no-op for the server. yargs supplies `allowedDir: ['']`, and
+`applyCliShellAndAllowedDirs` gates on `allowedDirs.length > 0`, so it sets
+`restrictWorkingDirectory = true` with an empty allowlist — the entry denies every working
+directory. The parser kept the empty element in `allowedDirectories`, but the builder ran it through
+`pathValue`, which returns undefined for a blank value, so the flag vanished from the rebuilt args.
+A no-op save therefore turned OFF the restriction and let the server fall back to the config or
+default allowed paths, permitting commands in directories the authored entry refused. That is the
+same widening shape as P96, P98 and P100.
+
+A blank entry is now emitted verbatim on a file-source save. The settings and provider paths keep
+dropping blanks, gated on `preserveRelativePaths` exactly as the P57 `--allowAllDirs` suppression
+above it is: there a blank line is editor noise rather than an authored deny-all, and the form
+already filters blanks when collecting the textarea, so an empty entry could only arrive from
+hand-written JSON — where silently switching the server to deny-everything would be a worse failure
+than dropping it.
+
+**Why:** The file source's contract is that a value the server acts on round-trips unchanged, and
+this value has a large, security-relevant effect. Restricting the change to the round-trip path keeps
+the export path's meaning of "blank line" intact, so the fix cannot surprise a settings user whose
+`wcli0.allowedDirectories` happens to contain an empty string. See
+[[analysis_57_preserve_allow_all_dirs]] and [[analysis_64_preserve_nonpositive_security_limits]].
+
+**Commit:** 6655602 - fix(vscode): round-24 codex review follow-up for PR #89 (P103)

--- a/docs/tasks/autodetect_mcp_source/analysis_104_preserve_blank_allowed_dir_rows.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_104_preserve_blank_allowed_dir_rows.md
@@ -1,0 +1,32 @@
+# Analysis 104 - Preserve blank allowed-directory rows in the webview
+
+## Decision: Rejected — the premise does not hold; regression tests added instead
+
+The normalization the review describes is real: `collect()` does turn a blank textarea into `[]`
+(and then into `null` via the Inherit checkbox). The conclusion drawn from it is not, because the
+dirty baseline is produced by the SAME function. After the form is populated,
+`initial = collect()` runs, so the baseline for `allowedDirectories` is the identical normalized
+value. `collectChanged()` compares `collect()` against `initial`, finds no difference, and never
+submits the field. The form is not "immediately dirty", and an unrelated save carries no
+`allowedDirectories` key at all — so `overlaySettings` leaves the parsed `['']` in place and the
+builder re-emits `--allowedDir ""` (P103).
+
+Verified against the shipped client rather than by reading it: the webview test harness runs the
+real browser-side script, and with a loaded `allowedDirectories: ['']` plus an unrelated
+`commandTimeout` edit, the posted `saveToFile` payload is exactly `{"commandTimeout": 45}`. Editing
+the textarea to `/ws/a` submits `{"allowedDirectories": ["/ws/a"]}`, which is the correct behavior
+for a real edit — the authored empty entry is replaced because the user replaced it.
+
+Three tests were added to pin this down, since the reasoning is subtle enough to be re-reported:
+two in `webviewButtons.test.cjs` covering the client contract (untouched list not submitted; an
+edited list still submitted), and one end-to-end test in `webview.test.cjs` that loads an entry with
+`--allowedDir ""`, saves an unrelated field, and asserts the written args still carry the empty
+entry.
+
+**Why:** The finding is a single-function reading of a two-function invariant — the client's
+normalization is only a bug if the baseline escapes it, and it does not. Adding a "lossless
+representation" for blank rows would introduce a real hazard in exchange: a trailing newline or a
+cleared textarea would then be submitted as an authored deny-all, turning an ordinary edit into a
+restriction the user never asked for. See [[analysis_103_preserve_empty_allowed_dir]].
+
+**Commit:** 0e0834b - test(vscode): pin the empty allowed-dir round-trip; reject P104 for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
@@ -1,0 +1,30 @@
+# Analysis 105 - Parse direct wcli0 arguments as one server argument list
+
+## Decision: Valid — fix applied
+
+For a direct `command: "wcli0"` entry the suffix scan had nothing to look for: every argument is
+already the server's own. Scanning anyway could cut the list in the wrong place. With
+`args: ["--allowAllDirs", "marker", "--no-allowAllDirs"]` the index-0 run failed the purity check on
+the positional `marker`, so the scan moved on and picked the trailing `--no-allowAllDirs` as the
+"server suffix". That left the ENABLING flag in `customArgs` and modeled `allowAllDirs` as false —
+and because a false boolean is simply not emitted, a no-op save wrote back `--allowAllDirs marker`.
+yargs reads that as allowAllDirs TRUE, so an unrelated edit flipped the server from restricted to
+unrestricted directories.
+
+The caller now takes the first of the review's two options: when `isWcli0Command(command)`, the
+whole arg list is handed to `parseServerArgs` (`start = 0`) instead of being scanned. That parser
+already implements yargs' own rules for this list — repeated booleans are last-wins (P89), and the
+`--` separator plus its positionals are preserved verbatim in `extraArgs` (P74) — so the split
+cannot land in the wrong place at all. The scan itself is now wrapper-only, and its dead
+`allowIndexZero` parameter was removed rather than left as an unused branch.
+
+Verified round-trips for a direct `wcli0` launch: `-- --debug` re-emits byte-identically with debug
+still false; `--shell cmd -- --shell bash` re-emits byte-identically; and the reported case now
+emits `marker` alone, which yargs resolves to allowAllDirs=false — the same restricted launch the
+original entry produced, and never the unrestricted rewrite.
+
+**Why:** Parsing beats preserving here because it keeps the entry editable: the flags stay modeled
+in the form, and the round-trip is still faithful because the emitted args resolve to the identical
+yargs result. The one visible change is that a boolean and its negation collapse to the value yargs
+computes for them, which is the same normalization every other modeled field already gets. See
+[[analysis_89_clear_safety_mode_on_later_false]] and [[analysis_75_no_server_suffix_past_double_dash]].

--- a/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_105_parse_direct_wcli0_arg_list.md
@@ -28,3 +28,5 @@ in the form, and the round-trip is still faithful because the emitted args resol
 yargs result. The one visible change is that a boolean and its negation collapse to the value yargs
 computes for them, which is the same normalization every other modeled field already gets. See
 [[analysis_89_clear_safety_mode_on_later_false]] and [[analysis_75_no_server_suffix_past_double_dash]].
+
+**Commit:** 0c1d494 - fix(vscode): parse a direct wcli0 launch as one server argument list (P105)

--- a/docs/tasks/autodetect_mcp_source/analysis_106_keep_valueless_scalar_before_positional.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_106_keep_valueless_scalar_before_positional.md
@@ -1,0 +1,28 @@
+# Analysis 106 - Keep valueless scalar flags ahead of following positionals
+
+## Decision: Valid — fix applied
+
+The parser preserved a valueless value option verbatim, which is correct in isolation but not once
+the builder reorders: `buildServerArgs` appends `extraArgs` AFTER the flags generated from the typed
+fields, so two tokens the entry deliberately kept apart become neighbours. yargs reads
+`node dist/index.js --shell --debug cmd` as shell='', debug=true and a POSITIONAL `cmd`; the rebuilt
+`--debug --shell cmd` makes `cmd` the shell value, so a no-op save changed which shell the server
+enables.
+
+The parser now records which preserved options were valueless (`valuelessOptionAt`) — a fact only the
+parse knows, since once the tokens sit side by side in `extraArgs` it is no longer visible — and
+`makeExtrasReorderSafe` rewrites them, but ONLY when a real positional follows. Each kind is
+re-emitted in the form that cannot capture a following token, verified against the installed parser:
+a string/csv option becomes `--flag=` (identical parse, consumes nothing); a number option is dropped
+because a valueless one defines no key at all while `--flag=` would define 0; an array option is
+dropped because a valueless one yields `[]` (ignored by the server) while `--flag=` would yield `['']`
+— the deny-all of P103. A valueless `c` bundle becomes `-<other letters> --config=`, since `-c=`
+swallows the next token.
+
+**Why:** Gating on "is there actually a positional after it" is what keeps this from churning every
+other preserved shape — a valueless flag next to another flag (P44) or next to its own repeated
+occurrence (P78/P98) is already safe in any order and still round-trips byte-for-byte. The rewrite
+targets exactly the arrangement the builder can corrupt. See
+[[analysis_109_preserve_valueless_array_before_positional]] and [[analysis_44_dont_consume_flag_as_value]].
+
+**Commit:** cd74db6 - fix(vscode): address the five P2 findings missed by the #89 merge (P106-P110)

--- a/docs/tasks/autodetect_mcp_source/analysis_107_reject_delimiters_in_transport_host.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_107_reject_delimiters_in_transport_host.md
@@ -1,0 +1,22 @@
+# Analysis 107 - Reject delimiters in edited transport hosts
+
+## Decision: Valid — fix applied
+
+The host field is pasted straight between `http://` and `:port`, with no check that it is an
+authority host. `gateway.example/api` produced `http://gateway.example/api:9444/mcp`, which reparses
+as host `gateway.example` with no explicit port — so the save reported success, the endpoint path was
+malformed, and the user's edit was silently lost on reload. The same shape applies to userinfo
+(`user@host`) and to a port typed into the host field (`example.com:8080` → `...:8080:9444`).
+
+`unusableTransportHost` now rejects a host carrying `/`, `?`, `#`, `@` or whitespace, and one
+carrying a single colon (an embedded port). An IPv6 literal is unaffected: it is bracketed by
+`fileSourceUrlHost` and carries two or more colons. The check runs only when the URL will actually be
+REBUILT from the fields — a URL preserved verbatim never interpolates them, so it cannot be blocked
+by a host value that is inert for it.
+
+**Why:** Refusing matches every other unsavable-edit guard in this feature (P55, P81, P88): the save
+writes nothing and says why, instead of reporting success for an edit the reparse discards. Bounding
+it to the rebuild path keeps the P5/P8/P10 preservation cases free of a check that has no bearing on
+them. See [[analysis_81_reject_host_port_edits_for_opaque_urls]] and [[analysis_67_rebuild_default_port_url_on_port_change]].
+
+**Commit:** cd74db6 - fix(vscode): address the five P2 findings missed by the #89 merge (P106-P110)

--- a/docs/tasks/autodetect_mcp_source/analysis_108_exclude_attached_negations_from_suffix.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_108_exclude_attached_negations_from_suffix.md
@@ -1,0 +1,20 @@
+# Analysis 108 - Exclude attached negations from modeled suffix evidence
+
+## Decision: Valid — fix applied
+
+P94 widened `isRecognizedServerFlag` to accept any attached value for a declared boolean, which is
+right for `--debug=0` but wrong for a NEGATED spelling. Verified against the installed parser: yargs
+applies `--name=value` before boolean negation, so `--no-debug=false` defines an unrelated `no-debug`
+key and leaves `debug` untouched. `parseServerArgs` already preserves such a token verbatim, so the
+detector was the only half that treated it as a wcli0 flag — enough to split a wrapper's own trailing
+token into the "server suffix", after which an unrelated edit reordered the wrapper's invocation.
+
+The detector now excludes attached values on `--no-*` spellings. A BARE `--no-debug`, which yargs
+really does treat as a negation, still counts as modeled evidence and stays editable.
+
+**Why:** The detector and the parser must agree about what is a wcli0 flag — the same pairing P94
+itself was about. Excluding only the attached negated form keeps that agreement exact without
+narrowing the P94 fix. See [[analysis_94_recognize_all_attached_booleans]] and
+[[analysis_76_attached_boolean_modeled_suffix]].
+
+**Commit:** cd74db6 - fix(vscode): address the five P2 findings missed by the #89 merge (P106-P110)

--- a/docs/tasks/autodetect_mcp_source/analysis_109_preserve_valueless_array_before_positional.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_109_preserve_valueless_array_before_positional.md
@@ -1,0 +1,22 @@
+# Analysis 109 - Preserve valueless array flags before later positionals
+
+## Decision: Valid — fix applied
+
+The array case of P106, and the more dangerous one. `node dist/index.js --allowedDir --debug C:/work`
+gives yargs an EMPTY `allowedDir` array with `C:/work` left positional, so the server applies no
+directory restriction at all. Re-emitted as `--debug --allowedDir C:/work`, the path becomes an
+allowed directory — and `applyCliShellAndAllowedDirs` then switches `restrictWorkingDirectory` ON and
+`enableInjectionProtection` OFF. An unrelated save silently rewrote the server's security posture in
+both directions at once.
+
+Handled by the same `makeExtrasReorderSafe` guard: a valueless array flag with a positional after it
+is DROPPED rather than rewritten, because `--allowedDir=` would yield `['']` — the deny-all state of
+P103 — while the valueless token is genuinely inert (the server's `length > 0` check ignores an empty
+array, exactly as if the flag were absent). The positional itself still round-trips.
+
+**Why:** Dropping an inert token is the only re-emission that preserves the launch, since yargs has
+no spelling for "empty array" that survives being moved. The alternative — refusing the save —
+would block every edit on such an entry to protect a token that does nothing. See
+[[analysis_106_keep_valueless_scalar_before_positional]] and [[analysis_103_preserve_empty_allowed_dir]].
+
+**Commit:** cd74db6 - fix(vscode): address the five P2 findings missed by the #89 merge (P106-P110)

--- a/docs/tasks/autodetect_mcp_source/analysis_10_preserve_socket_pipe_urls.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_10_preserve_socket_pipe_urls.md
@@ -1,0 +1,16 @@
+# Analysis 10 - Preserve socket and pipe URLs instead of rewriting them
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` now retains the verbatim `transportUrl` even when `parseHttpUrl` cannot
+decompose it (socket/named-pipe URLs such as `unix:///tmp/server.sock#/mcp`), leaving the
+host/port fields at their defaults and adding a clear note. On save, `preservedFileUrl`
+returns the raw URL for any URL it cannot decompose (when the transport mode is unchanged),
+so an unrelated save no longer rewrites it to `http://127.0.0.1:9444/mcp`.
+
+**Why:** The previous code only added a note and left `transportUrl` unset, so the save
+path reconstructed the URL from the default host/port and broke the configured
+socket/named-pipe server. Preserving the original URL fixes the round trip. Covered by a
+`parseMcpEntry` socket-URL test and a file-save test asserting the socket URL is preserved.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_110_reject_concurrent_launch_method_change.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_110_reject_concurrent_launch_method_change.md
@@ -1,0 +1,23 @@
+# Analysis 110 - Reject incompatible concurrent launch-method changes
+
+## Decision: Valid — fix applied
+
+P80 rebased a file save onto the CURRENT on-disk entry so concurrent edits are not overwritten, and
+P95 refused the save when the entry moved between the two reads. Both left one incompatibility
+unguarded: a concurrent change of the LAUNCH METHOD. Each method owns different fields, so an edit
+made against the old one cannot be overlaid onto the new entry — a `launch.packageSpec` edit made
+while the panel showed npx, overlaid onto a freshly parsed `node` entry, produces a node launch that
+ignores `packageSpec` entirely. The save reported success and the edit vanished on reparse.
+
+The handler now refuses when the on-disk launch method differs from the loaded one AND the submitted
+values contain a method-specific field (`launch.packageSpec`, `launch.nodeScriptPath`,
+`launch.customCommand`), unless the user is switching the method themselves. An unrelated edit still
+merges onto the new entry, and a deliberate switch still wins.
+
+**Why:** This is the transport-mode guard (P80) one level down, and the same reasoning applies:
+where two models are disjoint, a merge has no defensible answer, so the honest outcome is to refuse
+and ask for a reload. Keying the refusal on the submitted field names rather than on the settings
+diff avoids false positives, exactly as the P55 guard does. See
+[[analysis_80_preserve_concurrent_modeled_args]] and [[analysis_95_single_snapshot_for_file_saves]].
+
+**Commit:** cd74db6 - fix(vscode): address the five P2 findings missed by the #89 merge (P106-P110)

--- a/docs/tasks/autodetect_mcp_source/analysis_111_count_trailing_valueless_numeric_duplicates.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_111_count_trailing_valueless_numeric_duplicates.md
@@ -1,0 +1,23 @@
+# Analysis 111 - Preserve trailing valueless numeric duplicates
+
+## Decision: Valid - fix applied
+
+The duplicate-scalar pre-scan in `vscode-extension/src/configSource.ts` skipped every valueless
+number occurrence, which is right only for a LEADING one; verified against the installed
+yargs-parser, a valueless number option is dropped only while its key is still undefined
+(`--commandTimeout --commandTimeout 5` => `5`), whereas once an earlier occurrence has defined the
+key the repeat is appended as null and the option becomes an array
+(`--maxCommandLength 1000000 --maxCommandLength` => `[1000000, null]`). The condition now also
+counts a valueless number when the key already has a counted occurrence, so the trailing form is
+recognized as a duplicate and every token round-trips verbatim in `extraArgs` instead of being
+modeled and then stripped.
+
+**Why:** `applyCliSecurityOverrides` ignores an array value because it is not a number, so the
+authored entry runs on the server's own (much stricter) command-length limit and default command
+timeout. Modeling `1000000` made the form show the weaker limit and let the builder emit a plain
+`--maxCommandLength 1000000`, so saving an unrelated field silently activated a limit the entry
+never applied - the same class of regression as P90 (a diverted numeric occurrence still counts)
+and the exact mirror of P102, whose leading-valueless case the new condition deliberately leaves
+untouched and which is now pinned by its own regression test.
+
+**Commit:** 75d6868 - fix(vscode): address review feedback for PR #93 (P111-P112)

--- a/docs/tasks/autodetect_mcp_source/analysis_112_keep_positionals_out_of_rebuilt_arrays.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_112_keep_positionals_out_of_rebuilt_arrays.md
@@ -1,0 +1,25 @@
+# Analysis 112 - Keep positionals out of rebuilt allowed-directory arrays
+
+## Decision: Valid - fix applied
+
+`buildServerArgs` appends `extraArgs` after the flags it generates from the typed fields, so a
+bare positional preserved at the head of `extraArgs` landed directly behind the yargs ARRAY
+options (`--allowedDir`, `--blockedCommand`, `--blockedArgument`, `--blockedOperator`) and was
+consumed as another value: verified against the installed yargs-parser,
+`marker --allowedDir C:/trusted` yields one allowed directory plus the positional `marker`, while
+the rebuilt `--allowedDir C:/trusted marker` yields two. `vscode-extension/src/argsBuilder.ts` now
+records the indices of the tokens it emits for those array options and, when `extraArgs` begins
+with a run of value-like tokens, re-emits the array flags after that run - reproducing the
+authored order.
+
+**Why:** The alternative of diverting the array option into `extraArgs` would have kept the
+directory out of the form and still lost the guarantee as soon as the user edited the allowed
+list, whereas hoisting keeps the field editable and holds for an edited list too. Only the
+LEADING run needs it: any later positional already has a `-`-prefixed token in front of it, which
+is exactly where yargs stops consuming array values, so the normal emission order is unchanged for
+every other entry. The run is measured with the builder's existing `isOptionValueToken`, so a
+negative-number positional is covered like P93. This completes the reordering family started by
+P106/P109, which fixed the same builder-appends-extras hazard for valueless scalar and array
+flags.
+
+**Commit:** 75d6868 - fix(vscode): address review feedback for PR #93 (P111-P112)

--- a/docs/tasks/autodetect_mcp_source/analysis_113_track_valueless_init_config.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_113_track_valueless_init_config.md
@@ -1,0 +1,28 @@
+# Analysis 113 - Track valueless init-config before reordering extras
+
+## Decision: Valid - fix applied
+
+The server declares `--init-config` as a string option, but the form models no field for it, so the
+parser kept it verbatim in `extraArgs` and the P106 reorder guard - which consulted `VALUE_OPTIONS`
+only - never learned the token had no value. Verified against the installed yargs:
+`--init-config --debug path` yields an empty `init-config` plus the positional `path`, so the server
+runs normally, while the rebuilt `--debug --init-config path` yields `init-config: "path"`, which
+makes the server write a default config to that path and exit. `vscode-extension/src/configSource.ts`
+now carries an `UNMODELED_VALUE_OPTIONS` set (`--init-config` and its yargs camel-case spelling
+`--initConfig`, both verified as accepted aliases) behind a `valueOptionKind()` helper, and the three
+places that reason about value-consuming options - the valueless bookkeeping in `parseServerArgs`,
+the value-consumption scan in `makeExtrasReorderSafe`, and its rewrite - all go through it. A
+valueless occurrence is re-emitted as `--init-config=`, which yargs parses exactly like the bare
+valueless flag and which consumes nothing.
+
+**Why:** Modeling `--init-config` as a settings field was rejected: it is a one-shot bootstrap
+action that makes the server exit, not a launch setting, and surfacing it in the form would invite a
+save that turns a working entry into a create-config-and-quit entry. Preserving it verbatim is the
+right round-trip behavior; only the reordering metadata was missing. Routing every value-option
+lookup through one helper keeps the parse side and the reorder guard from drifting apart again, and
+the `string` kind is correct for the rewrite because a valueless string option and its `=` form both
+yield `''` - unlike number and array options, which stay dropped as inert. This extends the
+P106/P109 family from the options the form models to every value-consuming option the SERVER
+declares.
+
+**Commit:** af0d21e - fix(vscode): address review feedback for PR #93 (P113-P115)

--- a/docs/tasks/autodetect_mcp_source/analysis_114_preserve_boolean_like_positionals.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_114_preserve_boolean_like_positionals.md
@@ -1,0 +1,28 @@
+# Analysis 114 - Preserve boolean-like positionals before boolean flags
+
+## Decision: Valid - fix applied
+
+`buildServerArgs` appends `extraArgs` after the flags it generates, so a leading `true`/`false`
+positional preserved in `extraArgs` landed directly behind a generated bare boolean flag, and yargs
+consumes exactly a literal `true`/`false` after a declared boolean as its VALUE. Verified against
+the installed yargs: `--enableTruncation false` yields `enableTruncation: false` and NO positional,
+while `--enableTruncation=true false` yields `true` plus the positional - so the entry
+`["false", "--enableTruncation=true"]` came back as `["--enableTruncation", "false"]` and an
+unrelated save both disabled truncation and deleted the positional. `argsBuilder.ts` now rewrites
+that one token into its attached `--flag=true` form when the first preserved extra is `true` or
+`false`, in `buildServerArgs` (covering the plain append AND the P112 array hoist, where the last
+NON-array flag is what ends up in front of the run) and in `buildManagedServerArgs`, whose
+`--debug` had the same exposure.
+
+**Why:** The attached form was preferred over hoisting the positional in front of the flag: it is a
+single-token, provably equivalent change - the builder emits a bare boolean spelling only for an
+ENABLED setting, a disabled one being `--no-*`, which consumes nothing - and it mirrors the
+self-terminating `--flag=` rewrite P106 already uses on the parse side. Hoisting would have had to
+interleave with the P112 array hoist and could strand the positional behind a different flag. The
+guard is deliberately narrow: only the generated token that will sit immediately before the
+preserved run is examined, and only when that run starts with a literal `true`/`false`, because
+every other value the builder emits is preceded by its own flag and any other positional is already
+safe. `--allowAllDirs`, `--yolo`, `--unsafe`, `--debug`, `--enableTruncation` and
+`--enableLogResources` are the full set of bare boolean flags the builder emits.
+
+**Commit:** af0d21e - fix(vscode): address review feedback for PR #93 (P113-P115)

--- a/docs/tasks/autodetect_mcp_source/analysis_115_stop_suffix_scan_at_leading_separator.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_115_stop_suffix_scan_at_leading_separator.md
@@ -1,0 +1,22 @@
+# Analysis 115 - Stop wrapper suffix scanning at a leading separator
+
+## Decision: Valid - fix applied
+
+`serverFlagSuffixStart` started at index 1 so an index-0 flag run could not be mistaken for a wcli0
+suffix (P-wrapperflags), but that also hid a `--` options separator sitting at index 0: for
+`command: "node", args: ["--", "wrapper.js", "--debug"]` - where node treats `--` as the end of its
+own options and hands `--debug` to the wrapper - the scan resumed at `--debug`, split it into the
+server portion and showed it as wcli0's Debug setting, so clearing that setting saved
+`["--", "wrapper.js"]` and deleted the wrapper's own option. The scan now visits index 0 and applies
+the existing separator rules there (stop, unless the wcli0 binary itself follows, which proves the
+P17 pass-through), while an index-0 FLAG run is still skipped, so no suffix can begin at index 0.
+
+**Why:** The index-1 start was only ever about flag-run ambiguity, never about separators, so
+splitting the two concerns restores the P75 rule for the one position it could not see rather than
+weakening the P-wrapperflags guard. Handling the separator inside the same loop keeps a single
+implementation of the pass-through exception instead of duplicating it in a pre-check. Tests pin
+all three behaviors: the leading separator now round-trips verbatim, the P17
+`npx -- wcli0 --shell cmd` pass-through still models the server flags, and `mywrapper --transport
+fast` still keeps its own option in `customArgs`.
+
+**Commit:** af0d21e - fix(vscode): address review feedback for PR #93 (P113-P115)

--- a/docs/tasks/autodetect_mcp_source/analysis_11_clear_stale_notes.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_11_clear_stale_notes.md
@@ -1,0 +1,17 @@
+# Analysis 11 - Clear stale file-source notes after clean reloads
+
+## Decision: Valid — fix applied
+
+File-source parse notes are now carried in every `init` message (the `notes` field of
+`post()`), replacing the previous fire-once `notes` message that was only sent when notes
+were non-empty. The host stores `loadedFileNotes` and resets it on switch/save/reload, and
+the webview renders notes from each file-source init — clearing them when the array is
+empty.
+
+**Why:** Because the host only posted notes when `notes.length > 0` and the webview kept
+`sourceNotes` visible while in `mcpJson` mode, a stale warning (e.g. a custom-URL note)
+remained after a later clean reload/save. Sending notes on every init clears them. Covered
+by a webview test that loads a noteful entry then reloads a clean one and asserts the notes
+are cleared.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_12_preserve_stdio_only_fields.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_12_preserve_stdio_only_fields.md
@@ -1,0 +1,17 @@
+# Analysis 12 - Preserve stdio-only VS Code fields when saving
+
+## Decision: Valid — fix applied
+
+The same `mergeEntryOntoBase` change used for HTTP/SSE applies to stdio: when saving a file
+source, the regenerated `{ type, command, args, cwd?, env? }` is merged onto the loaded raw
+entry, so VS Code-supported stdio fields the form does not model (`envFile`, `dev`,
+`sandboxEnabled`, ...) are preserved. The opposite-mode key (`url`) is removed on a
+stdio<->http switch.
+
+**Why:** Rebuilding the stdio entry from scratch deleted those fields on any unrelated
+edit, so env files stopped loading, dev mode was disabled, or sandboxing was turned off.
+Merging preserves them. Covered by a unit test asserting `envFile`/`dev`/`sandboxEnabled`
+survive a file save while the edited flag is still written, plus a mode-switch test that
+asserts the stale `url` is dropped.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_13_allow_vscode_variable_config.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_13_allow_vscode_variable_config.md
@@ -1,0 +1,17 @@
+# Analysis 13 - Allow VS Code input variables in loaded --config paths
+
+## Decision: Valid — fix applied
+
+For a file-source save, `writeMcpJsonFromSettings` now detects a VS Code launch-time
+variable `--config` path (via `isVscodeVariableConfigPath`: an unresolved `${...}` that is
+NOT an extension-owned `${workspaceFolder}`/`${userHome}` token) and validates with the
+config path blanked, so the local unanchorable/loadability checks do not fire. The verbatim
+argv (`--config ${input:cfg}`) is still emitted into the entry because `buildLaunchSpec`
+keeps the unresolved token under `resolvePaths: false`.
+
+**Why:** VS Code resolves `${input:...}`/`${command:...}`/`${env:...}` when it launches the
+server, so the extension cannot (and must not) check those paths on disk; treating them as
+blocking made an otherwise valid `.vscode/mcp.json` entry unsaveable after any unrelated
+edit. Covered by a unit test asserting the save succeeds and the variable path round-trips.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_14_preserve_node_runtime_args.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_14_preserve_node_runtime_args.md
@@ -1,0 +1,15 @@
+# Analysis 14 - Preserve node runtime arguments when loading entries
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` now only uses the `node` fast path when `args[0]` is an actual script (not
+an option). A `node` entry whose first arg starts with `-` (e.g. `--inspect`) falls through
+to custom parsing, so `command: "node"` becomes the custom command and `--inspect
+dist/index.js` is preserved in `customArgs` before the wcli0 server flags.
+
+**Why:** Assuming `args[0]` is the script turned `--inspect` into the script path and
+reordered the real script after the server flags, breaking the launch on a no-op Save.
+Gating the node fast path on a non-option first arg preserves the launcher verbatim.
+Covered by unit tests for both the node-with-options (custom) and plain-node cases.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_15_preserve_custom_wrapper_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_15_preserve_custom_wrapper_flags.md
@@ -1,0 +1,17 @@
+# Analysis 15 - Avoid stealing wrapper options that look like server flags
+
+## Decision: Valid — fix applied
+
+The custom-launcher boundary is now found by scanning for the START of the longest pure
+wcli0 server-flag suffix (`serverFlagSuffixStart` + `isPureServerFlagRun`) rather than the
+first recognized flag. Because the forward builder emits `[...customArgs, ...serverFlags]`,
+the wcli0 flags are a contiguous suffix; a wrapper option that collides with a wcli0 flag
+name (`--config wrapper.json` before `wcli0`) stays in `customArgs` because a later bare
+token (`wcli0`) disqualifies the earlier run.
+
+**Why:** Splitting at the first recognized flag stole the wrapper's `--config wrapper.json`
+into settings and reordered it on Save, changing the launch. Suffix detection keeps the
+launcher args in order. Covered by unit tests for the colliding-wrapper case and a
+trailing-extraArg case; the existing uvx/custom round-trip tests still pass.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_16_repost_detection_on_folder_change.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_16_repost_detection_on_folder_change.md
@@ -1,0 +1,17 @@
+# Analysis 16 - Re-post source detection after workspace changes
+
+## Decision: Valid — fix applied
+
+After the synchronous re-post on a workspace-folder change, `wsSub` now refreshes the
+detection cache and pushes a dedicated `detected` message; the webview's new `detected`
+handler updates only the source-switcher rows and the "Load & edit" banner (via a factored
+`applyDetected`) without touching scope or field values.
+
+**Why:** The handler previously posted stale cached detection and refreshed without
+re-posting, so opening a folder that already had `.vscode/mcp.json` left the banner/row
+absent until an unrelated post. A full init re-post would reintroduce the P96 scope-race;
+a detection-only message updates the UI safely. Covered by a webview test asserting a
+`detected` message with the wcli0 entry is pushed after a folder change; the P96 test
+still passes.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_17_preserve_npx_launcher_options.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_17_preserve_npx_launcher_options.md
@@ -1,0 +1,15 @@
+# Analysis 17 - Preserve npx launcher options before the package
+
+## Decision: Valid — fix applied
+
+The `npx` fast path now applies only when the package token (after an optional `-y`) is not
+an option. An entry like `npx --package=wcli0 -- wcli0 --shell cmd` falls through to custom
+parsing, so `npx` becomes the custom command and `--package=wcli0 -- wcli0` is preserved in
+`customArgs` before the wcli0 server flags.
+
+**Why:** Skipping only `-y` and assuming the next token is the package treated
+`--package=wcli0` as the package spec and reordered the launcher on Save. Gating the npx
+fast path on a non-option package token preserves the launcher verbatim. Covered by unit
+tests for npx-with-options (custom) and plain npx (with and without `-y`).
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_18_variables_in_all_launch_fields.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_18_variables_in_all_launch_fields.md
@@ -1,0 +1,17 @@
+# Analysis 18 - Allow VS Code variables in all file-source launch fields
+
+## Decision: Valid — fix applied
+
+The file-source validation bypass is generalized from `configFile` to all launch fields via
+`neutralizeVscodeVariableLaunchFields`: optional path fields holding a VS Code launch-time
+variable (`configFile`, `cwd`, `initialDir`, `logDirectory`, variable `allowedDirectories`)
+are blanked for validation, and the required fields (`nodeScriptPath`, `customCommand`) are
+replaced with an absolute placeholder. The real values are still emitted verbatim because
+`buildLaunchSpec(..., { resolvePaths: false })` keeps the tokens.
+
+**Why:** VS Code resolves `${input:...}`/`${env:...}`/`${command:...}` at launch, so the
+extension's local anchorability checks must not reject an otherwise no-op file-source Save
+that uses them in any preserved field. Covered by unit tests for a variable `cwd` and a
+variable node script path.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_19_drop_stale_transport_fields.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_19_drop_stale_transport_fields.md
@@ -1,0 +1,15 @@
+# Analysis 19 - Drop stale transport-only fields when changing modes
+
+## Decision: Valid — fix applied
+
+`mergeEntryOntoBase` now removes the OTHER transport mode's ENTIRE field set on a mode
+switch, using `STDIO_FIELD_KEYS` (adds `envFile`/`dev`/`sandboxEnabled`) and
+`HTTP_FIELD_KEYS` (adds `headers`/`oauth`) rather than only the form-owned keys. Staying in
+the same mode still preserves that mode's unmodeled fields (P7/P12).
+
+**Why:** The previous lists only removed `url` or `command`/`args`/`cwd`/`env`, so an HTTP
+entry's `headers`/`oauth` survived into a stdio server (and stdio's `envFile`/`dev` into an
+HTTP server) after a mode change. Removing the other mode's whole field set fixes the leak.
+Covered by unit tests for both switch directions.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_1_export_persists_file_source.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_1_export_persists_file_source.md
@@ -1,0 +1,20 @@
+# Analysis 1 - Prevent export actions from persisting file-source edits
+
+## Decision: Valid — fix applied
+
+While the active source is `.vscode/mcp.json`, the export handlers
+(`generateConfig` / `writeMcpJson` / `showCommand`) ran `applySettings` on the
+posted form values and then executed the export command, which reads `wcli0.*`
+settings. Because the file-source form holds the mcp.json entry (not settings),
+this corrupted `wcli0.*` settings and produced output unrelated to the file being
+edited. Fixed in two layers: the host export handler now refuses with an error
+when `currentSource === 'mcpJson'` (defense in depth), and the webview disables
+the three export buttons whenever a file source is active (re-enabling them on
+the settings source, with `Write .vscode/mcp.json` still gated on a workspace
+folder).
+
+**Why:** The file-source design explicitly never writes `wcli0.*` settings (see
+the `saveToFile` handler). Letting an export persist file-source diffs violated
+that invariant and could silently overwrite the user's settings.
+
+**Commit:** 81ab523 — fix(vscode): address review feedback for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_20_merge_current_on_disk_entry.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_20_merge_current_on_disk_entry.md
@@ -1,0 +1,16 @@
+# Analysis 20 - Detect stale wcli0 entry changes before saving
+
+## Decision: Valid — fix applied
+
+`writeMcpJsonFromSettings` now keeps the form-generated fields separately and, at the write
+step, merges them onto the CURRENT on-disk `servers.wcli0` entry (re-read into `existing`)
+rather than the snapshot loaded into the panel. It falls back to the loaded `baseEntry`
+when no entry is on disk. Other servers are still preserved as before.
+
+**Why:** Merging onto the stale `loadedFileEntry` discarded external additions made to the
+same entry after it was loaded (new `headers`/`envFile`/`oauth`). Merging onto the current
+on-disk entry preserves those unmodeled additions while the user's form edits still win for
+modeled fields. Covered by a unit test that edits the on-disk entry after the load snapshot
+and asserts the external `headers` survive the save.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_21_parse_url_userinfo.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_21_parse_url_userinfo.md
@@ -1,0 +1,15 @@
+# Analysis 21 - Parse URL userinfo before extracting host and port
+
+## Decision: Valid — fix applied
+
+`parseHttpUrl`'s regex now skips an optional `userinfo@` segment
+(`^[a-z]+:\/\/(?:[^@/]*@)?(host)(:port)?`), so credentials in a URL such as
+`https://user:pass@example.com:9444/mcp` no longer get mistaken for the host and the
+explicit port behind them is read correctly.
+
+**Why:** Without skipping userinfo, `user` was parsed as the host and the port was missed,
+so the form showed the wrong host/default port, a port edit was ignored, and a host edit
+dropped the credentials. Covered by a `parseMcpEntry` test asserting the host/port are read
+past the credentials and the verbatim URL is preserved.
+
+**Commit:** 3eccda7 — fix(vscode): address review feedback for PR #89 (round 3)

--- a/docs/tasks/autodetect_mcp_source/analysis_22_toggle_dirty_indicator.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_22_toggle_dirty_indicator.md
@@ -1,0 +1,18 @@
+# Analysis 22 - Toggle the dirty indicator on edits
+
+## Decision: Valid — fix applied
+
+The `#dirtyMsg` span existed but was never toggled: `reflectDirty` only flipped the
+Revert button's `disabled` state, so the promised "Unsaved changes" indicator never
+appeared. `reflectDirty` now also toggles `#dirtyMsg`, showing it only when the form is
+dirty AND the active source is `.vscode/mcp.json` (the settings source has its own
+per-scope Save affordances). Because `reflectDirty` runs on every field edit (delegated
+input/change listeners) and on every reload/save via `setActiveSource`, the indicator
+clears correctly on save, revert, and source switches.
+
+**Why:** The reviewer correctly identified dead UI. Scoping the indicator to the file
+source matches the original intent (the dirty/Revert affordances are file-source-only)
+and keeps the settings flow unchanged. Covered by client-side DOM tests P22 in
+webviewButtons.test.cjs (shown when a file form is dirty; hidden on the settings source).
+
+**Commit:** baf060b — fix(vscode): address review feedback for PR #89 (round 4)

--- a/docs/tasks/autodetect_mcp_source/analysis_23_preserve_on_disk_env.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_23_preserve_on_disk_env.md
@@ -1,0 +1,19 @@
+# Analysis 23 - Preserve current on-disk env on file saves
+
+## Decision: Valid — fix applied
+
+`writeMcpJsonFromSettings` sourced the round-tripped `env` from the panel-open snapshot
+(`baseEntry`). Since `env` is a form-owned stdio key, the current-on-disk merge (P20)
+deleted the on-disk `env` and reapplied the stale one, so a variable another process
+added after the panel opened was silently dropped — and no env prompt appeared because
+the stale baseline looked empty/unchanged. The fix reads the CURRENT on-disk entry via
+`readWcli0Entry(folder)` and round-trips its raw `env` (falling back to `baseEntry` when
+nothing is on disk, mirroring the P20 merge-base re-derivation).
+
+**Why:** `env` is unmodeled by the form, so the file is the source of truth for it; the
+save must preserve whatever is on disk rather than a snapshot. Aligns with the existing
+P20 (merge against current on-disk entry) and P9 (preserve non-string env) handling.
+Covered by webview.test.cjs P23 (a PORT added on disk after load survives an unrelated
+save).
+
+**Commit:** baf060b — fix(vscode): address review feedback for PR #89 (round 4)

--- a/docs/tasks/autodetect_mcp_source/analysis_24_parse_valued_extra_args.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_24_parse_valued_extra_args.md
@@ -1,0 +1,21 @@
+# Analysis 24 - Parse custom suffixes with valued extraArgs
+
+## Decision: Valid — fix applied
+
+`isPureServerFlagRun` rejected any run containing a bare (non-dash) token, so a custom
+suffix ending in a valued extraArg such as `--futureFlag x` was disqualified and
+`serverFlagSuffixStart` mis-split the modeled flags (`--shell cmd`) into the launcher
+args. The fix consumes a trailing bare token as the preceding unrecognized flag's value:
+when the bare token is the LAST token of the run it is the value of a valued extraArg, so
+the run stays pure; a bare token with more tokens after it is still treated as a launcher
+positional and disqualifies the run.
+
+**Why:** The forward builder emits `[...launcherArgs, ...modeledFlags, ...extraArgs]`, so
+extraArg values appear at the tail while launcher positionals (uvx's package, `--` then
+the command) appear before the modeled flags and are followed by them. The "trailing
+only" rule is the precise discriminator that fixes P24 without regressing P15 (keep
+wrapper options/positionals in the launcher) or P17 (`npx --package=x -- wcli0 ...`).
+Covered by configSource.test.cjs P24 (trailing valued extraArg parses; non-trailing bare
+token stays a launcher positional).
+
+**Commit:** baf060b — fix(vscode): address review feedback for PR #89 (round 4)

--- a/docs/tasks/autodetect_mcp_source/analysis_25_push_source_reset.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_25_push_source_reset.md
@@ -1,0 +1,22 @@
+# Analysis 25 - Push source resets through dirty file forms
+
+## Decision: Valid — fix applied
+
+When the primary workspace folder changed, the host reset `currentSource` to settings and
+re-posted with `post(true)`, but a dirty webview ignores an external init (so it does not
+discard edits) and therefore never applied the source switch — the UI kept showing and
+saving as the now-gone file source until a save was rejected. The host now posts a
+dedicated `sourceReset` message (only when the file source was actually reset), and the
+webview handles it by calling `setActiveSource('settings', ...)` and clearing stale parse
+notes, switching off the file source even while dirty. Field values and the dirty state
+are left untouched, so unsaved edits are not discarded.
+
+**Why:** The external-init dirty guard is correct for field values but wrongly suppressed
+the source switch too. A separate message cleanly carries the source change without
+touching fields, mirroring the existing `detected` message pattern (P16/P96). This
+complements the P6 stale-save rejection by fixing the UI state proactively rather than
+only at save time. Covered by webview.test.cjs P25 (sourceReset posted on folder change,
+not posted when settings was active) and webviewButtons.test.cjs P25 (the webview switches
+off the file source on a dirty form).
+
+**Commit:** baf060b — fix(vscode): address review feedback for PR #89 (round 4)

--- a/docs/tasks/autodetect_mcp_source/analysis_26_describe_comment_handling.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_26_describe_comment_handling.md
@@ -1,0 +1,17 @@
+# Analysis 26 - Describe the comment handling accurately
+
+## Decision: Valid — fix applied
+
+The README claimed "comments/non-object files are refused rather than clobbered", but the
+writer only refuses non-object/malformed files; a file containing comments triggers a
+modal warning and, on confirmation, is rewritten as plain JSON (comments removed). The
+README now states that a non-object or malformed file is refused, while a file containing
+comments is rewritten as plain JSON only after the user confirms (the comments are
+removed).
+
+**Why:** Accurate docs about a destructive-on-confirm behavior matter: a user relying on
+the old text might assume comments are always protected. The new wording matches the
+actual code path in `writeMcpJsonFromSettings` (`containsJsoncComments` -> modal "Write
+anyway"). Documentation-only change; no test needed.
+
+**Commit:** baf060b — fix(vscode): address review feedback for PR #89 (round 4)

--- a/docs/tasks/autodetect_mcp_source/analysis_27_preserve_cwd_relative_config.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_27_preserve_cwd_relative_config.md
@@ -1,0 +1,27 @@
+# Analysis 27 - Preserve cwd-relative --config when saving file sources
+
+## Decision: Valid — fix applied
+
+When re-saving a loaded `.vscode/mcp.json` stdio source, `buildLaunchSpec(..., { resolvePaths:
+false })` ran every plain relative path arg through `pathValue`, which anchored it to a
+`${workspaceFolder}` token. For an entry with a non-workspace `cwd` that was wrong: the
+server resolves `--config config.json` (and `--allowedDir` / `--initialDir` /
+`--logDirectory`) against its own `cwd`, so an unrelated Save silently retargeted the
+config from `<cwd>/config.json` to `${workspaceFolder}/config.json`, changing which shells
+or safety settings load. A new `preserveRelativePaths` build option (set only for the
+file-source save in `writeMcpJsonFromSettings`) now keeps a plain relative path arg
+verbatim — and `cwd` itself round-trips verbatim too — so the entry launches the same file
+it was loaded with. Settings-driven exports keep the existing `${workspaceFolder}`
+anchoring, matching how the provider resolves relative path settings against the workspace.
+
+**Why:** This mirrors the established `nodeScriptArg` rule (a relative node script with a
+configured `cwd` stays relative rather than workspace-anchored, P30) and extends it to the
+other relative path args, which share the same cwd-resolution semantics. The signal had to
+be file-source vs settings-export, not merely "cwd is set": a settings export with a
+relative `cwd` must still anchor relative path settings to the workspace (existing P1
+behavior, kept green), because the provider absolutizes them against the workspace before
+launch. Covered by argsBuilder.test.cjs P27 (preserveRelativePaths keeps relative args
+verbatim; the settings export still anchors) and commands.test.cjs P27 (a file save
+preserves a cwd-relative `--config`).
+
+**Commit:** a233fef — fix(vscode): address review feedback for PR #89 (round 5)

--- a/docs/tasks/autodetect_mcp_source/analysis_28_guard_dirty_edits_to_settings.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_28_guard_dirty_edits_to_settings.md
@@ -1,0 +1,26 @@
+# Analysis 28 - Avoid retargeting dirty file edits to settings
+
+## Decision: Valid — fix applied
+
+After a folder change reset a dirty `.vscode/mcp.json` source, the `sourceReset` handler
+switched the form to the settings source but deliberately kept the file's values and a
+file-relative dirty baseline (P25, so unsaved edits are not discarded). The renamed "Save
+settings" button then posted a normal `save`, writing those file-derived edits into
+`wcli0.*` settings for the current scope — and against the wrong (file) diff baseline —
+silently after exactly the scenario the reset was meant to protect. The webview now sets a
+`resetFromFileSource` flag on `sourceReset` and tags a settings save with
+`fromResetFileSource` while that stale baseline is still dirty; the host shows a modal
+("these values came from a .vscode/mcp.json source that is no longer active … save them
+anyway?") and writes only on confirm. The flag clears whenever the form re-baselines to
+real values (any applied init / a save), so ordinary saves are never gated.
+
+**Why:** This honors both constraints that were in tension: P25 keeps the user's edits on
+screen (nothing is discarded), while a confirmation stops them from silently corrupting
+settings. Routing the modal through the host matches the existing pattern (window.confirm
+is unavailable in a VS Code webview, see P70). The approach was chosen with the user over
+re-baselining (which would make Save silently no-op) and discarding edits (which would
+contradict P25). Covered by webview.test.cjs P28 (a flagged save is confirmed before
+writing; confirm persists; an unflagged save is not gated) and webviewButtons.test.cjs P28
+(a save after a reset is flagged; the flag clears after re-baseline).
+
+**Commit:** a233fef — fix(vscode): address review feedback for PR #89 (round 5)

--- a/docs/tasks/autodetect_mcp_source/analysis_29_refuse_unsavable_file_edits.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_29_refuse_unsavable_file_edits.md
@@ -1,0 +1,25 @@
+# Analysis 29 - Refuse file-source shell/profile edits that cannot be saved
+
+## Decision: Valid — fix applied
+
+When editing a `.vscode/mcp.json` source that references a loadable `--config`, per-shell
+(`wcli0.shells`) or profile (`wcli0.profiles`) edits made on the Shells/Profiles tabs were
+overlaid onto the loaded settings and passed the existing "Write anyway" warning, but
+`writeMcpJsonFromSettings` only writes the mcp.json entry and leaves the referenced config
+file untouched. Since `parseMcpEntry` never reads shells/profiles back from that file, the
+post-write reparse dropped those edits while still reporting a successful save — a silent
+data loss. The file-source branch of `writeMcpJsonFromSettings` now refuses the save when
+the form carries per-shell or profile config, with a message directing the user to edit the
+referenced `--config` file directly and reload the source.
+
+**Why:** The pre-existing "Write anyway" warning is correct for a settings export — there
+shells/profiles persist in `wcli0.*` settings and the provider builds its own managed config
+from them, so a pinned `configFile` is a best-effort sync, not the only copy. For a file
+source there is no such persistence: the form values exist only in the form and have nowhere
+to go, so a hard refuse (mirroring the existing block at commands.ts when no loadable config
+file exists) is the safe behavior rather than a silent drop. The refusal is gated on
+`fileSource && (hasPerShellConfig || hasProfilesConfig)`, so a normal file save with no
+shell/profile edits is unaffected. Covered by commands.test.cjs P29 (a file save with
+profile edits is refused and writes nothing; a file save without them still succeeds).
+
+**Commit:** a233fef — fix(vscode): address review feedback for PR #89 (round 5)

--- a/docs/tasks/autodetect_mcp_source/analysis_2_reset_file_source_primary_folder.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_2_reset_file_source_primary_folder.md
@@ -1,0 +1,20 @@
+# Analysis 2 - Reset file source when the primary folder changes
+
+## Decision: Valid — fix applied
+
+The `onDidChangeWorkspaceFolders` handler only reset the file source when no
+folders remained. In a multi-root workspace, removing/reordering folders could
+change `primaryWorkspaceFolder()` to a different folder while keeping
+`currentSource === 'mcpJson'` and `loadedFileSettings` from the old folder; the
+next `saveToFile` would then overwrite the new primary folder's
+`.vscode/mcp.json` with the previous folder's config. Fixed by tracking the
+fsPath of the folder the file source was loaded from (`loadedFileFolder`, set on
+load and on save, cleared on switching to settings) and resetting the file source
+in the folders-change handler whenever the current primary folder's fsPath no
+longer matches it — which also subsumes the previous no-folder case.
+
+**Why:** A file source is workspace-relative and bound to one folder. Saving it
+against a different folder is data loss; resetting to the settings source is the
+safe, predictable fallback.
+
+**Commit:** 81ab523 — fix(vscode): address review feedback for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_30_transport_flags_corrupt_stdio_entry.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_30_transport_flags_corrupt_stdio_entry.md
@@ -1,0 +1,35 @@
+# Analysis 30 - Transport flags in a stdio entry's args flip the type and delete command/args on save
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` derives `transportMode` from the entry `type` (stdio by default),
+then calls `parseServerArgs` on the args and `Object.assign`s the parsed
+settings over it. Because `--transport` is in `VALUE_OPTIONS`, a `--transport
+http` flag in a stdio entry's args overwrites `transportMode` to `'http'`. On
+save, `writeMcpJsonFromSettings` then takes the http/sse branch (the stdio
+guard `settings.transportMode === 'stdio'` is false), generates `{ type, url }`,
+and `mergeEntryOntoBase(..., 'http')` deletes the whole `STDIO_FIELD_KEYS` set
+(`type`, `command`, `args`, `cwd`, `env`, `envFile`, `dev`, `sandboxEnabled`).
+The launcher is gone and a default URL is written, with no prompt. The sibling
+transport sub-flags (`--http-host`, `--http-port`, `--sse-host`, `--sse-port`,
+the allowed-origins flags) are consumed into `transportHost`/`transportPort`/
+`transportAllowedOrigins` but never re-emitted for stdio (the forward builder
+only emits them in the non-stdio branch), so they are dropped on a no-op save.
+
+**Why:** An mcp.json entry's `type` is authoritative — it selects stdio vs. an
+http/sse `url` server. The reverse parser must not let a flag inside `args`
+override it, and must not consume transport sub-flags it cannot re-emit for the
+mode the `type` selected. This is the same preserve-the-authored-entry invariant
+behind P5/P10 (preserve URLs the form cannot model) and P19 (drop only the
+OTHER mode's fields).
+
+**Proposed fix:** In `parseMcpEntry`, after parsing server args for a stdio
+entry, drop any parsed `transportMode`/`transportHost`/`transportPort`/
+`transportAllowedOrigins` (or never consume the `--transport`/`--http-*`/
+`--sse-*` tokens for a non-http/sse entry) so they fall through to `extraArgs`
+and round-trip verbatim, leaving `transportMode = 'stdio'`. Add a note when an
+unusual transport flag is present in a stdio entry. No existing test covers the
+save path here (configSource.test.cjs only asserts the parse direction).
+Related: [[analysis_31_unknown_transport_type_coerced_stdio]].
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_31_unknown_transport_type_coerced_stdio.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_31_unknown_transport_type_coerced_stdio.md
@@ -1,0 +1,28 @@
+# Analysis 31 - An unrecognized transport `type` is silently rewritten to stdio on save
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` reads `const type = asString(entry.type) || 'stdio'` and then
+checks `if (type === 'http' || type === 'sse')` case-sensitively. Any other
+non-empty value (`'HTTP'`, `'websocket'`, a typo, or a future transport) falls
+through to the stdio branch, sets `transportMode = 'stdio'`, and emits no note.
+On save, `mergeEntryOntoBase` deletes `type` (present in both
+`STDIO_OWNED_KEYS` and `HTTP_OWNED_KEYS`) and writes the generated type
+(`'stdio'`, or `'http'`/`'sse'`), so the original type is overwritten. An
+uppercase-`HTTP` entry that carries only a `url` is even worse: it parses as a
+stdio entry with an empty command, so the save is blocked by validation and the
+form misleads the user into thinking the entry is a broken stdio launch rather
+than an http server.
+
+**Why:** This violates the preserve-or-warn discipline the round trip already
+applies to values the form cannot fully model (verbatim URLs in P5/P8/P10, raw
+env in P9). The `type` field is a single authoritative token; silently coercing
+it corrupts the entry on a no-op save.
+
+**Proposed fix:** Either match `type` case-insensitively for `http`/`sse`, or —
+preferred for forward-compat — when `entry.type` is a non-empty value other than
+`stdio`/`http`/`sse`, emit a note and have the file-source save preserve the
+original `type` verbatim (skip regenerating it, or refuse the save like P29).
+Related: [[analysis_30_transport_flags_corrupt_stdio_entry]].
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_32_short_config_alias_unrecognized.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_32_short_config_alias_unrecognized.md
@@ -1,0 +1,28 @@
+# Analysis 32 - The short-form `-c` / `--c` config alias is not recognized when loading an entry
+
+## Decision: Valid — fix applied
+
+The server exposes `config` with alias `c`. The forward builder's
+`stripConfigArgs` strips every yargs form (`-c X`, `--c X`, `-c=X`, `--c=X`,
+`-cX` bundling, `--no-c`). The reverse parser's `VALUE_OPTIONS` table lists only
+`'--config'`, so a short-form `-c config.json` (or `--c`) in a loaded entry is
+not modeled: `-c` and its value fall into `extraArgs` and `configFile` stays
+empty. The data round-trips via `extraArgs`, but three user-visible things go
+wrong: the Config-file field renders empty (misleading — the entry does
+reference a config file); the "references a config file via --config" note
+(configSource.ts:428) does not fire (it keys on `s.configFile.trim()`); and the
+`configFileLoadable` validation is skipped because `resolvedConfigFilePath`
+returns undefined for an empty `configFile`, so a `-c` that pins a
+missing/malformed file saves without the P85-style warning a `--config` pin
+would get.
+
+**Why:** The reverse parser and the forward builder must agree on the grammar of
+every flag, or the form/validation diverges from what the server actually
+receives. The config alias is the one short form the server defines, and the
+forward side already exhausts it.
+
+**Proposed fix:** Add `'-c'` and `'--c'` (and handle `-cX` bundling) to
+`VALUE_OPTIONS` for `configFile`, or normalize `-c`/`--c` to `--config` before
+the parse loop, so the alias maps to `configFile` like the long form.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_33_nonstring_args_coerced_empty.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_33_nonstring_args_coerced_empty.md
@@ -1,0 +1,25 @@
+# Analysis 33 - Non-string `args` elements are silently coerced to empty string
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` builds the arg list with
+`entry.args.map((a) => asString(a))`, and `asString` returns `''` for every
+non-string. A numeric arg (`args: ["--inspect", 9229]`) therefore becomes
+`["--inspect", ""]`; the next save writes `"--inspect", ""`, corrupting the
+original value. The inconsistency is with `env`: P9 made the file-source save
+round-trip the raw on-disk `env` verbatim (numbers, null, etc.) precisely so an
+unrelated save would not mangle it, but `args` are always rebuilt from the
+coerced settings. Node's `spawn` would have stringified `9229` to `"9229"`, so
+`asString`'s `''` is more lossy than the server's own coercion.
+
+**Why:** An unrelated save must not modify values the form does not edit. Args
+are form-modeled (custom args / extra args / server flags), so they cannot be
+preserved verbatim the way `env` is, but coercing non-strings to `''` is a
+silent corruption a reviewer would flag alongside P9.
+
+**Proposed fix:** Coerce with `String(a)` (matching node's spawn behavior) at
+minimum, or — for full fidelity — round-trip the raw `entry.args` verbatim from
+the on-disk entry on a file-source save the way `env` is, regenerating only the
+modeled flags. Related: [[analysis_34_invalid_numeric_blocks_save]].
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_34_invalid_numeric_blocks_save.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_34_invalid_numeric_blocks_save.md
@@ -1,0 +1,28 @@
+# Analysis 34 - An invalid numeric flag value is consumed into a typed field and blocks every save
+
+## Decision: Valid — fix applied
+
+`parseServerArgs` parses a number option with
+`const n = Number(value); out[key] = Number.isFinite(n) ? n : value`. A
+non-numeric value (`--commandTimeout abc`) stores the raw string `'abc'` in the
+`number | null` field and consumes the flag (it never reaches `extraArgs`).
+`Object.assign` puts that string into `s.commandTimeout`. On save,
+`validateLaunchSpec` computes `!(value > 0)` → `!('abc' > 0)` → `!(NaN > 0)` →
+blocking, so the save is refused with "wcli0.commandTimeout (abc) must be a
+positive number". Because the flag was consumed rather than passed through, the
+user cannot save any unrelated edit until they manually clear the field (clearing
+works only because an empty number maps back to null and the flag is then simply
+absent). A value the parser cannot model should round-trip verbatim through
+`extraArgs`, the same escape hatch used for unknown flags.
+
+**Why:** Loading an entry should never leave the user unable to save an
+unrelated change. The forward path tolerates only valid numbers, so the reverse
+path must not poison a typed field with an unparseable value that the forward
+path then rejects.
+
+**Proposed fix:** When `Number(value)` is not finite, push the original
+`--flag value` (or `--flag=value`) tokens to `extraArgs` instead of storing the
+raw string in the typed field, so they survive a round trip untouched.
+Related: [[analysis_33_nonstring_args_coerced_empty]].
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_35_p29_gate_missing_http_sse.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_35_p29_gate_missing_http_sse.md
@@ -1,0 +1,30 @@
+# Analysis 35 - The P29 refusal is nested inside the stdio branch, so http/sse file sources silently drop shells/profiles
+
+## Decision: Valid — fix applied
+
+`writeMcpJsonFromSettings` opens `if (settings.transportMode === 'stdio')` at
+commands.ts:365, and the P29 refusal (line 389), the no-config-file guard
+(line 406), and the sync warning (line 426) all live inside it. The http/sse
+`else` branch (line 464) only validates the port and writes `{ type, url }`
+(plus preserved `headers`/`oauth`). So a file source set to http/sse that also
+carries per-shell settings or environment profiles is never refused: those values
+cannot be expressed in an http/sse entry (no `--config`, no shells/profiles
+keys), so they are silently dropped while the save reports success. This is the
+same unsavable-edit class as P29, just unguarded for the non-stdio modes.
+
+**Why:** P29's intent was "a file save must not silently drop per-shell/profile
+edits it cannot persist." Nesting the guard under stdio leaves the http/sse
+modes uncovered, so the protection is incomplete. The provider does launch over
+http/sse with profiles honored, so the dropped values are real.
+
+**Proposed fix:** Hoist the `fileSource && (hasPerShellConfig(settings) ||
+hasProfilesConfig(settings))` refusal (or a transport-aware variant) above the
+stdio/http branch split so it covers every file-source save. Pair with
+[[analysis_36_p29_bypass_ignore_mask]] (the mask bypass) since both are gaps in
+the same gate.
+**Resolution:** Implemented in PR #89 round 6: the refusal was hoisted above the
+stdio/http split in `writeMcpJsonFromSettings`, so an http/sse file source with
+shells/profiles is now refused too (commands.ts, the `fileSource &&
+(hasRawPerShellConfig || hasRawProfilesConfig)` guard).
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_36_p29_bypass_ignore_mask.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_36_p29_bypass_ignore_mask.md
@@ -1,0 +1,35 @@
+# Analysis 36 - The ignore-inherited masks bypass the P29 refusal and silently drop shells/profiles on a file save
+
+## Decision: Valid — fix applied
+
+`applyScopeAvailability` disables the `ignoreInheritedShells` /
+`ignoreInheritedProfiles` selects only when `scope === 'Global'`; `setActiveSource`
+never disables them for a file source. So at the retained Workspace scope (the
+scope radio is hidden but `currentScope`/`formScope` stays Workspace) the user
+can set either mask to Ignore. The P29 gate calls
+`hasPerShellConfig(settings)` / `hasProfilesConfig(settings)`, and both return
+`false` when their mask is set (settings.ts:328, :393). The masks exist to let a
+Workspace scope opt out of User-scope shells/profiles — a concept with no meaning
+for a scope-less file source, where `parseMcpEntry` starts from `defaultSettings()`
+and never reads shells/profiles back. So enabling a mask on a file source both
+silently drops the mask itself (no entry field for it) and defeats the P29
+refusal, letting the user's per-shell/profile edits be silently dropped on a save
+that reports success. The existing P29 tests (commands.test.cjs:855,880) cover
+only the no-mask case.
+
+**Why:** P29 must catch every file-source save that carries shells/profiles the
+entry cannot persist. Routing it through the mask-aware `hasPerShellConfig`/
+`hasProfilesConfig` re-opens the hole, and leaving the mask controls editable on
+a file source invites the bypass.
+
+**Proposed fix:** Disable both mask selects when `currentSourceClient ===
+'mcpJson'` (add to `setActiveSource`), AND/OR evaluate the P29 condition on the
+raw `settings.shells`/`settings.profiles` (ignoring the masks) for a file
+source, so the refusal cannot be bypassed. Pair with
+[[analysis_35_p29_gate_missing_http_sse]].
+**Resolution:** Implemented in PR #89 round 6 via the raw-check approach: the
+hoisted refusal calls `hasRawPerShellConfig` / `hasRawProfilesConfig` (new in
+settings.ts), which ignore the `ignoreInheritedShells/Profiles` masks, so enabling
+a mask can no longer suppress the refusal. Covers [[analysis_39_dont_report_mask_edits_saved]].
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_37_toctou_split_file_reads.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_37_toctou_split_file_reads.md
@@ -1,0 +1,29 @@
+# Analysis 37 - The env source and the merge base come from two separate file reads straddling the env-prompt modal
+
+## Decision: Valid — fix applied
+
+For a file-source stdio save, `writeMcpJsonFromSettings` calls
+`readWcli0Entry(folder)` (commands.ts:516) to source the round-tripped `env`,
+then awaits the Include/Omit `showWarningMessage` modal (lines 523-535), then
+`readFile`s the whole file again (line 576) to build `existing` and the
+`servers.wcli0` merge base (lines 633-636). An external change to
+`.vscode/mcp.json` during that modal makes the two reads disagree. If env was
+added in between, the prompt counted only the first read's keys and the merge
+deletes the second read's newer env (env is a form-owned stdio key) — a silent
+loss exactly like the one P23 fixed, re-opened by the split read. If the file is
+deleted between the reads, `readFile` throws `FileNotFound`, `existing` becomes
+`{}`, the merge falls back to `baseEntry`, and the write recreates the file with
+only `servers.wcli0`, losing every other server that was present at the first
+read, with no warning.
+
+**Why:** A save must operate on a single consistent snapshot of the file it is
+merging into. P20/P23 established that the on-disk entry is the source of truth
+for the merge base and for env; reading it twice across a user-facing modal
+breaks that invariant under concurrent edits.
+
+**Proposed fix:** Read the file once at the top of the function, parse it once,
+and derive both the env (the current `servers.wcli0.env`) and the merge base
+(`servers.wcli0`) from that single parsed object — eliminating the second
+`readFile`/`readWcli0Entry` and the window between them.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_38_sourceReset_false_positive.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_38_sourceReset_false_positive.md
@@ -1,0 +1,33 @@
+# Analysis 38 - `sourceReset` unconditionally arms the P28 flag, producing a false confirmation on a clean form
+
+## Decision: Valid — fix applied
+
+On a workspace-folder change, `wsSub` sends `post(true)` (an external init) and
+then, only when the file source was reset, the `sourceReset` message
+(webview.ts:561 then :567-568). The `sourceReset` handler sets
+`resetFromFileSource = true` unconditionally (line 2017). For a DIRTY form the
+external init is skipped by the dirty guard (line 2043-2044), so the flag is
+correctly armed (P28: the form still holds file-derived values). But for a CLEAN
+form the external init is applied: it re-baselines the form to real settings
+values and clears `resetFromFileSource = false` (line 2054), and the
+immediately-following `sourceReset` then sets it back to `true`. The form now
+holds settings values against a settings baseline yet is flagged file-derived,
+so the next "Save settings" posts `fromResetFileSource: true && isDirty()` and
+trips the P28 modal — a false positive ("these values came from a .vscode/mcp.json
+source that is no longer active..."). If the user trusts the warning and
+declines, a legitimate settings edit is abandoned. The existing P28 test
+(webviewButtons.test.cjs:281) dispatches `sourceReset` before a non-external init
+on a dirty form — the reverse of the real ordering — so it does not cover this.
+
+**Why:** `sourceReset` exists (P25) to switch a DIRTY form off a gone file
+source; for a clean form the preceding external init already did that switch and
+re-baselined. Arming the P28 flag regardless of whether the form still holds
+file-derived values makes the guard fire on values that actually came from
+settings.
+
+**Proposed fix:** Gate the flag on the form still being dirty in the
+`sourceReset` handler: `if (isDirty()) resetFromFileSource = true;`. A clean
+form (just re-baselined by the external init, `isDirty() === false`) leaves it
+cleared; a dirty form (init skipped) arms it, preserving P28.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_39_dont_report_mask_edits_saved.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_39_dont_report_mask_edits_saved.md
@@ -1,0 +1,27 @@
+# Analysis 39 - Don't report inherited-mask edits as saved to mcp.json
+
+## Decision: Valid — fix applied (jointly with P36)
+
+The `ignoreInheritedShells` / `ignoreInheritedProfiles` masks are scope-merge
+affordances with no representation in an mcp.json `servers.wcli0` entry, and
+`parseMcpEntry` never reads them back. Letting them be edited on a file source
+(Codex's point) is the same hole that lets them bypass the P29 refusal (P36):
+both are closed by making a file source unable to set them. The mask selects are
+now disabled while `currentSourceClient === 'mcpJson'` (re-enabled when the form
+returns to the settings source), so a file save can neither carry a mask edit
+nor use one to suppress `hasPerShellConfig`/`hasProfilesConfig`.
+
+**Why:** A file source has no scope to inherit from, so the masks are
+meaningless there; disabling them matches the existing pattern of disabling
+controls that do not apply to the active source (the export buttons, P1) and
+removes both the misleading-saved-state and the P29-bypass symptoms at once.
+
+**Proposed fix:** `setActiveSource` disables/enables both mask selects with the
+source; the P29 raw-check defense (P36) covers any non-UI path. Covers
+[[comment_39_dont_report_mask_edits_saved]] and
+[[comment_36_p29_bypass_ignore_mask]].
+**Resolution:** Same fix as [[analysis_36_p29_bypass_ignore_mask]] — the
+`hasRaw*` refusal blocks a file-source save carrying shells/profiles regardless of
+the mask, so a mask edit can no longer be misreported as saved.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_3_preserve_custom_launcher_args.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_3_preserve_custom_launcher_args.md
@@ -1,0 +1,22 @@
+# Analysis 3 - Preserve dash-prefixed custom launcher args
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry`'s custom branch split a custom command's args at the first
+dash-prefixed token, assuming everything from there is wcli0 server flags. That
+broke launchers whose own arguments are options (e.g. `uvx --from ... wcli0`),
+moving them into `extraArgs` after the generated server flags and reordering the
+command on save. Fixed by making the boundary the first *recognized* wcli0 server
+flag instead of the first dash: added a `BOOLEAN_FLAGS` set and an `isServerFlag`
+helper (covering `VALUE_OPTIONS`, the boolean/tri-state flags, and the `--opt=value`
+form) and using `args.findIndex(isServerFlag)`. The forward builder emits
+`[...customArgs, ...serverFlags]`, so this recovers the split faithfully and the
+load/save round-trip preserves argument order.
+
+**Why:** The forward emission order is the contract the reverse parser must
+invert. Keying on recognized wcli0 flags — not on any dash — matches that
+contract and keeps unknown launcher options in `customArgs` where they belong.
+A residual ambiguity (a launcher arg that literally equals a wcli0 flag name) is
+acceptably rare and already warned about for `--config` / `--transport`.
+
+**Commit:** 81ab523 — fix(vscode): address review feedback for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_40_preserve_uneditable_argv.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_40_preserve_uneditable_argv.md
@@ -1,0 +1,25 @@
+# Analysis 40 - Preserve current uneditable argv settings on file saves
+
+## Decision: Valid — fix applied
+
+For a file-source stdio save the whole `args` array is regenerated from
+`buildLaunchSpec(settings)`, where `settings` overlays the form's editable
+changes onto the snapshot loaded when the panel opened. The argv-derived fields
+the form does not edit (`customArgs`, `blockedCommands`/`blockedArguments`/
+`blockedOperators`, `maxReturnLines`, `transportAllowedOrigins`, `extraArgs`)
+therefore come from that stale snapshot, so an on-disk addition made by another
+editor after load (e.g. `--blockedCommand rm`) is dropped on an unrelated save.
+The fix re-reads the current on-disk entry once (sharing the single read with
+the P37/P41 changes) and re-parses it, then copies every uneditable argv-derived
+field from the on-disk parse onto `settings` before `buildLaunchSpec` — the
+args-equivalent of P23 (which already sources `env` from the on-disk entry).
+
+**Why:** The file is the source of truth for fields the form cannot edit; the
+save must carry forward whatever is on disk rather than a stale snapshot. This
+extends the P20/P23 on-disk-merge discipline to the regenerated `args`.
+
+**Proposed fix:** In `writeMcpJsonFromSettings`, parse the on-disk
+`servers.wcli0` and copy its `customArgs`/blocked lists/`maxReturnLines`/
+`transportAllowedOrigins`/`extraArgs` onto the settings used to build the spec.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_41_preserve_current_custom_urls.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_41_preserve_current_custom_urls.md
@@ -1,0 +1,22 @@
+# Analysis 41 - Preserve current custom URLs on file saves
+
+## Decision: Valid — fix applied
+
+`preservedFileUrl` decided whether to keep an http/sse entry's URL verbatim
+against `baseEntry` — the snapshot captured when the panel loaded — even though
+the merge step (P20) had already re-read the current on-disk entry. So an
+external edit to an unmodeled part of the URL after load (scheme/path/default
+port) was overwritten with the stale URL on the next save, as long as the modeled
+host/port still matched the form. The fix makes the file-source URL preservation
+use the CURRENT on-disk entry's `url` (from the single shared read) instead of
+`baseEntry`, so a concurrent URL change survives when its modeled host/port are
+unchanged — the URL twin of the P20 on-disk merge.
+
+**Why:** Once the save re-reads the on-disk entry for the merge base (P20) and
+for env (P23), the URL-preservation decision must use the same current snapshot,
+or it silently reverts a legitimate concurrent edit.
+
+**Proposed fix:** Pass the current on-disk entry to `preservedFileUrl` for a
+file source (replacing `baseEntry`), reusing the single read.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_42_parse_modeled_before_multiple_extras.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_42_parse_modeled_before_multiple_extras.md
@@ -1,0 +1,26 @@
+# Analysis 42 - Parse modeled flags before multiple valued extras
+
+## Decision: Valid — fix applied
+
+`isPureServerFlagRun` let only the FINAL unknown flag consume a following bare
+value (the P24 trailing rule). A suffix with several unknown value-bearing
+flags (`--shell cmd --future x --another y`) therefore failed the purity check at
+`--shell` (the first `--future x` orphaned `x`), so `serverFlagSuffixStart`
+split later and stranded `--shell cmd` in `customArgs`; the form then showed the
+default shell and a later edit appended a second `--shell`. The fix lets EVERY
+unrecognized `--flag` consume one following non-flag value (not just the last),
+so a run of `--unknown value` pairs stays pure and the modeled flags before them
+are recovered. A bare token that is NOT the value of a preceding unknown flag
+(an orphan positional) still disqualifies the run, preserving P15/P17.
+
+**Why:** The forward builder emits `[...launcherArgs, ...modeledFlags,
+...extraArgs]`, and extraArgs are commonly `--flag value` pairs; the reverse
+parser must recognize any number of them in the suffix, not only a single
+trailing one, or it mis-splits and drops modeled flags.
+
+**Proposed fix:** In `isPureServerFlagRun`, when an unrecognized `--flag` is
+followed by a non-flag token, consume that token as the flag's value regardless
+of position; keep rejecting a bare token that follows a RECOGNIZED value-option
+already consumed, or a bare token with no preceding flag.
+
+**Commit:** ceefe56 — fix(vscode): round-6 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_43_continue_scan_after_launcher_flag.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_43_continue_scan_after_launcher_flag.md
@@ -1,0 +1,30 @@
+# Analysis 43 - Keep scanning after ambiguous launcher-only flags
+
+## Decision: Valid — fix applied
+
+For a non-wcli0 (wrapper) command, `serverFlagSuffixStart` returned the smallest
+index whose remaining tokens form a pure server-flag run, and the call site then
+forced the split to `args.length` whenever that index was `0`. With a valueless
+wrapper flag before the modeled flags — `wrapper --no-cache --shell bash` — the
+whole argv parses as a pure run from index 0 (`--no-cache` is accepted as a leading
+extraArg-style flag, then `--shell` consumes `bash`), so the index-0 guard stranded
+`--shell bash` in `customArgs`; the form showed the default shell and a shell edit
+appended a SECOND `--shell` instead of replacing the existing one. The fix passes
+`allowIndexZero` into `serverFlagSuffixStart` (true only when the command IS the
+wcli0 binary) and starts the scan at index 1 for wrapper commands, so the leading
+ambiguous token stays in the launcher portion while the scan still finds the LATER
+modeled-flag suffix.
+
+**Why:** The index-0 guard for `P-wrapperflags` correctly refuses to trust an
+index-0 boundary for a wrapper command (`mywrapper --transport fast` is the
+wrapper's option, not wcli0's), but giving up entirely also discarded a legitimate
+later suffix. Scanning from index 1 keeps the `P-wrapperflags` safety (a flag-only
+run with no later modeled suffix still stays whole) while recovering modeled flags
+that follow a leading wrapper flag, exactly as `P15`/`P42` already do when a
+launcher positional separates them.
+
+**Proposed fix:** Parametrize `serverFlagSuffixStart(args, allowIndexZero)` to begin
+the scan at `allowIndexZero ? 0 : 1`, pass `isWcli0Command(command)`, and remove the
+separate `start === 0` guard at the call site.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_44_dont_consume_flag_as_value.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_44_dont_consume_flag_as_value.md
@@ -1,0 +1,23 @@
+# Analysis 44 - Do not consume another flag as a missing option value
+
+## Decision: Valid — fix applied
+
+The space-separated value branch in `parseServerArgs` consumed the next token as a
+value option's value even when that token was another flag. For
+`--blockedCommand --debug`, yargs parses `blockedCommand=[]` plus `debug=true`, but
+the parser modeled `blockedCommands=["--debug"]` and dropped `debug`; a no-op save
+then re-emitted `--blockedCommand=--debug`, silently changing the server behavior.
+The fix consumes the next token as the value ONLY when it does not start with `-`;
+when the next token is another flag the value option is preserved verbatim in
+`extraArgs` and the following flag is parsed on the next iteration.
+
+**Why:** This mirrors `argsBuilder.stripConfigArgs` (P86), which already refuses to
+swallow a following option as a value, and matches yargs' own behavior. Preserving
+the bare option in `extraArgs` round-trips it (`--blockedCommand` re-emits as an
+empty blocked-command list) while the unrelated flag survives, so a load/save cycle
+no longer corrupts the entry.
+
+**Proposed fix:** Add `&& !args[i + 1].startsWith('-')` to the space-separated
+value-option condition; the existing fall-through pushes the option to `extraArgs`.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_45_parse_bundled_config_alias.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_45_parse_bundled_config_alias.md
@@ -1,0 +1,27 @@
+# Analysis 45 - Parse bundled config aliases as configFile
+
+## Decision: Valid — fix applied
+
+`VALUE_OPTIONS` recognized only `-c`, `--c`, and `--config` (plus the `=` forms),
+but yargs reads the single-character `c` alias anywhere in a single-dash bundle, so
+`-c/other.json`, `-cX`, `-xc/other.json`, and `-dc /other.json` all set the server's
+config. A loaded entry using a bundled alias kept the real config pin in `extraArgs`,
+so the Config file field showed nothing and the loadability/`--config` checks
+believed there was no config file while the server would still load one. The fix
+adds a short-option bundle handler in `parseServerArgs` (single-dash, no `=`,
+containing `c`) that takes the value attached after the `c` or, when `c` is the
+bundle's last character, the following non-flag token — mirroring
+`argsBuilder.stripConfigArgs`.
+
+**Why:** The forward stripper and the reverse parser must be symmetric: the forward
+direction strips any single-dash bundle containing `c` to avoid the silent
+config-fallback bug, so the reverse direction must model the same forms as
+`configFile`. wcli0's only single-character option is `c`, so this cannot collide
+with another modeled short flag. A trailing `c` with no value (or a following flag)
+is preserved verbatim in `extraArgs` rather than fabricating a value (consistent with
+P44/P86).
+
+**Proposed fix:** Insert a bundle branch in `parseServerArgs` after the `=` form
+handling that sets `configFile` from the attached value or the next non-flag token.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_46_merge_from_single_snapshot.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_46_merge_from_single_snapshot.md
@@ -1,0 +1,27 @@
+# Analysis 46 - Merge from a single file snapshot
+
+## Decision: Valid — fix applied
+
+A file-source save read the on-disk entry once up front (`onDiskEntry`) to supply the
+env/argv/url preservation data, but the merge base was read AGAIN later from the
+full-file read at the write step. Because validation and user-facing modals are
+awaited between the two reads, an external edit landing in that window paired a fresh
+merge base (the later read) with stale generated `args`/`env` (the up-front read),
+producing an incoherent entry — e.g. the unmodeled `dev`/`headers` from the new read
+kept while externally added env/flags were dropped. The fix merges onto the SAME
+up-front snapshot (`onDiskEntry ?? baseEntry`) used for preservation, so the written
+entry is a coherent view of one snapshot.
+
+**Why:** The up-front read already captures an external edit made after the panel
+loaded (so it still satisfies P20's goal of not merging onto the stale panel
+snapshot); using a second, later read only for the merge base reintroduces a
+split-snapshot hazard. Deriving the preservation data and the merge base from the
+same parsed snapshot is the option the reviewer endorsed and the lowest-risk fix —
+it eliminates the corrupting half-merge and keeps the result internally consistent
+(last-writer-wins on the up-front snapshot).
+
+**Proposed fix:** At the write-step merge, set the merge base to
+`onDiskEntry ?? baseEntry` instead of re-extracting `servers.wcli0` from the later
+full-file read.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_47_recognize_kebab_case_aliases.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_47_recognize_kebab_case_aliases.md
@@ -1,0 +1,28 @@
+# Analysis 47 - Recognize yargs kebab-case option aliases
+
+## Decision: Valid — fix applied
+
+The server defines its multi-word options in camelCase, but yargs camel-case
+expansion also accepts the kebab-case spelling, so a hand-written entry may write
+`--max-command-length 1000` (applied by the server as `maxCommandLength`). The
+reverse `VALUE_OPTIONS`/`BOOLEAN_FLAGS` tables only recognized the camelCase forms,
+so a kebab-case value was hidden in `extraArgs`; if the user then set the same field
+in the form, the save emitted both spellings and yargs parsed the scalar as an array,
+making the server ignore the override. The fix adds kebab-case aliases for every
+modeled camelCase value option and boolean/tri-state flag, mapped identically to
+their camelCase forms.
+
+**Why:** The reverse parser must recognize the same flag spellings yargs accepts in
+the forward direction, or a perfectly valid committed entry round-trips into a
+duplicated, server-breaking arg list. Modeling the kebab aliases (not just preserving
+them verbatim) lets the form edit the value and re-emit a single canonical spelling.
+
+**Proposed fix:** Add `--allowed-dir`, `--initial-dir`, `--command-timeout`,
+`--max-command-length`, `--wsl-mount-point`, `--blocked-command`,
+`--blocked-argument`, `--blocked-operator`, `--max-output-lines`,
+`--max-return-lines`, `--log-directory` to `VALUE_OPTIONS`; add `--allow-all-dirs`,
+`--enable-truncation`/`--no-enable-truncation`,
+`--enable-log-resources`/`--no-enable-log-resources` to `BOOLEAN_FLAGS` and the
+boolean handling in `parseServerArgs`.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_48_compare_transport_type_case_insensitive.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_48_compare_transport_type_case_insensitive.md
@@ -1,0 +1,21 @@
+# Analysis 48 - Compare file source transport types case-insensitively
+
+## Decision: Valid — fix applied
+
+`preservedFileUrl` compared `settings.transportMode` to the loaded entry's RAW
+`type` string. `parseMcpEntry` models an entry written as `HTTP`/`SSE` by lowercasing
+the type, so `settings.transportMode` is already lowercase; a no-op save of an
+uppercase entry therefore saw `"http" !== "HTTP"`, treated it as a transport-mode
+switch, returned `undefined`, and rebuilt the URL to the canonical
+`http://host:port/...` form — losing the custom-scheme/default-port/socket URL shape
+the parser promised to preserve (P5/P8/P10). The fix lowercases `base.type` before the
+comparison.
+
+**Why:** The preservation decision must use the same normalized type the parser used
+to model the entry; comparing the raw type makes case alone look like a mode change.
+Lowercasing matches `parseMcpEntry`'s own `rawType.toLowerCase()` (P31).
+
+**Proposed fix:** In `preservedFileUrl`, compute
+`base.type.toLowerCase()` for the `baseType` comparison.
+
+**Commit:** 3c4a087 — fix(vscode): round-7 codex review follow-ups for PR #89 (parser + save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_49_disable_masks_for_file_sources.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_49_disable_masks_for_file_sources.md
@@ -1,0 +1,28 @@
+# Analysis 49 - Disable settings-only masks for file sources
+
+## Decision: Valid — fix applied
+
+`ignoreInheritedShells` / `ignoreInheritedProfiles` are settings-only opt-outs that no
+`.vscode/mcp.json` entry can store. `applyFileTransportLock` only disables the
+Shells/Profiles panels for an http/sse file source; a stdio file source left them
+editable, and `applyScopeAvailability` only disabled the masks at User (Global) scope.
+So a stdio file source loaded from a prior Workspace scope kept both masks editable.
+Editing one passed the host's `hasRaw*Config` guard (which ignores the masks) and let
+Save to file "succeed", after which the reparse dropped the edit while reporting Saved.
+
+The fix disables both masks on ANY file source. The owner of the masks' disabled state,
+`applyScopeAvailability`, now disables them when `currentSourceClient === 'mcpJson'`
+(`isUser || isFile`); it runs after `applyFileTransportLock`'s blanket re-enable for the
+stdio case, so the masks stay locked. As defense-in-depth (mirroring the P29/P-httpshells
+dual UI+host guard), `writeMcpJsonFromSettings` also refuses a file-source save whose
+settings carry a non-default mask (P-maskfile).
+
+**Why:** The UI control is the front line, but the masks default to false and a clean
+file load never sets them, so the host guard never falsely fires and makes the refusal
+explicit and unit-testable (the UI lock, like the existing http/sse panel lock, runs
+only in the real webview and is not exercised by the minimal test DOM).
+
+**Proposed fix:** `applyScopeAvailability` disables the masks for a file source;
+`writeMcpJsonFromSettings` adds a P-maskfile refusal.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_4_clear_omitted_env_baseline.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_4_clear_omitted_env_baseline.md
@@ -1,0 +1,20 @@
+# Analysis 4 - Clear omitted env from the saved file baseline
+
+## Decision: Valid — fix applied
+
+`saveToFile` set the loaded baseline (`loadedFileSettings`) to the pre-write
+`settings` object, which still carried `env` even when `writeMcpJsonFromSettings`
+honored the user's "Omit environment" choice and wrote the entry without it.
+Because `env` is not modeled by the form, the next `overlaySettings` re-applied
+the stale `env`, reintroducing and re-prompting for a secret the user had
+explicitly omitted. Fixed by re-baselining from disk after a successful write:
+`saveToFile` now re-reads the entry via `readWcli0Entry` and re-parses it with
+`parseMcpEntry`, so the baseline always matches exactly what was written
+(env-less when omitted). This also keeps the baseline truthful for any other
+write-time transform.
+
+**Why:** The baseline must reflect the file on disk, not the form's intent. The
+pre-write object diverges from disk whenever the write path drops or transforms a
+field; reading back the authoritative state is the robust fix.
+
+**Commit:** 81ab523 — fix(vscode): address review feedback for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_50_treat_oversized_ports_invalid.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_50_treat_oversized_ports_invalid.md
@@ -1,0 +1,26 @@
+# Analysis 50 - Treat oversized URL ports as invalid
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry`'s http/sse branch modeled any explicit port `> 0` as "fully modeled",
+so a malformed `url: "http://localhost:70000/mcp"` loaded `70000` into the form's
+`<input max="65535">`. The number input then failed client-side validation, blocking
+every unrelated save until the user noticed and edited the port. Only `:0` was routed
+to the unusable-port recovery branch.
+
+The fix narrows the "fully modeled" condition to `port >= 1 && port <= 65535`, so an
+out-of-range port falls through to the same unusable-port branch as `:0`: the host is
+modeled, the port keeps the form default, a note explains the canonical URL is rebuilt
+on save, and `preservedFileUrl` does not round-trip the out-of-range URL verbatim (the
+default port can never match it), so the save rebuilds a valid `http://host:port` form
+instead of writing back the invalid port.
+
+**Why:** The form's port field is constrained to `1..65535`; a value it cannot hold
+must be treated as unusable, exactly like `:0`, so loading a malformed URL never strands
+the form in an invalid state. Reusing the existing unusable-port branch keeps the
+behavior and the note consistent (P-port0/P-portmax).
+
+**Proposed fix:** In `parseMcpEntry`, gate the fully-modeled branch on
+`parsed.port >= 1 && parsed.port <= 65535`.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_51_preserve_stdio_transport_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_51_preserve_stdio_transport_flags.md
@@ -1,0 +1,30 @@
+# Analysis 51 - Preserve stdio transport flags on file saves
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` keeps a hand-authored `--transport http`/`--transport=sse` in a stdio
+entry's `extraArgs` rather than flipping the transport mode (P30). But the file-source
+save fed those `extraArgs` through `buildLaunchSpec` → `buildServerArgs`, whose
+`stripExtraTransport` was unconditionally true for every stdio launch. A no-op Save to
+file therefore dropped the authored `--transport` token and left its companion
+`--http-*` options orphaned — the opposite of the file source's verbatim round-trip
+guarantee.
+
+The fix adds a `preserveExtraTransport` build option, set only for the file-source save.
+When set AND no `--config` is emitted, the stdio path no longer strips an `extraArgs`
+`--transport`, so the user's authored token (and its companions) round-trip verbatim.
+The safety strip still applies to the provider and settings-export paths (so a stray
+`--transport http` can never turn a stdio registration into a network listener), and it
+still applies here when a `--config` is emitted, because the builder also pushes
+`--transport stdio` and two `--transport` tokens yargs-merge into an array the server
+applies neither of.
+
+**Why:** A file source is the source of truth; an unrelated edit must not silently
+mutate the user's argv. The safety strip exists to protect the provider/export paths,
+not the file round-trip, so scoping the preservation to `preserveExtraTransport`
+keeps both behaviors intact.
+
+**Proposed fix:** Add `BuildOptions.preserveExtraTransport`; pass it from
+`writeMcpJsonFromSettings` for a file source.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_52_refuse_unknown_transport_types.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_52_refuse_unknown_transport_types.md
@@ -1,0 +1,26 @@
+# Analysis 52 - Refuse saves for unknown transport types
+
+## Decision: Valid — fix applied
+
+An entry with a future/custom `type` such as `websocket` is parsed as stdio for its
+editable fields, with a note that a save will normalize it (P31). But nothing blocked
+the save: if the entry also had valid `command`/`args`, an unrelated edit went through
+`mergeEntryOntoBase`, which removes the whole stdio field set (including `type`) from
+the base and writes `type: 'stdio'` from the generated entry — silently coercing the
+user's deliberately-chosen transport and dropping any URL-like fields.
+
+The fix adds a host guard in `writeMcpJsonFromSettings`: for a file source whose current
+on-disk (merge-base) entry has a `type` that is not stdio/http/sse (case-insensitive),
+the save is refused with a message directing the user to edit `.vscode/mcp.json`
+directly. The check uses the current on-disk entry (`urlBase`) so a type changed after
+the panel loaded is still honored.
+
+**Why:** The form genuinely cannot model the transport, so the only non-destructive
+options are refuse or preserve; refusing is simplest and matches the existing note that
+already tells the user to edit the file directly. Guarding on the merge base (not the
+stale loaded snapshot) keeps the decision consistent with what the save would overwrite.
+
+**Proposed fix:** Refuse a file-source save when the merge-base entry's `type` is not
+stdio/http/sse.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_53_preserve_current_wslmountpoint.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_53_preserve_current_wslmountpoint.md
@@ -1,0 +1,23 @@
+# Analysis 53 - Preserve current wslMountPoint on file saves
+
+## Decision: Valid — fix applied
+
+`--wslMountPoint` round-trips through `parseMcpEntry`/`buildServerArgs` but has no form
+control, so it belongs to the same class as `customArgs`, the blocked lists,
+`--maxReturnLines`, and the transport allowed-origins: uneditable argv fields that the
+file-source save re-derives from the CURRENT on-disk entry and splices back (P40). It
+was simply missing from that carry-forward list, so an unrelated save rebuilt `args`
+from the stale loaded `settings.wslMountPoint` and dropped a `--wslMountPoint` that
+another process had added or changed after the panel loaded.
+
+The fix adds `wslMountPoint: onDisk.wslMountPoint` to the stdio carry-forward
+`buildSettings`, alongside the other uneditable argv fields.
+
+**Why:** The carry-forward's stated purpose is to preserve every argv-derived field the
+form does not edit; `--wslMountPoint` is one of them, so omitting it was an oversight
+that breaks the same guarantee P40 establishes for the other flags.
+
+**Proposed fix:** Add `wslMountPoint` to the on-disk carry-forward in
+`writeMcpJsonFromSettings`.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_54_reject_all_profile_edits_for_file_sources.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_54_reject_all_profile_edits_for_file_sources.md
@@ -1,0 +1,27 @@
+# Analysis 54 - Reject all profile edits for file sources
+
+## Decision: Valid — fix applied
+
+The file-source guard gated profiles on `hasRawProfilesConfig`, which only counts
+launch-MEANINGFUL profiles (those `buildProfiles` would emit). The Profiles editor,
+however, accepts any JSON object, so a non-emittable profile such as
+`{"p":{"description":"x","env":{}}}` slipped past the guard. The save "succeeded", the
+entry stored nothing (no entry can carry profiles), and the post-write reparse returned
+an empty profiles map while the UI reported Saved — silently discarding the edit.
+
+The fix gates the file-source guard on ANY non-empty `settings.profiles` object
+(`Object.keys(...).length > 0`) instead of `hasRawProfilesConfig`. Emptiness is the
+correct gate because a clean file load never populates profiles (`parseMcpEntry` leaves
+them `{}`), so the refusal fires only on a real edit, never on an untouched save.
+
+**Why:** The question for a file source is not "would this profile force a managed
+launch?" but "can this entry store it?" — and the answer is never. So any non-empty
+profiles object is an unsaved edit and must be refused, matching the intent of the
+existing P29/P-maskedshells guards. (Per-shell config keeps using
+`hasRawPerShellConfig` because `collectShells` already submits only meaningful shells,
+so no analogous non-meaningful gap exists there.)
+
+**Proposed fix:** Replace `hasRawProfilesConfig(settings)` in the guard with a
+non-empty `settings.profiles` check.
+
+**Commit:** 378cffb — fix(vscode): round-8 codex review follow-ups for PR #89 (file-source save round-trip)

--- a/docs/tasks/autodetect_mcp_source/analysis_55_refuse_stale_network_field_edits.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_55_refuse_stale_network_field_edits.md
@@ -1,0 +1,22 @@
+# Analysis 55 - Refuse stale edits before locking network file fields
+
+## Decision: Valid — fix applied
+
+The `saveToFile` handler now refuses a file-source save when the resolved transport mode
+is `http`/`sse` and `collectChanged()` carries any key other than `transport.mode`,
+`transport.host`, or `transport.port`. A network entry stores only `{type, url}`, so any
+other submitted field (safety, config file, launch command, limits, per-shell, profiles)
+is an unsaved edit the post-write reparse would silently drop behind a misleading "Saved".
+The guard surfaces a clear error and writes nothing; a pure transport edit (host/port/mode)
+still saves, and a clean stdio->http switch still succeeds.
+
+**Why:** `applyFileTransportLock` only disables the non-transport controls visually; it does
+not discard edits already made while the entry was stdio, and `collectChanged()` still
+submits them. The fix keys off the submitted changed-field names (the authoritative record
+of the user's edits), so there are no false positives from settings-representation
+differences. This complements the existing host-side guards (P29/P49/P54/P-httpshells/
+P-maskfile) in `writeMcpJsonFromSettings`, which remain as defense in depth for the
+shells/profiles/mask subset and the settings-export path. See [[analysis_29_refuse_unsavable_file_edits]]
+and [[analysis_49_disable_masks_for_file_sources]].
+
+**Commit:** 3727aec - fix(vscode): round-9 codex review follow-ups for PR #89 (P55/P56)

--- a/docs/tasks/autodetect_mcp_source/analysis_56_keep_unknown_only_suffix_with_wrapper.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_56_keep_unknown_only_suffix_with_wrapper.md
@@ -1,0 +1,21 @@
+# Analysis 56 - Keep unknown-only suffix flags with wrapper args
+
+## Decision: Valid — fix applied
+
+`isPureServerFlagRun` now accepts a `requireModeled` flag and returns `seenModeled` (rather
+than unconditionally `true`) when set. `serverFlagSuffixStart` passes `requireModeled` for a
+non-wcli0 wrapper scan (`!allowIndexZero`), so an unknown-only suffix such as the wrapper's
+own `--verbose` in `wrapper target --verbose` is no longer mistaken for a wcli0 server-flag
+suffix: it stays in `customArgs` instead of moving into `extraArgs`. The wcli0 binary itself
+(the index-0 case) keeps `requireModeled` false, so its unknown-only args remain legitimate
+`extraArgs`.
+
+**Why:** Without evidence of a modeled wcli0 flag there is no unambiguous server-flag
+boundary, so the trailing `--verbose` belongs to the wrapper. Moving it into `extraArgs` made
+a later save emit the generated server flags before it (`target --shell cmd --verbose`),
+reordering the wrapper invocation. Requiring a modeled flag mirrors the existing P43/P15
+boundary logic, and suffixes that DO contain a modeled flag (P15/P24/P42/P43) still split
+exactly as before. See [[analysis_43_continue_scan_after_launcher_flag]] and
+[[analysis_15_preserve_custom_wrapper_flags]].
+
+**Commit:** 3727aec - fix(vscode): round-9 codex review follow-ups for PR #89 (P55/P56)

--- a/docs/tasks/autodetect_mcp_source/analysis_57_preserve_allow_all_dirs.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_57_preserve_allow_all_dirs.md
@@ -1,0 +1,48 @@
+# Analysis 57 - Preserve --allowAllDirs on a file save when --initialDir is set
+
+## Decision: Valid — fixed
+
+`buildServerArgs` emits `--allowAllDirs` only when `!dirsConfigured`, where
+`dirsConfigured = s.allowedDirectories.some((d) => d.trim()) || s.initialDir.trim().length > 0`
+(argsBuilder.ts:415-416). For a loaded `.vscode/mcp.json` stdio file source, this silently
+drops a user-authored `--allowAllDirs` whenever the entry also sets `--initialDir`, because
+`allowAllDirs` is a modeled, form-editable field excluded from the on-disk uneditable-argv
+carry-forward (commands.ts:632-646), and `validateLaunchSpec` has no guard for it. The save
+reports "Saved" and the post-write reparse flips the "Allow all directories" tri-select off.
+
+The drop is not server-equivalent for the `--initialDir` combination. The server applies
+`--allowAllDirs` as `loadConfig`'s `disableIfEmpty`, which clears `restrictWorkingDirectory`
+(src/utils/config.ts:186-193) BEFORE the CLI `--initialDir` is merged by `applyCliInitialDir`
+(src/index.ts ordering; src/utils/config.ts:802-812). With the restriction already off,
+`applyCliInitialDir` does not add the initial directory to `allowedPaths`, so the server stays
+unrestricted; the round-tripped entry without the flag keeps the restriction and confines the
+server to the initial directory. The `--allowedDir` case is server-inert
+(`applyCliShellAndAllowedDirs` forces `restrictWorkingDirectory = true` regardless), but the
+round trip still flips the tri-select from enabled to disabled.
+
+**Why:** An mcp.json entry's authored flags are authoritative — a flag the form displays as
+set must round-trip, and the working-directory restriction is security-relevant. The
+`argsBuilder` comment ("meaningless once paths are configured") conflates `--initialDir` with
+`--allowedDir`; only the latter forces the restriction back on. This is the same
+preserve-the-authored-entry invariant behind P40/P-staleargs (preserve uneditable argv) and
+P30 (don't let a flag in the args silently change the server's posture), but the mechanism is
+distinct: `allowAllDirs` is an editable modeled boolean dropped by `buildServerArgs`'s emit
+condition, which the carry-forward never reaches. See [[analysis_40_preserve_uneditable_argv]]
+and [[analysis_30_transport_flags_corrupt_stdio_entry]].
+
+**Proposed fix:** For a file source (where `preserveRelativePaths`/`preserveExtraTransport` is
+already set), gate the `--allowAllDirs` suppression on `allowedDirectories` only, not
+`initialDir` — or carry `allowAllDirs` forward from the on-disk entry like the other uneditable
+argv fields. Add a round-trip unit test for `--allowAllDirs --initialDir /work`. The existing
+forward-builder test (`argsBuilder.test.cjs`) currently encodes the buggy assumption and must
+be updated.
+
+**Fix applied:** `buildServerArgs` now emits `--allowAllDirs` whenever it is set on a
+file-source round trip (gated on `opts.preserveRelativePaths`), keeping the existing
+suppression for the provider/settings-export paths. Round-trip unit test added
+(`argsBuilder.test.cjs`); the prior forward-builder test was kept for the non-file-source
+paths. Server claim re-verified: `loadConfig(disableIfEmpty)` (src/index.ts:1603) runs before
+`applyCliInitialDir` (src/index.ts:1606), so dropping the flag confines an otherwise
+unrestricted server.
+
+**Commit:** (pending)

--- a/docs/tasks/autodetect_mcp_source/analysis_58_allow_subsecond_timeout.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_58_allow_subsecond_timeout.md
@@ -1,0 +1,46 @@
+# Analysis 58 - Don't strand file saves on a sub-1-second commandTimeout/maxCommandLength
+
+## Decision: Valid — fixed
+
+The `commandTimeout` / `maxCommandLength` number inputs are rendered with `min="1"`
+(webview.ts:1074-1075), and the save handler gates on `validateNumbers()` (which
+`checkValidity()`-rejects every enabled `input[type=number]`, webview.ts:1752-1761) before
+posting `saveToFile`. A loaded `.vscode/mcp.json` stdio entry carrying a server-valid
+sub-1-second value (`--commandTimeout 0.5`) is parsed into the typed field as `0.5`; for a
+stdio file source the Limits & Safety panel is not locked, so the untouched input fails
+`rangeUnderflow` and blocks EVERY file-source save — including edits to unrelated fields — until
+the user changes the value to >= 1, which they never intended and which corrupts a valid value.
+
+The host accepts the value: the file-source save validates with `managed = false`, whose
+`validateLaunchSpec` branch blocks only `!(value > 0)` (argsBuilder.ts:1047), `buildServerArgs`
+emits `--commandTimeout` when `> 0` (argsBuilder.ts:372), and the server's
+`applyCliSecurityOverrides` applies any value > 0. `validateLaunchSpec` already splits the bound
+by path (managed requires >= 1 because the value is written into a config file that
+`validateConfig` re-validates; non-managed CLI flags require only `> 0`, argsBuilder.ts:1033-1053),
+but the client-side `min="1"` does not — it applies the managed bound to every source.
+
+**Why:** The client number-input constraints must match the host's acceptance for the active
+source, or a hand-authored, server-valid value the form can display but not re-submit strands
+the round trip. This is the wrongful-refusal class behind P34 (an unparseable numeric value
+falls to `extraArgs` rather than blocking saves) and P50 (an out-of-range port is recovered
+rather than stranding the form), but the root cause is distinct: `0.5` is a parseable,
+host-accepted value modeled into the typed field, and the defect is a client/host bound mismatch
+(`min="1"` vs `> 0`), not an unparseable value or an out-of-range-recovery case. Related to P59,
+the host-side counterpart for the log-limit fields. See [[analysis_34_invalid_numeric_blocks_save]]
+and [[analysis_50_treat_oversized_ports_invalid]].
+
+**Proposed fix:** Relax the `min`/`step` on `commandTimeout` / `maxCommandLength` (or skip the
+managed-bound client check for a file/stdio source) so a server-valid `> 0` value passes
+`validateNumbers`, matching the host's non-managed acceptance; keep the managed-mode (>= 1)
+enforcement on the host. Add a webview test that loads `--commandTimeout 0.5` and asserts an
+unrelated edit can be saved.
+
+**Fix applied:** the `commandTimeout`/`maxCommandLength` inputs now carry `min="0"` (not
+`min="1"`), so a loaded server-valid `> 0` value passes `validateNumbers`; the host
+`validateLaunchSpec` keeps the per-mode bound (`> 0` non-managed CLI, `>= 1` managed). The
+per-shell timeout inputs are untouched (their values are config-file-bound `>= 1`). Webview
+test added (`webview.test.cjs`). Server claim re-verified: `applyCliSecurityOverrides` applies
+any `> 0`; the `< 1` rejection is in `validateConfig`, which runs only inside `loadConfig`
+before the CLI override.
+
+**Commit:** (pending)

--- a/docs/tasks/autodetect_mcp_source/analysis_59_allow_out_of_range_log_limits.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_59_allow_out_of_range_log_limits.md
@@ -1,0 +1,56 @@
+# Analysis 59 - Don't refuse file-source saves over an out-of-range CLI log limit
+
+## Decision: Valid — fixed
+
+For a file-source save, `writeMcpJsonFromSettings` validates with `managed = false`
+(commands.ts:550). `validateLaunchSpec`'s `maxReturnLines` and `maxOutputLines` checks
+(argsBuilder.ts:1015-1026) apply the config-file bound (1..10000, integer for `maxReturnLines`)
+UNCONDITIONALLY — ignoring `managed`, unlike the `commandTimeout`/`maxCommandLength` checks just
+below them, which are managed-aware (argsBuilder.ts:1033-1053). A loaded stdio entry carrying
+`--maxReturnLines 50000` is modeled into the typed field as `50000` (finite, so P34's
+unparseable-value route does not divert it), `overlaySettings` preserves it on any unrelated
+edit (it has no `FIELD_TO_PROP` form control), and the save is refused with a message claiming
+the server rejects it at startup. Because `maxReturnLines` has no control anywhere in the form,
+the user cannot fix it — every panel save of the entry is stranded.
+
+The refusal's premise is wrong for the CLI/mcp.json launch. The server runs
+`validateLoggingConfig` only inside `loadConfig` (on the file/default config), BEFORE the CLI
+override; `applyCliLogging` (src/index.ts runs it after `loadConfig`) then applies any
+`maxReturnLines > 0` with no upper-bound/integer check and no re-validation, and the `CLIServer`
+constructor does not re-validate. So `--maxReturnLines 50000` runs with 50000 and
+`--maxReturnLines 0` is ignored (default 500) — both server-valid. The 1..10000-integer bound is
+correct only for the managed/config-file emission path, where the value is written into a config
+file that `validateLoggingConfig` re-checks.
+
+**Why:** A hand-authored, server-valid numeric flag the form cannot edit must round-trip, not
+block unrelated saves. This is the wrongful-refusal/stranded-save class behind P34 (route a
+problematic numeric value to `extraArgs`) and P50 (recover an out-of-range port), but neither
+covers it: P34 fires only for non-finite values, and P50's recovery is specific to the transport
+port (which has a form control and a verbatim-URL recovery path). P58 is the client-side
+counterpart (the `min`/`max` inputs) for the fields that DO have a control; this is the
+host-side `validateLaunchSpec` refusal for `maxReturnLines`, which has none. See
+[[analysis_34_invalid_numeric_blocks_save]] and [[analysis_40_preserve_uneditable_argv]].
+
+**Proposed fix:** Make the `maxReturnLines` / `maxOutputLines` range checks managed-aware (skip
+the 1..10000 block on the non-managed CLI/file path, matching `commandTimeout`/`maxCommandLength`),
+OR route a finite-but-out-of-range modeled value to `extraArgs` at parse time (mirroring P34) so
+it round-trips verbatim and bypasses `validateLaunchSpec`. Note the secondary loss: even past
+the refusal, `buildServerArgs` (argsBuilder.ts:405-407) drops an out-of-range `maxReturnLines`
+via the same `isValidLogLimit` gate, so the P40 carry-forward would still lose it — the parse-time
+`extraArgs` route avoids both. Add a round-trip test for `--maxReturnLines 50000`.
+
+**Fix applied:** took the parse-time `extraArgs` route (the option the analysis preferred).
+`parseServerArgs` now diverts a finite-but-out-of-range `maxReturnLines`/`maxOutputLines` to
+`extraArgs` verbatim via a `divertNumber` predicate (reusing `isValidLogLimit` /
+`isValidMaxOutputLines`, now exported from `argsBuilder`), so the value round-trips without
+poisoning the typed field or tripping `validateLaunchSpec`, and `buildServerArgs`'s
+`isValid*` emit gate no longer drops it. Because the form-editable `maxOutputLines` could
+then collide with a typed value, `buildServerArgs` strips a duplicate diverted flag
+(`stripValueFlag`) when it emits the same log limit from the typed field. `validateLaunchSpec`
+itself is left strict for the settings/managed path (it never sees the diverted value).
+Round-trip tests added (`configSource.test.cjs`, `commands.test.cjs`, `argsBuilder.test.cjs`).
+Server claim re-verified: `applyCliLogging` (src/index.ts:1624) applies any `> 0` with no
+re-validation; `validateLoggingConfig` runs only inside `loadConfig` (src/index.ts:1603),
+before the CLI override.
+
+**Commit:** (pending)

--- a/docs/tasks/autodetect_mcp_source/analysis_5_preserve_http_sse_urls.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_5_preserve_http_sse_urls.md
@@ -1,0 +1,23 @@
+# Analysis 5 - Preserve full HTTP/SSE URLs when round-tripping
+
+## Decision: Valid — fix applied
+
+Loading an http/sse entry kept only host and port, so a save rebuilt the URL as
+`http://host:port/{mcp,sse}` — silently downgrading custom schemes/paths (e.g.
+`https://gateway.example/custom/mcp`) and breaking URLs that relied on a default
+port. Fixed by preserving the verbatim URL through the round-trip: added an
+optional `transportUrl` field to `Wcli0Settings` (set only by the file-source
+reverse parser, never a `wcli0.*` setting), and `writeMcpJsonFromSettings` now
+writes that URL back unchanged while it still parses to the host/port shown in
+the form, falling back to the canonical reconstruction only when the user edited
+the host/port. The standalone port validation is skipped for a preserved URL so a
+default-port URL stays saveable. `parseMcpEntry` also adds a note when the URL is
+non-canonical, so the user knows editing host/port will rewrite it.
+
+**Why:** The form models only host/port, so it cannot represent an arbitrary URL.
+Preserving the original verbatim (and warning when it cannot be fully modeled)
+matches the reviewer's "preserve the original URL parts or refuse" guidance
+without expanding the form, and avoids silent corruption of externally-hosted
+endpoints.
+
+**Commit:** 81ab523 — fix(vscode): address review feedback for PR #89

--- a/docs/tasks/autodetect_mcp_source/analysis_60_preserve_wildcard_url_host.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_60_preserve_wildcard_url_host.md
@@ -1,0 +1,46 @@
+# Analysis 60 - Preserve a user-authored wildcard URL host on a port-only file save
+
+## Decision: Valid — fixed
+
+For a loaded http/sse file source, `writeMcpJsonFromSettings` writes the URL as
+`preservedFileUrl(settings, urlBase)`, falling back to a freshly built
+`http://<clientHost>:<port>/<path>` (commands.ts:727-733). `preservedFileUrl`
+(commands.ts:229-264) returns the verbatim URL only
+while the host AND port still match what it decomposes to, so a port-only edit makes it return
+`undefined` and the rebuild branch runs. `clientHost` (mcpProvider.ts:407-413) maps the wildcard
+bind hosts `0.0.0.0 -> 127.0.0.1` and `:: / [::] -> [::1]`, so a committed
+`http://0.0.0.0:9444/mcp` whose port the user changes to 8080 is written as
+`http://127.0.0.1:8080/mcp`: the untouched host silently changes value, with `ok = true`, no
+error, and no parse note. The no-op save preserves `0.0.0.0` exactly (same function, host and
+port match), so the round trip is internally inconsistent.
+
+`parseMcpEntry` compounds this: `isCanonicalTransportUrl` (configSource.ts:710-721) returns true
+for a wildcard `http://0.0.0.0:9444/mcp`, so the parser emits NO note — the user gets no warning
+that editing the port will rewrite the host, and the form offers no way to keep `0.0.0.0`/`[::]`
+while changing the port.
+
+**Why:** A save must change only the field the user edited (invariant: never silently change an
+untouched field). The `clientHost` bind -> connect normalization is a settings-export concept
+(build a connectable URL from a bind-host setting) and is correct there
+(`commands.test.cjs` exercises it on the no-`baseEntry` path); applying it in the file-source
+rebuild mutates a host that came from a user-authored connect URL. This is the
+preserve-the-loaded-URL class behind P5/P8/P10/P41, but those preserve a URL while host/port are
+unchanged or model default-port/socket URLs (which DO carry notes); here a canonical wildcard URL
+is silently rebuilt on an unrelated port edit with no note. See [[analysis_5_preserve_http_sse_urls]]
+and [[analysis_41_preserve_current_custom_urls]].
+
+**Proposed fix:** In the file-source rebuild, reuse the loaded URL's verbatim host when only the
+port changed (rebuild `host:port` from the loaded host rather than the `clientHost`-normalized
+one), or skip `clientHost` for a file source so a wildcard host round-trips; alternatively emit a
+note from `parseMcpEntry` for a wildcard URL so the bind -> loopback rewrite on a port edit is at
+least surfaced. Add a file-source unit test: load `http://0.0.0.0:9444/mcp`, edit only the port,
+assert the saved URL keeps `0.0.0.0` (and `[::]` -> `[::]`).
+
+**Fix applied:** the file-source URL rebuild now uses a new `fileSourceUrlHost` helper (the
+verbatim connect host, with only syntactic IPv6 bracketing) instead of `clientHost`, so a
+port-only edit of `http://0.0.0.0:9444/mcp` keeps `0.0.0.0` (and `[::]` keeps `[::]`) rather
+than the bind->loopback rewrite. The settings-driven export still uses `clientHost`. This
+also makes a host edit round-trip verbatim, so no parse-time note is needed. File-source
+unit tests added for the IPv4 and IPv6 wildcard cases (`commands.test.cjs`).
+
+**Commit:** (pending)

--- a/docs/tasks/autodetect_mcp_source/analysis_61_strip_preserved_value_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_61_strip_preserved_value_flags.md
@@ -1,0 +1,39 @@
+# Analysis 61 - Strip preserved value flags when replacing them
+
+## Decision: Valid — fixed
+
+`buildServerArgs` (argsBuilder.ts) preserves unrecognized/diverted tokens via `extraArgs`
+and appends them verbatim after the typed flags. The parser (`parseServerArgs`,
+configSource.ts) diverts a modeled option into `extraArgs` in two cases: a numeric value the
+typed field cannot faithfully hold (`divertNumber`: an unparseable `--commandTimeout bad`,
+P34; or an out-of-range log limit, P59), and a value that is itself a flag
+(`--logDirectory --debug`, where the space-separated branch refuses to consume the next
+token and preserves the flag alone). In both cases the modeled flag token survives in
+`extraArgs`. The builder's duplicate-cleanup only stripped `--maxOutputLines` /
+`--maxReturnLines`, so when the user then set `commandTimeout`, `logDirectory`, `shell`,
+`initialDir`, `maxCommandLength`, `wslMountPoint`, or a transport host/port/origin in the
+form, the save emitted the typed flag AND the stale diverted copy. The server's yargs
+(`src/index.ts`) parses a repeated scalar option as an array, while `applyCliSecurityOverrides`
+/ `applyCliLogging` / `applyCliTransport` expect a number/string — so the edited value is
+ignored or crashes startup instead of replacing the bad argument.
+
+**Why:** A save must let the form value win over a diverted/preserved copy of the same
+modeled scalar flag (invariant: the typed field is authoritative once set). This is the same
+class as P59, which only solved it for the two log-limit fields; the concern correctly
+generalizes it to every modeled SCALAR value flag the builder emits. Array options
+(`--allowedDir`, `--blockedCommand/Argument/Operator`) are intentionally exempt: the server
+merges repeated values, so a preserved duplicate is harmless rather than an array-coercion
+hazard. See [[analysis_59_allow_out_of_range_log_limits]].
+
+**Fix applied:** the post-build duplicate-cleanup in `buildServerArgs` now strips every
+modeled scalar value flag it actually emitted — `--shell`, `--initialDir`/`--initial-dir`,
+`--commandTimeout`/`--command-timeout`, `--maxCommandLength`/`--max-command-length`,
+`--wslMountPoint`/`--wsl-mount-point`, `--maxOutputLines`/`--max-output-lines`,
+`--maxReturnLines`/`--max-return-lines`, `--logDirectory`/`--log-directory`, and the emitted
+transport host/port/origin flag — from `extraArgs` via `stripValueFlag`. Each strip is guarded
+by the SAME emit condition (captured into `emitShell`/`emitCommandTimeout`/etc. booleans and
+the `emittedTransportScalarFlags` list) so an UNSET field still round-trips its preserved
+malformed value verbatim. Both the camelCase and kebab-case spellings the parser produces are
+stripped. Unit tests added in `argsBuilder.test.cjs` (P61).
+
+**Commit:** 65e018d — fix(vscode): round-11 codex review follow-ups for PR #89 (P61-P62)

--- a/docs/tasks/autodetect_mcp_source/analysis_62_dont_fabricate_config_from_short_bundle.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_62_dont_fabricate_config_from_short_bundle.md
@@ -1,0 +1,41 @@
+# Analysis 62 - Don't fabricate config paths from short bundles
+
+## Decision: Valid — fixed
+
+`parseServerArgs` (configSource.ts) models a single-dash bundle carrying the `c` config
+alias so a hand-written `-c<value>` entry round-trips as `configFile` instead of hiding in
+`extraArgs` (P45). The attached-value branch took everything after the first `c`
+(`token.slice(token.indexOf('c') + 1)`) as the config path. But the server's yargs `config`
+alias (`src/index.ts`, `alias: 'c'`, type string, default parser settings) does NOT read an
+arbitrary remainder as the value. Verified empirically against the installed yargs-parser:
+
+- `-cfoo` => `config: ""` (parsed as `-c -f -o -o` boolean short flags)
+- `-cX` => `config: ""`
+- `-cC:/x.json` => `config: ""` (a word-character start, even a Windows drive letter)
+- `-cfoo.json` => `config: ""`
+- `-c.foo` / `-c./rel.json` => `config: {…}` (dot-notation object, not a path)
+- `-c/` => `config: ""` (a lone non-word char is read as a boolean)
+- `-c/other.json` => `config: "/other.json"` (non-word first char, length >= 2)
+- `-c~/x.json` => `config: "~/x.json"`
+- `-c123` / `-c5.5` / `-c-5` => `config: "123" / "5.5" / "-5"` (fully numeric remainder)
+
+So for the common `-cfoo` / `-cX` shapes the parser filled `wcli0.configFile` with a file the
+server never loaded; a subsequent no-op save then emitted a spurious `--config foo`, changing
+the launched configuration (or failed the loadability check on a non-existent path).
+
+**Why:** Loading then re-saving an unedited entry must not change the launched configuration
+(the round-trip-fidelity invariant behind P44/P45/P86). The fix has to mirror the server's
+actual yargs parse, not a superset of it. The `=` form (`-c=foo`) and the space-separated form
+(`-c foo`, `-dc /x.json`) already set config for word-character values and are handled by the
+other branches; only the attached single-dash bundle without `=` is restricted here. See
+[[comment_45_parse_bundled_config_alias]] and [[analysis_45_parse_bundled_config_alias]].
+
+**Fix applied:** a new `yargsBundleConfigValue(remainder)` helper returns the config string
+only in the shapes yargs actually attaches it — a fully numeric remainder, or a remainder
+whose first character is a non-word, non-dot character with at least one more character
+following. The bundle branch models `configFile` only when the helper returns a value;
+otherwise it preserves the token verbatim in `extraArgs` so the entry round-trips unchanged.
+The existing P45 path cases (`-c/ws/a.json`, `-xc/ws/c.json`) still resolve. Unit tests added
+in `configSource.test.cjs` (P62).
+
+**Commit:** 65e018d — fix(vscode): round-11 codex review follow-ups for PR #89 (P61-P62)

--- a/docs/tasks/autodetect_mcp_source/analysis_63_consume_negated_boolean_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_63_consume_negated_boolean_flags.md
@@ -1,0 +1,26 @@
+# Analysis 63 - Consume negated boolean flags before preserving extras
+
+## Decision: Valid — fix applied
+
+`parseServerArgs` only modeled the positive boolean flags (`--allowAllDirs`,
+`--debug`, `--yolo`, `--unsafe`) and the tri-state negations, leaving the
+server's other boolean negations (`--no-allowAllDirs`/`--no-allow-all-dirs`,
+`--no-debug`, `--no-yolo`, `--no-unsafe`) to fall through to `extraArgs`. A
+preserved negation then survived a save and yargs collapsed `--debug --no-debug`
+to `debug: false`, discarding the user's form edit. The fix adds these tokens to
+`BOOLEAN_FLAGS` (so the suffix detector treats them as modeled wcli0 flags, like
+their positive forms) and adds explicit handlers in `parseServerArgs` that
+consume and model them: `allowAllDirs`/`debug` are set to `false`, while
+`--no-yolo`/`--no-unsafe` clear `safetyMode` only when it currently matches the
+negated mode (mirroring yargs last-wins for `--yolo --no-yolo` => safe without
+clobbering an independent `--unsafe`).
+
+**Why:** The reverse parser already round-trips every other flavor of flag the
+forward builder and the server understand; leaving these negations in `extraArgs`
+re-emitted them after the form's positive flag and let yargs silently win.
+Consuming them makes a loaded entry's boolean state editable and prevents the
+duplicate-flag corruption. The server declares all four as boolean options
+(`src/index.ts`) and `.conflicts('unsafe','yolo')` forbids both positives at
+once, so modeling the negations cannot introduce an impossible safety state.
+
+**Commit:** 18dc478 — fix(vscode): round-12 codex review follow-ups for PR #89 (P63-P66)

--- a/docs/tasks/autodetect_mcp_source/analysis_64_preserve_nonpositive_security_limits.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_64_preserve_nonpositive_security_limits.md
@@ -1,0 +1,23 @@
+# Analysis 64 - Preserve ignored security-limit values instead of blocking saves
+
+## Decision: Valid — fix applied
+
+`divertNumber` diverted unparseable numbers (P34) and out-of-range log limits
+(P59) to `extraArgs`, but returned false for any finite `commandTimeout`/
+`maxCommandLength`, so a loaded `--commandTimeout 0` or `--maxCommandLength=-1`
+was modeled into the typed field. The form's number input rejects a negative and
+`validateLaunchSpec` blocks any value `<= 0` (non-managed), so the entry could
+never be saved again — even for an unrelated edit. The fix extends `divertNumber`
+to return true for non-positive `commandTimeout`/`maxCommandLength`, so these
+values round-trip verbatim through `extraArgs` instead of stranding the form.
+
+**Why:** The server ignores a non-positive `commandTimeout`/`maxCommandLength`
+and runs on its default (it never lowers the limit for such a value), so the
+loaded entry is valid to the server even though the form cannot represent it.
+Diverting it matches the existing treatment of other unrepresentable numerics:
+the field stays at its default (`null`), `buildServerArgs` does not emit the flag
+(its `> 0` guard), and the preserved token survives a save. If the user later
+sets a positive value in the form, `buildServerArgs` emits it and `stripValueFlag`
+removes the stale preserved copy, so the edit wins.
+
+**Commit:** 18dc478 — fix(vscode): round-12 codex review follow-ups for PR #89 (P63-P66)

--- a/docs/tasks/autodetect_mcp_source/analysis_65_strip_negated_scalar_aliases.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_65_strip_negated_scalar_aliases.md
@@ -1,0 +1,26 @@
+# Analysis 65 - Strip negated scalar aliases when replacing preserved flags
+
+## Decision: Valid — fix applied
+
+`stripValueFlag` removed a preserved scalar flag from `extraArgs` only by its
+positive spellings (`--flag`, `--flag=value`). A loaded file's yargs negation of
+the same option (`--no-shell`, `--no-logDirectory`, `--no-commandTimeout`, ...)
+is not modeled by the parser, so it stayed in `extraArgs`; once the user set that
+field in the form, `buildServerArgs` emitted the positive flag and then appended
+the surviving negation. Yargs parsed the option as an array
+(`shell: ['cmd', false]`, `logDirectory: ['/tmp', false]`) the server's scalar
+`applyCli*` helpers resolve to neither, so the edited value was ignored or
+crashed the server. The fix builds a negated-name set (`--flag` -> `--no-flag`)
+inside `stripValueFlag` and drops any matching `--no-*` token (carrying no value,
+so the token alone is removed).
+
+**Why:** The strip is already gated by the same emission condition as each
+positive flag, so an UNSET field still round-trips its preserved negation
+verbatim — only when the form actually emits the positive value is the
+conflicting negation removed, exactly as required to avoid the array-coercion
+hazard. Boolean-array options (`--allowedDir`, `--blocked*`) are not routed
+through `stripValueFlag`, so this scalar-only change cannot disturb the
+intentional repeat-merge behavior. Handled at the emitter (not the parser) per
+the review's guidance, keeping an untouched scalar negation preserved on save.
+
+**Commit:** 18dc478 — fix(vscode): round-12 codex review follow-ups for PR #89 (P63-P66)

--- a/docs/tasks/autodetect_mcp_source/analysis_66_reject_nonnumeric_url_ports.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_66_reject_nonnumeric_url_ports.md
@@ -1,0 +1,25 @@
+# Analysis 66 - Reject non-numeric URL ports instead of treating them as omitted
+
+## Decision: Valid — fix applied
+
+`parseHttpUrl` matched the port with an optional digit-only group
+(`(?::(\d+))?`), so a URL with an explicit but non-numeric port
+(`http://host:abc/mcp`, `http://host:-1/mcp`) matched the host with the port
+group skipped, yielding `port: undefined`. Both the load path (`parseMcpEntry`)
+and the save path (`preservedFileUrl`) treat an undefined port as an
+omitted/default-port URL and preserve it verbatim while the host is unchanged, so
+editing only the port field could never fix the malformed URL. The fix changes
+the regex to capture the explicit port token even when malformed
+(`(?::([^/?#]*))?`) and classifies it: absent group -> `undefined` (omitted),
+digit-only -> its number, anything else -> `NaN` (explicit but unusable).
+
+**Why:** Reporting a malformed port as `NaN` (distinct from `undefined`) routes
+it through the existing unusable-port branch shared with `:0`/`:70000`: the host
+is modeled, the form keeps its default port, and `preservedFileUrl`'s
+`parsed.port === settings.transportPort` check is always false for `NaN`, so the
+save rebuilds the canonical `http://host:port` URL from the (editable) port field
+instead of round-tripping the broken URL. The load-path note was extended to
+describe a non-numeric port distinctly, and the port group stops at `/?#` so a
+valid numeric port followed by a path/query/fragment is still read correctly.
+
+**Commit:** 18dc478 — fix(vscode): round-12 codex review follow-ups for PR #89 (P63-P66)

--- a/docs/tasks/autodetect_mcp_source/analysis_67_rebuild_default_port_url_on_port_change.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_67_rebuild_default_port_url_on_port_change.md
@@ -1,0 +1,27 @@
+# Analysis 67 - Rebuild default-port URLs when the port changes
+
+## Decision: Valid — fix applied
+
+`preservedFileUrl`'s default-port branch returned the loaded URL verbatim whenever
+`parsed.host === settings.transportHost`, ignoring the port field entirely. A
+default-port URL such as `https://gateway.example/custom/mcp` loads with
+`transportHost` set and `transportPort` left at the form default (9444), so a
+port-only edit was silently discarded: the save reported success, wrote the
+original URL back unchanged, and the next reparse dropped the user's edited port.
+The fix preserves the verbatim URL only while the host is unchanged AND the port
+is still the form default; once the port is edited away from the default, the
+branch falls back to canonical reconstruction (`http://host:port/<mcp|sse>`),
+mirroring the existing host-edit behavior. The parse note in `parseMcpEntry` was
+updated from "the port field does not affect it" to "editing the host or port
+rewrites it" to match.
+
+**Why:** The codebase's contract is that a file-source save round-trips a loaded
+URL verbatim only while the modeled fields (host/port) are untouched, and rebuilds
+the canonical form once they change (P5/P8 for host edits). Treating a port edit
+the same way as a host edit makes the behavior consistent and honors the user's
+edit instead of silently dropping it and reporting a false "Saved". Comparing
+against `defaultSettings().transportPort` is the exact signal of "the port field
+is still the default the parser left for a default-port URL", so an untouched save
+still preserves the verbatim URL (P8) while a real port edit rebuilds it.
+
+**Commit:** de5c856 — fix(vscode): round-13 codex review follow-ups for PR #89 (P67-P70)

--- a/docs/tasks/autodetect_mcp_source/analysis_68_honor_explicit_false_boolean_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_68_honor_explicit_false_boolean_flags.md
@@ -1,0 +1,26 @@
+# Analysis 68 - Honor explicit false values for boolean flags
+
+## Decision: Valid — fix applied
+
+`parseServerArgs` matched each boolean/tri-state/safety flag by exact token and
+recorded it as unconditionally true, leaving a following `false` to fall through
+to `extraArgs`. yargs declares `allowAllDirs`/`debug`/`yolo`/`unsafe`/
+`enableTruncation`/`enableLogResources` as `type:'boolean'`, and a boolean option
+consumes a following bare `true`/`false` token as its value (verified against the
+project's yargs: `--debug false` parses to `debug=false`, with the `false`
+consumed rather than left as a positional). The form therefore showed the opposite
+of what the server runs, and the stranded `false` could defeat a later edit. The
+fix adds `boolValueAt`/`boolValueFollows` helpers and, for every positive boolean
+spelling, models the explicit `true`/`false` value and consumes it (the `--no-*`
+spellings already mean false and do not consume a token, matching yargs).
+
+**Why:** The reverse parser's job is to model exactly what the server will run so
+the form is faithful and a round-trip is lossless. yargs only consumes a following
+`true`/`false` for a boolean (any other token stays a positional and the flag
+reads true), so the helpers consume strictly those two literals — `--debug
+notabool` keeps `debug=true` and leaves `notabool` for the existing extraArgs path,
+matching yargs precisely. The negated forms are unchanged because yargs does not
+consume a value after `--no-debug` (`--no-debug false` leaves `false` as a
+positional).
+
+**Commit:** de5c856 — fix(vscode): round-13 codex review follow-ups for PR #89 (P67-P70)

--- a/docs/tasks/autodetect_mcp_source/analysis_69_file_source_single_snapshot.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_69_file_source_single_snapshot.md
@@ -1,0 +1,25 @@
+# Analysis 69 - Keep file-source saves on one file snapshot
+
+## Decision: Valid — fix applied
+
+A file-source save read `servers.wcli0` up front (for URL/env/argv preservation and
+the merge base) and then reread the whole file at the write step, treating
+`FileNotFound` as a fresh file. A concurrent delete/recreate of `.vscode/mcp.json`
+during an intervening warning modal therefore made the write start from `{}` and
+emit a file containing only `servers.wcli0`, silently dropping every other server
+present in the originally loaded file. The fix takes one full-file snapshot up
+front for a file source (extracted into a shared `readExistingMcpJson` helper that
+also runs the malformed-root / non-object-`servers` guards) and reuses it for the
+merge base, the other-servers container, and the comment-warning check; the
+later re-read now runs only for the settings-driven export. The single snapshot
+closes the window between the two reads.
+
+**Why:** The merge base already had to come from one up-front snapshot to stay
+coherent with the env/argv it derives (P46), and the same snapshot is the correct
+source for the surrounding servers. Reusing it — rather than adding an abort path —
+preserves the existing P20/P41/P46 behaviors (an external edit before the save is
+still captured by the single up-front read) while guaranteeing that other servers
+survive a delete during a modal. The settings-driven export keeps its single
+bottom read, so its behavior is unchanged.
+
+**Commit:** de5c856 — fix(vscode): round-13 codex review follow-ups for PR #89 (P67-P70)

--- a/docs/tasks/autodetect_mcp_source/analysis_6_reject_stale_file_saves.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_6_reject_stale_file_saves.md
@@ -1,0 +1,19 @@
+# Analysis 6 - Reject stale file-source saves after workspace changes
+
+## Decision: Valid — fix applied
+
+Added a guard at the top of the `saveToFile` host handler in `webview.ts`: a file-source
+save now proceeds only while `currentSource === 'mcpJson'`, `loadedFileFolder ===
+folder.uri.fsPath`, and the loaded raw entry is still present. When the primary workspace
+folder changes (multi-root removal/reorder), `wsSub` resets the file source, so a dirty
+webview that ignored the external init and still posts `saveToFile` is now rejected with
+an explanation instead of overwriting the new folder's `.vscode/mcp.json` with the
+previous folder's config.
+
+**Why:** This is the P1 wrong-folder overwrite the P2 reset was meant to prevent; the
+reset alone is insufficient because the webview's dirty guard suppresses the external init
+that would otherwise flip the client out of file mode. Verified by a new unit test that
+changes the primary folder after loading a file source and asserts the save is refused and
+nothing is written to the new folder.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_70_preserve_conflicting_safety_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_70_preserve_conflicting_safety_flags.md
@@ -1,0 +1,26 @@
+# Analysis 70 - Preserve mutually exclusive safety flags
+
+## Decision: Valid — fix applied
+
+`parseServerArgs` mapped `--yolo` to `safetyMode='yolo'` and `--unsafe` to
+`safetyMode='unsafe'`, so an entry containing both collapsed to whichever appeared
+last. The server declares the pair conflicting (`.conflicts('unsafe','yolo')` in
+`src/index.ts`) and refuses to launch with both, so a no-op or unrelated save of
+such an entry silently rewrote a previously-failing entry into a valid single-mode
+launch the user never chose. The fix detects the conflict up front
+(`lastSafetyPositive` mirrors yargs last-wins, so a trailing `--no-yolo` or
+`--yolo false` is not counted as positive) and, when both positives are present,
+preserves both flags verbatim in `extraArgs` rather than modeling either into
+`safetyMode`, leaving the conflicting (server-rejected) state intact.
+
+**Why:** The parser's preservation contract is that anything it cannot faithfully
+model round-trips verbatim instead of being silently transformed; collapsing the
+conflict violated that and changed the entry's security posture without the user's
+choice. Leaving `safetyMode` at its default 'safe' while round-tripping both flags
+means a no-op save reproduces the same rejected entry (the forward builder emits no
+yolo/unsafe for 'safe' and does not strip them from `extraArgs`), so the server
+still rejects it exactly as before — no silent invalid-to-valid normalization. An
+entry with only one positive flag, or `--yolo false` alongside `--unsafe`, is not a
+conflict and is still modeled normally.
+
+**Commit:** de5c856 — fix(vscode): round-13 codex review follow-ups for PR #89 (P67-P70)

--- a/docs/tasks/autodetect_mcp_source/analysis_71_preserve_false_safety_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_71_preserve_false_safety_flags.md
@@ -1,0 +1,36 @@
+# Analysis 71 - Preserve false safety flags in conflict round-trips
+
+## Decision: Valid — fix applied
+
+`parseServerArgs` detected a `--yolo`/`--unsafe` conflict only when BOTH flags
+resolved to a *positive* last value (`lastSafetyPositive`). But the server's
+`.conflicts('unsafe','yolo')` (in `src/index.ts`) fails whenever both keys are
+merely *defined*, regardless of value — and yargs-parser defines the key for
+`--yolo false`, `--no-yolo`, and `--yolo=false` exactly as it does for `--yolo`. I
+verified this against the project's yargs: `--yolo false --unsafe`, `--no-yolo
+--unsafe`, `--yolo=false --unsafe`, and even `--no-yolo --no-unsafe` are all
+REJECTED. The old detector counted the false/negated side as absent, modeled such
+an entry as a plain `unsafe` (or `yolo`) launch, and a no-op save rewrote the args
+to a single valid safety flag — silently turning a server-rejected hand-authored
+entry into a working unsafe launch.
+
+The fix replaces `lastSafetyPositive` with a presence check: the conflict fires
+whenever both families appear in any form (`--yolo` / `--no-yolo` / `--yolo=…`
+and the `--unsafe` equivalents). Under a conflict every safety-family token —
+including the bare positives (already handled by P70), the consumed `true`/`false`
+values, the `--no-yolo`/`--no-unsafe` negations (newly preserved), and the attached
+`--yolo=…`/`--unsafe=…` forms — round-trips verbatim in `extraArgs`, and
+`safetyMode` is left at its default. A no-op save therefore reproduces the exact
+rejected entry rather than a valid single-mode launch.
+
+**Why:** The parser's contract is that anything it cannot faithfully model
+round-trips verbatim instead of being silently transformed. Collapsing a
+server-rejected conflict to one mode violated that and changed the entry's security
+posture without the user's choice. Two existing tests (P63 case `c`, P70 case `c`)
+asserted the old behavior precisely because earlier rounds mis-modeled yargs'
+conflict semantics as last-wins; both are corrected here, and the P63 first case
+was narrowed to a single safety family (its `--no-yolo --no-unsafe` pair was itself
+a now-recognized conflict). A single safety family — `--yolo false` or `--no-yolo`
+alone, with no `--unsafe` — is not a conflict and is still modeled normally.
+
+**Commit:** ce1a2b3 — fix(vscode): round-14 codex review follow-ups for PR #89 (P71-P73)

--- a/docs/tasks/autodetect_mcp_source/analysis_72_model_attached_boolean_assignments.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_72_model_attached_boolean_assignments.md
@@ -1,0 +1,34 @@
+# Analysis 72 - Model attached boolean assignments before saving
+
+## Decision: Valid — fix applied
+
+`parseServerArgs`' attached-form branch (`--opt=value`) only consulted
+`VALUE_OPTIONS`, which lists value-bearing flags. The server's boolean options
+(`debug`, `enableTruncation`, `enableLogResources`, `allowAllDirs`, `yolo`,
+`unsafe`) are not value-bearing, so a yargs attached assignment such as
+`--debug=true` or `--enableTruncation=false` fell through to `extraArgs` verbatim
+instead of being modeled. The form then showed the option's default value, and
+because the preserved token sits later in argv, a user who changed that setting in
+the form got `--debug` (or `--no-enableTruncation`) emitted *before* the stale
+`--debug=false` — yargs last-wins let the preserved attached value defeat the edit,
+so the setting could not be changed from the form.
+
+The fix adds an `applyAttachedBoolean` helper invoked from the attached-form branch
+for the literal `=true`/`=false` yargs round-trips: it models each boolean (and its
+kebab-case alias) the same way the bare spellings already are, so the value leaves
+`extraArgs` and the form reflects it. Safety flags are modeled only when there is no
+conflict (`--unsafe=true` -> unsafe, `--yolo=false` -> default safe); under a
+conflict they return false and round-trip verbatim, preserving the server-rejected
+state (P71). Any non-`true`/`false` attached value on a boolean flag (e.g.
+`--debug=verbose`) is still preserved verbatim, since the typed field cannot
+faithfully hold it.
+
+**Why:** Modeling the value is the only way the form can edit it; leaving it in
+`extraArgs` both hid the real setting and silently overrode the user's edit on save.
+The change mirrors the existing P68 handling of the bare `--debug false` form, so
+the attached and space-separated spellings now behave identically. Restricting
+modeling to the exact `true`/`false` tokens keeps the parser faithful to yargs and
+avoids coercing ambiguous values into the typed field (matching the P34/P59
+"divert what cannot be faithfully modeled" philosophy).
+
+**Commit:** ce1a2b3 — fix(vscode): round-14 codex review follow-ups for PR #89 (P71-P73)

--- a/docs/tasks/autodetect_mcp_source/analysis_73_keep_dash_prefixed_paths_attached.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_73_keep_dash_prefixed_paths_attached.md
@@ -1,0 +1,31 @@
+# Analysis 73 - Keep dash-prefixed file paths attached
+
+## Decision: Valid — fix applied
+
+`buildServerArgs` emitted its scalar path options — `--config`, `--allowedDir`,
+`--initialDir`, `--logDirectory`, `--wslMountPoint` — as two separate argv entries
+(`args.push(flag, value)`). A file-source round-trip (`preserveRelativePaths`)
+preserves a value verbatim, so a directory literally named `--unsafe` (authored as
+the attached `--logDirectory=--unsafe`, which the parser models into the typed
+field) was re-emitted as `--logDirectory --unsafe`. yargs then parses `--unsafe` as
+a separate safety flag rather than the directory name, changing the launch
+semantics and potentially disabling protections on a no-op save.
+
+The fix routes those scalar emissions through the existing `pushOption` helper,
+which already emits the dash-aware `--opt=value` form (it was used for the
+blocked-list options for exactly this reason). A dash-prefixed value now stays
+attached to its flag (`--logDirectory=--unsafe`), so yargs reads it as the value;
+the round-trip parser handles the attached form on reload. Non-dash values are
+unaffected — `pushOption` still emits them as separate tokens, so existing output
+is byte-for-byte identical.
+
+**Why:** The forward builder must produce argv that yargs parses back to the same
+values the form holds; a dash-prefixed scalar broke that invariant for the same
+reason the blocked-list options already used `pushOption`. Applying the same helper
+to every value-bearing scalar whose value can start with a dash closes the gap
+consistently rather than special-casing one option. `pushOption`'s doc comment was
+generalized to note the path-flag use, and a P73 test asserts the attached form for
+all five scalar path options plus the unchanged space-separated emission for a
+normal value.
+
+**Commit:** ce1a2b3 — fix(vscode): round-14 codex review follow-ups for PR #89 (P71-P73)

--- a/docs/tasks/autodetect_mcp_source/analysis_74_stop_parsing_after_double_dash.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_74_stop_parsing_after_double_dash.md
@@ -1,0 +1,23 @@
+# Analysis 74 - Stop parsing args after the `--` separator
+
+## Decision: Valid — fix applied
+
+`parseServerArgs`' main loop pushed a bare `--` to `extraArgs` but kept iterating, so any tokens
+after the separator were still matched against the boolean/value-option branches. yargs-parser
+treats every token after `--` as a positional, so a hand-authored `node dist/index.js -- --shell
+cmd` (or the npx/node fast paths, whose `serverArgs` slice can contain the separator) was loaded as
+`shell=cmd`. The form then showed an active shell and a no-op save re-emitted `--shell cmd` as a
+real flag, changing how the server launched.
+
+The fix adds a `token === '--'` guard at the top of the loop body: it copies the separator and the
+entire remainder into `extraArgs` verbatim and breaks out of parsing. Flags before the separator are
+still modeled normally; only the post-`--` tokens are preserved untouched.
+
+**Why:** Matching yargs' positional semantics is the only faithful round-trip. Preserving the
+remainder verbatim guarantees a no-op save reproduces the original argv exactly, instead of
+promoting positionals to active wcli0 flags. This mirrors the existing "preserve what cannot be
+faithfully modeled" approach used for unknown flags and out-of-range values. The complementary
+suffix-detector fix is P75 (a `--` in a custom launcher's args is handled before parseServerArgs is
+even reached).
+
+**Commit:** bb6fe6c — fix(vscode): round-15 codex review follow-ups for PR #89 (P74-P78)

--- a/docs/tasks/autodetect_mcp_source/analysis_75_no_server_suffix_past_double_dash.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_75_no_server_suffix_past_double_dash.md
@@ -1,0 +1,22 @@
+# Analysis 75 - Do not scan past `--` for a server suffix
+
+## Decision: Valid — fix applied
+
+`serverFlagSuffixStart` scans for the start of the contiguous wcli0 server-flag suffix.
+`isPureServerFlagRun` correctly disqualifies a run that *starts* with `--`, but the scan loop simply
+advanced to the next index, so for `command: "wcli0", args: ["--", "--debug"]` it found a valid run
+at index 1 and split there. The wcli0 binary's own `--` is an options separator: yargs leaves
+`--debug` positional, so modeling it (and re-emitting it as an active flag on save) was wrong.
+
+The fix stops the scan when it reaches a `--`, but only when the command IS the wcli0 binary
+(`allowIndexZero`). That scoping is essential: for a wrapper command a `--` is a pass-through
+separator before the wrapped binary, and the wrapped wcli0's flags legitimately follow it — e.g.
+`npx --package=wcli0 -- wcli0 --shell cmd`, where `--shell` must still be modeled (the P17 case). So
+the break is correct for the binary's own separator and intentionally skipped for a wrapper's.
+
+**Why:** Only the wcli0 binary's own `--` makes the remainder positional; a wrapper's `--` delegates
+to the wrapped program, which then parses its own flags. Scoping the break to `allowIndexZero`
+fixes the reviewer's direct-entry case without regressing the npx/uvx pass-through behavior that the
+existing P17 test locks in (this was caught by that test during implementation).
+
+**Commit:** bb6fe6c — fix(vscode): round-15 codex review follow-ups for PR #89 (P74-P78)

--- a/docs/tasks/autodetect_mcp_source/analysis_76_attached_boolean_modeled_suffix.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_76_attached_boolean_modeled_suffix.md
@@ -1,0 +1,24 @@
+# Analysis 76 - Count attached boolean flags as modeled suffixes
+
+## Decision: Valid — fix applied
+
+`isRecognizedServerFlag` decides whether a token counts as a modeled wcli0 flag, which the wrapper
+suffix detector (`requireModeled`) uses to confirm a suffix really is wcli0's. Its attached-form
+check only consulted `VALUE_OPTIONS`, so a boolean assignment such as `--debug=true` or
+`--enableTruncation=false` was not recognized. A wrapper entry like `wrapper target --debug=true`
+therefore failed the modeled-flag requirement, the whole suffix stayed in `customArgs`, the form
+showed the default, and a save left the original attached boolean in the launcher args — the user
+could not edit or disable that flag.
+
+The fix extends the attached-form branch of `isRecognizedServerFlag` to also recognize a flag whose
+name is a `BOOLEAN_FLAGS` member when the value is the literal `true`/`false`. This exactly mirrors
+what `parseServerArgs`/`applyAttachedBoolean` actually model (P72), so the suffix detector only
+counts a token as modeled evidence when the parser would in fact model it. Any other attached value
+(`--debug=verbose`) still does not count and round-trips verbatim.
+
+**Why:** The suffix detector and the parser must agree on what "modeled" means, or a flag the parser
+can handle gets stranded in `customArgs`. Restricting recognition to the literal `true`/`false`
+keeps the two in lockstep and avoids treating an unmodeled value as false evidence of a wcli0
+suffix. The fix threads alongside P77's `stdio` parameter on the same helper.
+
+**Commit:** bb6fe6c — fix(vscode): round-15 codex review follow-ups for PR #89 (P74-P78)

--- a/docs/tasks/autodetect_mcp_source/analysis_77_stdio_transport_not_suffix_evidence.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_77_stdio_transport_not_suffix_evidence.md
@@ -1,0 +1,28 @@
+# Analysis 77 - Do not let stdio transport flags prove a server suffix
+
+## Decision: Valid — fix applied
+
+A stdio entry's `type` is authoritative, so `parseServerArgs({stdio:true})` deliberately leaves
+`--transport`/`--http-*`/`--sse-*` flags in `extraArgs` verbatim and never models them (P30). But
+the suffix detector (`serverFlagSuffixStart` -> `isPureServerFlagRun`) still treated any
+`VALUE_OPTIONS` flag — transport flags included — as modeled evidence. So a wrapper like
+`wrapper target --transport fast` was split as if `--transport fast` were an editable wcli0 suffix,
+even though nothing there is editable. After any real form edit, the regenerated flags were emitted
+between the wrapper's positional and its option (`target --shell cmd --transport fast`), reordering
+the wrapper invocation.
+
+The fix threads a `stdio` flag through `serverFlagSuffixStart`, `isPureServerFlagRun`, and
+`isRecognizedServerFlag` (the custom-launcher branch only ever parses stdio entries, so it passes
+`stdio=true`). In stdio context a transport flag still consumes its value structurally (so it is not
+mistaken for an orphan that disqualifies a run) but does NOT set `seenModeled`. A transport-only
+suffix therefore fails the wrapper's `requireModeled` check and stays in `customArgs`; a suffix that
+also contains a real wcli0 flag (`--shell`) still splits, with the transport flag riding along in
+`extraArgs`.
+
+**Why:** The suffix detector must mirror what the parser models. Since stdio never models transport
+flags, they cannot be evidence that a suffix belongs to wcli0. Keeping the value-consumption while
+dropping the `seenModeled` credit is the minimal change that both stops the false split for wrappers
+and leaves the wcli0-binary case (which preserves the transport flags as `extraArgs` regardless)
+unchanged.
+
+**Commit:** bb6fe6c — fix(vscode): round-15 codex review follow-ups for PR #89 (P74-P78)

--- a/docs/tasks/autodetect_mcp_source/analysis_78_preserve_duplicate_scalar_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_78_preserve_duplicate_scalar_flags.md
@@ -1,0 +1,27 @@
+# Analysis 78 - Preserve duplicate scalar flags instead of last-wins
+
+## Decision: Valid — fix applied
+
+`applyValue` wrote each scalar option (`string`/`number`/`csv` kinds) straight onto the settings
+object, so a repeated scalar collapsed last-wins: `--config a --config b` loaded as `config=b`,
+`--shell cmd --shell bash` as `shell=bash`. yargs instead parses a repeated scalar as an array
+(`['a','b']`), which the single-value form field cannot represent and which the server treats very
+differently (config-array loading, etc.). A no-op save then silently rewrote the hand-authored entry
+to the last value, changing the launch.
+
+The fix adds a pre-scan (`duplicatedScalarKeys`) that counts scalar value-option occurrences per
+settings key. The count mirrors the modeling paths exactly — it honors the stdio transport exclusion
+(`optionFor`), the number-diversion rule (`divertNumber`), the `-c` config bundle, and stops at the
+`--` separator (P74) — so a key is flagged only when two occurrences would really have landed in the
+same field. At each scalar modeling site (attached `--opt=value`, space `--opt value`, and both `-c`
+bundle forms) a flagged key is now preserved verbatim in `extraArgs` instead of modeled. Array-kind
+options (allowedDirectories, blockedCommands, ...) legitimately repeat and are untouched; a single
+scalar occurrence is still modeled normally, so the common case does not regress.
+
+**Why:** "Preserve/refuse rather than collapse" is the only lossless choice — the typed field cannot
+hold an array, so modeling it would always misrepresent the entry and a save would change behavior.
+Counting through the same predicates the loop uses keeps the pre-scan and the parse in agreement, and
+exempting array kinds preserves the existing accumulation semantics (P47). The duplicate's
+occurrences round-trip in original order, so re-emitting them reproduces the server's array exactly.
+
+**Commit:** bb6fe6c — fix(vscode): round-15 codex review follow-ups for PR #89 (P74-P78)

--- a/docs/tasks/autodetect_mcp_source/analysis_79_stop_conflict_scan_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_79_stop_conflict_scan_at_separator.md
@@ -1,0 +1,26 @@
+# Analysis 79 - Stop conflict scanning at the option separator
+
+## Decision: Valid — fix applied
+
+The `yoloPresent` / `unsafePresent` scans that drive `safetyConflict` ran over the whole `args`
+array, while everything else in `parseServerArgs` — the parse loop and the duplicate-scalar
+pre-scan — stops at the `--` options separator (P74/P78). So `['--unsafe', '--', '--yolo']`, which
+yargs runs in unsafe mode (the token after `--` is a positional and never defines `yolo`), was
+reported as a mutually-exclusive pair: both safety tokens were preserved verbatim in `extraArgs`
+and `safetyMode` stayed at the default `safe`. The form then showed the wrong protection level for
+a server that really runs unsafe, and picking a different safety mode from that form would emit a
+genuine `--yolo`/`--unsafe` conflict — turning a working entry into one the server rejects.
+
+The fix slices `args` at the first `--` (`separatorAt` / `optionArgs`) and runs both presence scans
+over that prefix only. A conflict written entirely before the separator is still detected and still
+round-trips verbatim (P70/P71), and the separator plus its positionals still land in `extraArgs`
+unchanged.
+
+**Why:** The conflict check exists to mirror what yargs does with the entry, so it has to obey the
+same option/positional boundary yargs does; scanning past `--` measured tokens the parser itself
+never treats as options. Slicing once and reusing the prefix keeps the three scans in agreement
+(loop, duplicate pre-scan, safety scan), which is the property every earlier separator fix relied
+on. See [[analysis_74_stop_parsing_after_double_dash]] and
+[[analysis_70_preserve_conflicting_safety_flags]].
+
+**Commit:** e7a73ce - fix(vscode): round-16 codex review follow-ups for PR #89 (P79-P82)

--- a/docs/tasks/autodetect_mcp_source/analysis_7_preserve_http_auth_fields.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_7_preserve_http_auth_fields.md
@@ -1,0 +1,16 @@
+# Analysis 7 - Preserve HTTP/SSE auth fields when saving
+
+## Decision: Valid — fix applied
+
+`writeMcpJsonFromSettings` now takes the loaded raw entry (`opts.baseEntry`) when saving a
+file source and merges the regenerated `{ type, url }` onto it via `mergeEntryOntoBase`
+instead of replacing the whole entry. Keys the form does not model (`headers`, `oauth`,
+and any other VS Code-supported HTTP/SSE field) are carried through; only the form-owned
+keys for the current transport mode are rewritten and the opposite mode's keys removed.
+
+**Why:** Rebuilding the entry from scratch dropped authentication/configuration metadata on
+any unrelated edit, so a remote MCP server could stop connecting after a load/save round
+trip. Merging preserves those fields. Covered by a unit test asserting `headers`/`oauth`
+survive a file save and a webview-path test asserting `headers` survive `saveToFile`.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_80_preserve_concurrent_modeled_args.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_80_preserve_concurrent_modeled_args.md
@@ -1,0 +1,32 @@
+# Analysis 80 - Preserve concurrent changes to unchanged modeled arguments
+
+## Decision: Valid — fix applied
+
+A file-source save built its settings as `overlaySettings(loadedFileSettings, msg.values)` — the
+panel's load-time snapshot with the user's changed fields laid over it — and
+`writeMcpJsonFromSettings` then refreshed only the argv fields that have no form control
+(`customArgs`, blocked lists, `--maxReturnLines`, allowed origins, `--wslMountPoint`, `extraArgs`,
+P40). Every MODELED field therefore came from the stale snapshot, and because `buildLaunchSpec`
+regenerates the whole `args` array, a Debug-only save silently rewrote a `--shell bash` another
+editor had written after the panel loaded back to the loaded `--shell cmd`.
+
+The fix moves the baseline to the CURRENT entry: the `saveToFile` handler re-reads
+`.vscode/mcp.json` (`readWcli0Entry`) and overlays `msg.values` onto that fresh `parseMcpEntry`
+result, falling back to the loaded snapshot when nothing usable is on disk (a deleted or malformed
+entry, matching the P23 merge-base fallback). Because `collectChanged()` submits exactly the fields
+the user edited, this is a real three-way merge: submitted fields keep the user's value, every
+other modeled field tracks disk. A concurrent transport-mode switch is refused instead of merged —
+the two modes model disjoint field sets, so overlaying stdio edits onto an http entry (or the
+reverse) cannot be meaningful — unless the user is switching the mode themselves. The write-time
+carry-forward in `commands.ts` is kept as-is: it re-reads at the last moment (after the modals) and
+still owns the fields with no form control.
+
+**Why:** "Last writer wins for what you touched, disk wins for what you did not" is the rule the
+file source already applies to env (P23) and to every uneditable argv field (P40); modeled fields
+were simply the gap. Keying the merge off the submitted changed-field names rather than diffing
+settings avoids false positives from representation differences, exactly as the P55 guard does.
+Refusing on a concurrent mode switch is the "reject the stale save" half of the review's suggestion,
+applied only where a merge has no defensible answer. See [[analysis_23_preserve_on_disk_env]] and
+[[analysis_55_refuse_stale_network_field_edits]].
+
+**Commit:** e7a73ce - fix(vscode): round-16 codex review follow-ups for PR #89 (P79-P82)

--- a/docs/tasks/autodetect_mcp_source/analysis_81_reject_host_port_edits_for_opaque_urls.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_81_reject_host_port_edits_for_opaque_urls.md
@@ -1,0 +1,28 @@
+# Analysis 81 - Reject host and port edits for opaque transport URLs
+
+## Decision: Valid — fix applied
+
+For an http/sse URL `parseHttpUrl` cannot decompose — a socket or named-pipe form such as
+`unix:///tmp/server.sock#/mcp` — `parseMcpEntry` models neither host nor port (both stay at the form
+defaults) and `preservedFileUrl` returns the raw URL verbatim so an unrelated save does not rewrite
+it to `http://host:port/mcp` (P10). The host and port controls stay enabled though, and the network
+save's stale-edit guard (P55) lists `transport.host` / `transport.port` as savable, so editing either
+one was accepted, the original URL was written back unchanged, and the post-write reparse dropped the
+edit behind a "Saved" — the same silent-loss shape P55 and P67 were opened for.
+
+The fix adds a guard in `writeMcpJsonFromSettings`, before URL preservation is decided: for a file
+source whose current on-disk URL is opaque and whose transport mode is unchanged, a `transportHost`
+or `transportPort` differing from `defaultSettings()` is an unsavable edit, so the save is refused
+with an error naming the URL and pointing at `.vscode/mcp.json`. Departure-from-default is the right
+signal because that is exactly what the parser leaves for such a URL, the same test P67 uses for a
+default-port URL. A mode switch still falls through to canonical reconstruction, where the host/port
+fields do reach the written URL, and an untouched save still round-trips the URL verbatim (P10).
+
+**Why:** Of the review's two options, refusing is the one that fits this codebase: disabling the
+controls is a webview-only measure that P55 already showed to be insufficient (a disabled control
+does not discard an edit made earlier), and serializing host/port into an opaque URL is impossible by
+definition. The refusal also matches the parse note the user already sees for these URLs ("edit
+.vscode/mcp.json directly to change it"), so the form's advice and its behavior now agree. See
+[[analysis_10_preserve_socket_pipe_urls]] and [[analysis_67_rebuild_default_port_url_on_port_change]].
+
+**Commit:** e7a73ce - fix(vscode): round-16 codex review follow-ups for PR #89 (P79-P82)

--- a/docs/tasks/autodetect_mcp_source/analysis_82_preserve_npx_install_confirmation.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_82_preserve_npx_install_confirmation.md
@@ -1,0 +1,27 @@
+# Analysis 82 - Preserve npx's installation confirmation behavior
+
+## Decision: Valid — fix applied
+
+The npx fast path accepted an entry with or without the leading `-y` (`npxPackageAt`), while
+`buildLaunchSpec` unconditionally emits `['-y', packageSpec, ...flags]`. A hand-authored
+`command: "npx", args: ["wcli0@1.2.3"]` was therefore modeled as the npx launch method, and any
+unrelated save added `-y` — converting a launch that asks before installing a missing package into
+one that accepts the download automatically. npm documents exactly that: npx prompts before
+installing, and `-y`/`--yes` suppresses the prompt.
+
+The fix requires `args[0] === '-y'` for the fast path. Without it the entry falls through to custom
+parsing, the same treatment `npx --package=x -- wcli0` already gets (P17): `customCommand` is `npx`,
+the package token stays in `customArgs`, and `serverFlagSuffixStart` still recovers the wcli0 flags
+after it, so `--shell` and friends remain editable and a no-op save re-emits `npx wcli0@1.2.3 ...`
+byte-for-byte. A parse note explains why the entry shows as a custom command. The same change drops
+the invented package spec for a bare `command: "npx"` entry with no args, which previously would have
+been saved as `npx -y wcli0@latest`.
+
+**Why:** The launch method is a lossy model — choosing it asserts "this entry is `npx -y <pkg>`" —
+so it may only be applied to entries that really are that. Falling through to custom is the
+project's established lossless escape for a launcher shape the form cannot represent, and it costs
+nothing here: the server flags stay modeled and only the launcher tokens become read-only text.
+Adding a "no -y" flag to the settings model instead would put a persisted, form-visible option into
+every scope to serve one hand-authored edge case. See [[analysis_17_preserve_npx_launcher_options]].
+
+**Commit:** e7a73ce - fix(vscode): round-16 codex review follow-ups for PR #89 (P79-P82)

--- a/docs/tasks/autodetect_mcp_source/analysis_83_stop_wrapper_scan_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_83_stop_wrapper_scan_at_separator.md
@@ -1,0 +1,28 @@
+# Analysis 83 - Stop scanning generic wrappers after option separators
+
+## Decision: Valid â€” fix applied
+
+P75 stopped the server-flag suffix scan at a `--` separator only for the wcli0 binary itself
+(`allowIndexZero`), on the reasoning that a wrapper's `--` is a pass-through separator whose
+remainder belongs to the wrapped binary. That is true for the npx case P17 preserves, but not in
+general: in `node --inspect dist/index.js -- --debug` the separator belongs to the invoked script,
+so yargs leaves `--debug` positional. The scan nevertheless split it out as a server flag, the form
+showed Debug enabled for a server running without it, and any newly saved flag was appended after
+the same separator â€” written, reported as saved, reparsed as "set", and never actually read by the
+server.
+
+The scan now stops at `--` for every command, with one narrow exception: a wrapper separator
+followed somewhere later by the wcli0 binary itself (`isWcli0Command`), which is the only shape that
+proves a pass-through. There the scan resumes at the token after that binary, so
+`npx --package=wcli0 -- wcli0 --shell cmd` still models `--shell` (P17). A second `--` after the
+wrapped binary is that binary's own separator and stops the scan, exactly as for a direct wcli0
+launch (P75).
+
+**Why:** The suffix scan's job is to find tokens the server's yargs will read as options, so it must
+respect the same option/positional boundary yargs does â€” the property P74, P75 and P79 each restored
+in a different scanner. Requiring the wrapped binary to be visibly wcli0 keeps the one proven
+pass-through working while defaulting every unrecognized wrapper to the lossless outcome: the
+remainder stays in `customArgs` and round-trips verbatim, unmodeled but never misreported. See
+[[analysis_75_no_server_suffix_past_double_dash]] and [[analysis_17_preserve_npx_launcher_options]].
+
+**Commit:** 869edb8 - fix(vscode): round-17 codex review follow-ups for PR #89 (P83-P86)

--- a/docs/tasks/autodetect_mcp_source/analysis_84_keep_dash_prefixed_shell_attached.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_84_keep_dash_prefixed_shell_attached.md
@@ -1,0 +1,24 @@
+# Analysis 84 - Keep dash-prefixed shell values attached
+
+## Decision: Valid â€” fix applied
+
+`buildServerArgs` emitted the shell with a plain `args.push('--shell', s.shell)` while every other
+scalar whose value can start with a dash goes through `pushOption`, which switches to the attached
+`--flag=value` form for exactly this reason (P73). A loaded entry can carry a dash-prefixed shell
+value the form's select cannot represent: yargs reads `--shell=--unsafe` as the shell name
+`"--unsafe"`, but reads the two-token `--shell --unsafe` as an empty shell value PLUS an active
+`unsafe` boolean. A no-op save therefore converted a broken-but-harmless hand-authored launch into a
+working one with every safety restriction disabled â€” the most dangerous shape of silent rewrite in
+this feature.
+
+The fix routes `--shell` through `pushOption` like the other dash-capable scalars. An ordinary shell
+name still emits as two tokens, so nothing about the common case changes.
+
+**Why:** Of the review's two options, the attached-value helper is strictly better than
+preserve/refuse here: it round-trips the value AND keeps the field editable, where preservation in
+`extraArgs` would leave the shell field empty and let a later edit fight the preserved token. It also
+removes an inconsistency rather than adding a special case â€” `--shell` was simply the one dash-capable
+scalar that had been missed when P73 introduced the helper. See
+[[analysis_73_keep_dash_prefixed_paths_attached]].
+
+**Commit:** 869edb8 - fix(vscode): round-17 codex review follow-ups for PR #89 (P83-P86)

--- a/docs/tasks/autodetect_mcp_source/analysis_85_require_nonempty_npx_package.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_85_require_nonempty_npx_package.md
@@ -1,0 +1,23 @@
+# Analysis 85 - Require a nonempty package for the npx fast path
+
+## Decision: Valid â€” fix applied
+
+P82 tightened the npx fast path to require the leading `-y` but kept the older tolerance for a
+missing package token (`args[1] === undefined`), so `npx -y` and `npx -y ""` still selected the
+modeled npx launch. `buildLaunchSpec` substitutes an empty `packageSpec` with `wcli0@latest`, so an
+unrelated save rewrote an incomplete invocation â€” one npx itself rejects, since it requires a package
+or an explicit call â€” into a complete automatic install-and-run of wcli0. That is the same
+save-changes-the-launch defect P82 fixed, in the half of the condition P82 left alone.
+
+The fix requires a real package token: present, non-blank, and not dash-prefixed. `npx -y` and
+`npx -y ""` now parse as a custom launch, where `npx` is the command and the remaining tokens
+round-trip verbatim in `customArgs`, so a save reproduces the original entry exactly instead of
+completing it.
+
+**Why:** The launch method asserts a specific shape (`npx -y <pkg>`), and an entry with no package is
+not that shape â€” modeling it means inventing a package the user never wrote. Falling through to
+custom is the project's standing lossless escape for launcher shapes the form cannot represent, and
+it costs nothing here because there are no server flags to strand. See
+[[analysis_82_preserve_npx_install_confirmation]].
+
+**Commit:** 869edb8 - fix(vscode): round-17 codex review follow-ups for PR #89 (P83-P86)

--- a/docs/tasks/autodetect_mcp_source/analysis_86_strip_bom_before_parsing_jsonc.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_86_strip_bom_before_parsing_jsonc.md
@@ -1,0 +1,23 @@
+# Analysis 86 - Strip UTF-8 BOMs before parsing detected JSONC
+
+## Decision: Valid â€” fix applied
+
+VS Code can save `.vscode/mcp.json` with its "UTF-8 with BOM" encoding and reads such a file back
+without complaint, but `Buffer.toString('utf8')` keeps the leading `U+FEFF` and `JSON.parse` rejects
+it. Every caller of `parseJsonc` swallowed the throw as "malformed": `detectWorkspaceMcpJson`
+reported the file as existing with no wcli0 entry (so no banner, no Load & edit),
+`readWcli0Entry` returned undefined, and the save path refused the file as invalid JSON. The whole
+load/edit feature was unavailable for a file VS Code itself considers fine.
+
+The fix strips a leading BOM inside `parseJsonc`, which covers detection, the entry load and the
+save's merge read at once, as the review suggested. The write path now re-attaches the BOM when the
+file it read had one (`hadBom`), so saving does not silently re-encode a file whose BOM was
+deliberate.
+
+**Why:** Centralizing in the parser is the only place that fixes all three callers without repeating
+the check, and it is where the impedance mismatch actually lives â€” the parser accepts a JSON *text*,
+and a BOM is an encoding artifact, not part of that text. Preserving the BOM on write follows the
+same principle as the rest of this feature's save path: change what the form owns and leave
+everything else about the file exactly as it was found.
+
+**Commit:** 869edb8 - fix(vscode): round-17 codex review follow-ups for PR #89 (P83-P86)

--- a/docs/tasks/autodetect_mcp_source/analysis_87_model_every_attached_boolean.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_87_model_every_attached_boolean.md
@@ -1,0 +1,27 @@
+# Analysis 87 - Model every attached boolean assignment
+
+## Decision: Valid â€” fix applied
+
+P72 modeled attached boolean assignments but only for the literal spellings `=true` / `=false`,
+preserving anything else verbatim on the assumption that yargs would not read it as a boolean. The
+installed yargs-parser says otherwise: `processValue` coerces a declared boolean's attached string
+with `val === 'true'`, so `--debug=0`, `--debug=1`, `--debug=yes` and `--debug=verbose` all mean
+FALSE. Preserving those in `extraArgs` produced the exact failure P72 set out to prevent -- the form
+showed the default while the server ran with the flag off, and enabling Debug later emitted
+`--debug` followed by the preserved `--debug=0`, which yargs resolves last-wins back to false. The
+edit was written, reported as saved, and had no effect.
+
+The fix drops the literal-value gate: every attached assignment is now offered to
+`applyAttachedBoolean` with `on = (value === 'true')`, mirroring yargs' own coercion exactly. Flags
+that are not known booleans (and safety flags under a conflict) still return false and are preserved
+verbatim, so nothing else changes. The P72 test's `--debug=verbose` case was updated from
+"preserved" to "modeled as false", which is what the server actually does with it.
+
+**Why:** The parser's contract in this feature is to model what yargs would do, not a subset of
+spellings that look modelable -- the same correction P68 made for the space form and P79 for the
+separator. Copying yargs' one-line rule is both simpler than the gate it replaces and impossible to
+drift from, and it removes a whole class of preserved tokens that could silently override later
+edits. See [[analysis_72_model_attached_boolean_assignments]] and
+[[analysis_68_honor_explicit_false_boolean_flags]].
+
+**Commit:** f563e8a - fix(vscode): round-18 codex review follow-ups for PR #89 (P87-P88)

--- a/docs/tasks/autodetect_mcp_source/analysis_88_refuse_network_entry_without_url.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_88_refuse_network_entry_without_url.md
@@ -1,0 +1,26 @@
+# Analysis 88 - Refuse network entries without a usable URL
+
+## Decision: Valid â€” fix applied
+
+For a file-source http/sse save the URL is either preserved verbatim or rebuilt from host/port. An
+entry with no usable url -- `{"type":"http"}`, `url: ""`, or a non-string url -- has nothing to
+preserve, so it fell through to the canonical fallback and an unrelated (even empty) save wrote
+`http://127.0.0.1:9444/mcp`. An entry that pointed nowhere silently became one pointing at a live
+local endpoint the user never chose, which is a security-relevant change of where the client
+connects, not merely a formatting one.
+
+The fix keeps the url key exactly as found -- absent stays absent, an empty or non-string value
+round-trips -- while the transport mode, host and port are all still at what the parser left
+(`keepMissingUrl`). A real host/port edit, or a transport-mode switch, still writes the rebuilt URL,
+so the form remains the way to fix such an entry. A parse note tells the user the entry has no usable
+url, that saving keeps it as-is, and how to set one.
+
+**Why:** Of the review's two options, preserving beats refusing here: refusing would block every
+unrelated edit on an entry the form is otherwise perfectly able to edit, while preservation is the
+rule this feature already applies to every other unrepresentable value (a socket URL P10, an
+out-of-range port P59, a non-positive limit P64, conflicting safety flags P70). Gating on
+"host and port untouched" reuses the P67/P81 test for a deliberate endpoint edit, so the only save
+that writes a URL is one where the user actually chose it. See
+[[analysis_10_preserve_socket_pipe_urls]] and [[analysis_81_reject_host_port_edits_for_opaque_urls]].
+
+**Commit:** f563e8a - fix(vscode): round-18 codex review follow-ups for PR #89 (P87-P88)

--- a/docs/tasks/autodetect_mcp_source/analysis_89_clear_safety_mode_on_later_false.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_89_clear_safety_mode_on_later_false.md
@@ -1,0 +1,28 @@
+# Analysis 89 - Clear a prior safety mode when a later value is false
+
+## Decision: Valid â€” fix applied
+
+Both safety branches â€” the bare/space form and the attached assignment `applyAttachedBoolean` â€” set
+`safetyMode` when the value was true and did nothing when it was false. That is only correct for a
+single occurrence. For a repeat ending in false the earlier positive survived, so
+`--unsafe --unsafe=false` (and `--unsafe --unsafe false`) loaded as `safetyMode: 'unsafe'` even
+though the server runs with protections ON, and a no-op save then re-emitted a bare `--unsafe` â€”
+turning a protected launch into an unrestricted one without the user touching anything. The negated
+`--no-unsafe` / `--no-yolo` spellings already cleared the mode; the positive-with-false spellings
+were the gap.
+
+Verified against the installed yargs-parser rather than assumed: repeated booleans are last-wins,
+not arrays â€” `--unsafe --unsafe=false` and `--unsafe --unsafe false` both give `unsafe: false`, and
+`--unsafe=false --unsafe` gives `unsafe: true`. The fix mirrors that in both branches: a false value
+clears the mode when it matches the family being parsed, leaving the reverse order still positive.
+The family guard matches the existing `--no-*` handling and cannot misfire, because both families
+present at once is a conflict and is preserved verbatim before these branches run (P70/P71).
+
+**Why:** This is the same "model what yargs does, not what the flag looks like" correction as P68,
+P79 and P87, but on the option where being wrong is most costly: every other misparse writes a wrong
+value, this one silently removes the shell restrictions. Clearing to `safe` rather than leaving the
+field untouched also keeps the form honest for the mixed case, where the default would otherwise be
+indistinguishable from an explicit selection. See [[analysis_87_model_every_attached_boolean]] and
+[[analysis_71_preserve_false_safety_flags]].
+
+**Commit:** 5d7e6fe - fix(vscode): round-19 codex review follow-ups for PR #89 (P89-P92)

--- a/docs/tasks/autodetect_mcp_source/analysis_8_default_port_url_port_zero.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_8_default_port_url_port_zero.md
@@ -1,0 +1,17 @@
+# Analysis 8 - Avoid loading default-port URLs as invalid port 0
+
+## Decision: Valid — fix applied
+
+`parseMcpEntry` no longer stores `transportPort = 0` for a URL that omits an explicit
+port. It now keeps the form's default port (a valid `min=1` value), still sets the host,
+retains the verbatim URL, and adds a note that the port field does not affect the
+preserved URL. The save path's `preservedFileUrl` round-trips the loaded URL while the
+host is unchanged (and rebuilds the canonical URL when the host is edited).
+
+**Why:** Rendering `0` into the `transport.port` input (which has `min="1"`) made
+`validateNumbers()` block Save, so an otherwise-unchanged default-port HTTP/SSE entry
+could not be saved. Keeping a valid default port plus verbatim-URL preservation lets the
+entry round-trip. Covered by updated `parseMcpEntry` tests and new file-save tests
+(round-trip unchanged; rebuild on host edit).
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/analysis_90_count_diverted_numeric_duplicates.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_90_count_diverted_numeric_duplicates.md
@@ -1,0 +1,25 @@
+# Analysis 90 - Count diverted numeric occurrences when detecting duplicates
+
+## Decision: Valid â€” fix applied
+
+The P78 duplicate pre-scan was written to mirror the modeling paths exactly, so it skipped an
+occurrence whose numeric value `divertNumber` would keep out of the typed field. That made a MIXED
+repeat invisible: `--commandTimeout bad --commandTimeout 5` counted once, so the malformed copy was
+diverted to `extraArgs` and `5` was modeled into the field. The builder then emitted
+`--commandTimeout 5` and â€” because the field was set â€” stripped the preserved malformed copy (P61),
+turning an entry the server ignored entirely (yargs yields the array `['bad', 5]`, which
+`applyCliSecurityOverrides` rejects as not-a-number, so the default timeout applied) into one that
+really applies 5.
+
+The fix counts every syntactically present scalar occurrence, diverted or not. Both occurrences are
+then preserved verbatim, the typed field stays unset, nothing is emitted for it and nothing is
+stripped, so the pair round-trips in order. A single diverted occurrence is unaffected (count 1),
+keeping the P34/P59/P64 preservation behavior intact.
+
+**Why:** The pre-scan's real question is "would yargs see this key twice?", which is a syntactic
+question â€” the diversion rule is about what the FORM can hold, a different concern that was
+conflated with it. Answering the syntactic question makes the scan agree with yargs for mixed
+repeats and, as a bonus, makes it simpler than the version it replaces. See
+[[analysis_78_preserve_duplicate_scalar_flags]] and [[analysis_61_strip_preserved_value_flags]].
+
+**Commit:** 5d7e6fe - fix(vscode): round-19 codex review follow-ups for PR #89 (P89-P92)

--- a/docs/tasks/autodetect_mcp_source/analysis_91_trim_urls_before_decomposing.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_91_trim_urls_before_decomposing.md
@@ -1,0 +1,23 @@
+# Analysis 91 - Trim URLs consistently before decomposing them
+
+## Decision: Valid â€” fix applied
+
+`parseMcpEntry` decomposed `entry.url` untrimmed while `preservedFileUrl` trims before parsing, so
+the two paths disagreed about the same entry. For `" http://gateway.example:8443/mcp"` the parser
+saw an undecomposable URL and left the form at the default host and port; the save path decomposed it
+successfully, compared `gateway.example:8443` against those displayed defaults, found a mismatch,
+concluded the user had edited the endpoint and rewrote it to `http://127.0.0.1:9444/mcp`. A no-op
+save silently repointed the client at a different server.
+
+The fix trims in `parseMcpEntry` too, so both paths decompose the identical string. The entry loads
+with its real host and port shown and editable, and the stored `transportUrl` is the trimmed form â€”
+matching what the save writes back, so the round-trip is stable.
+
+**Why:** Every preservation decision in this feature compares what the parser modeled against what
+the form now holds; that comparison is only sound while both sides parse the same value. Trimming at
+the single point where the URL enters the model is the smaller and safer half of the review's two
+options â€” the alternative, teaching both paths to preserve untrimmed input, would leave the form
+unable to show or edit an endpoint over a stray space. See
+[[analysis_5_preserve_http_sse_urls]] and [[analysis_67_rebuild_default_port_url_on_port_change]].
+
+**Commit:** 5d7e6fe - fix(vscode): round-19 codex review follow-ups for PR #89 (P89-P92)

--- a/docs/tasks/autodetect_mcp_source/analysis_92_preserve_variable_bearing_urls.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_92_preserve_variable_bearing_urls.md
@@ -1,0 +1,24 @@
+# Analysis 92 - Preserve variable-bearing network URLs
+
+## Decision: Valid â€” fix applied
+
+`parseHttpUrl`'s authority regex treats the first colon after the host as the port delimiter, but in
+`http://${input:host}:8080/mcp` that colon is inside a VS Code substitution token. The URL decomposed
+to host `${input` with a malformed port, so the form showed a truncated host and the default port,
+and `preservedFileUrl` â€” seeing a decomposable URL whose host/port did not match the form â€” rebuilt
+it. A no-op save wrote `http://${input:9444/mcp`, destroying both the variable and the endpoint. The
+mirror case `http://host:${input:port}/mcp` fails the same way.
+
+The fix reports any URL whose authority contains a `${` token as undecomposable, which routes it into
+the path already built for socket and named-pipe URLs: the verbatim URL is retained and re-emitted
+untouched (P10), the parse note tells the user to edit `.vscode/mcp.json` directly, and a host/port
+edit is refused rather than silently applied (P81). Plain URLs, including one whose host happens to
+be a bare `${NAME}` with no colon, are unaffected.
+
+**Why:** These values are unknowable until VS Code resolves them at launch, so any host/port the form
+could show would be fiction â€” "cannot be represented by these fields" is literally true, and the
+codebase already has a correct, tested behavior for that state. Checking only the authority (not the
+whole URL) keeps a variable in the PATH from disabling decomposition unnecessarily. See
+[[analysis_10_preserve_socket_pipe_urls]] and [[analysis_81_reject_host_port_edits_for_opaque_urls]].
+
+**Commit:** 5d7e6fe - fix(vscode): round-19 codex review follow-ups for PR #89 (P89-P92)

--- a/docs/tasks/autodetect_mcp_source/analysis_93_count_negative_numeric_values.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_93_count_negative_numeric_values.md
@@ -1,0 +1,26 @@
+# Analysis 93 - Count negative numeric values as scalar occurrences
+
+## Decision: Valid — fix applied
+
+Every "is the next token this option's value?" test in the parser used `!next.startsWith('-')`,
+which is not what yargs does: yargs-parser also consumes a dash-prefixed token that LOOKS LIKE A
+NUMBER. Verified against the installed parser — `--commandTimeout -1` gives `-1`, `--shell -1` gives
+`'-1'`, while `--shell -x` gives `''` plus a separate `-x` flag. So a repeat with a negative value
+was invisible to the duplicate pre-scan: `--commandTimeout -1 --commandTimeout 5` counted once, `5`
+was modeled into the field, and the builder emitted `--commandTimeout 5` while `stripValueFlag`
+removed the preserved `--commandTimeout` but left `-1` behind as an orphan. An entry the server
+ignored entirely (yargs yields the array `[-1, 5]`) became one applying a five-second timeout.
+
+A single `isOptionValue` helper now encodes yargs' rule (any non-dash token, or a negative number)
+and is used by the pre-scan, the modeling loop and the `-c` bundle path; `argsBuilder` gains the
+matching `isOptionValueToken` for its three strippers, so a stripped option takes its negative value
+with it instead of orphaning it. Non-numeric dash tokens still count as separate flags, so the P44
+"do not swallow the following option" behavior is unchanged.
+
+**Why:** The parser and the strippers only stay correct while they agree with yargs about where a
+value ends — the same class of mismatch as P74 (separator), P87 (attached booleans) and P89
+(repeated booleans). Encoding the rule once, in a named helper on each side, makes the two sides
+verifiably consistent rather than repeating a heuristic at six call sites. See
+[[analysis_90_count_diverted_numeric_duplicates]] and [[analysis_61_strip_preserved_value_flags]].
+
+**Commit:** bfa5c70 - fix(vscode): round-20 codex review follow-ups for PR #89 (P93-P97)

--- a/docs/tasks/autodetect_mcp_source/analysis_94_recognize_all_attached_booleans.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_94_recognize_all_attached_booleans.md
@@ -1,0 +1,23 @@
+# Analysis 94 - Recognize all attached boolean values in wrapper suffixes
+
+## Decision: Valid — fix applied
+
+P87 taught `parseServerArgs` that yargs coerces every attached value other than exactly `true` to
+false, but `isRecognizedServerFlag` — the detector that decides where a wrapper's own args end and
+the wcli0 server-flag suffix begins — still counted only `=true` / `=false` as a modeled flag. The
+two disagreed, so `wrapper target --enableTruncation=0` failed the modeled-evidence requirement
+(P56), the whole suffix stayed in `customArgs`, and the form showed truncation ENABLED for an entry
+that has it disabled. The flag was also uneditable, and turning it on from the form would have
+appended a second, conflicting spelling.
+
+The fix drops the literal check: any attached assignment whose flag is a declared boolean is
+recognized. The two functions now apply the same rule, so anything the parser will model is
+detectable as suffix evidence.
+
+**Why:** These two predicates are a pair — the detector decides which tokens reach the parser, so
+any spelling the parser understands must be recognized by the detector or it never gets the chance.
+P76 established that pairing for attached booleans; this closes the gap P87 opened in it by widening
+the parser alone. See [[analysis_87_model_every_attached_boolean]] and
+[[analysis_76_attached_boolean_modeled_suffix]].
+
+**Commit:** bfa5c70 - fix(vscode): round-20 codex review follow-ups for PR #89 (P93-P97)

--- a/docs/tasks/autodetect_mcp_source/analysis_95_single_snapshot_for_file_saves.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_95_single_snapshot_for_file_saves.md
@@ -1,0 +1,25 @@
+# Analysis 95 - Use the same snapshot for overlaying and writing file edits
+
+## Decision: Valid — fix applied
+
+P80 fixed the stale-baseline bug by re-reading the entry in the `saveToFile` handler and overlaying
+the submitted changes onto that fresh parse. But the writer takes its OWN full-file snapshot (P69,
+deliberately, so the file's other servers cannot be lost to a concurrent delete/recreate), so two
+reads exist. A write landing between them produces the worst pairing: modeled fields derived from
+the older entry, merged onto the newer one. A Debug-only save would then have written back the older
+`--shell cmd` over a concurrent `--shell bash` — the exact overwrite P80 set out to prevent, in a
+narrower window.
+
+The handler now passes `expectedEntryJson` — the serialized entry its settings were overlaid on —
+and the writer refuses when its own snapshot does not match, reporting that the file changed and
+that nothing was written. Agreement, including both reads finding no entry, proceeds as before, so
+the deleted-entry recreate path (P23) still works.
+
+**Why:** Of the review's two options, rejecting fits this codebase where passing the snapshot does
+not: the writer needs the WHOLE file (for the other servers), not just the entry, and it must read
+that itself to keep the P69 guarantee. Comparing what the caller assumed against what the writer
+found gives the same safety without weakening P69, and the race is rare enough that asking for a
+reload costs nothing. See [[analysis_80_preserve_concurrent_modeled_args]] and
+[[analysis_69_file_source_single_snapshot]].
+
+**Commit:** bfa5c70 - fix(vscode): round-20 codex review follow-ups for PR #89 (P93-P97)

--- a/docs/tasks/autodetect_mcp_source/analysis_96_preserve_explicit_shell_all.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_96_preserve_explicit_shell_all.md
@@ -1,0 +1,26 @@
+# Analysis 96 - Preserve an explicit `--shell all` argument
+
+## Decision: Valid — fix applied
+
+The form's `shell: 'all'` is an OMISSION sentinel: `buildServerArgs` emits no `--shell` for it, and
+the server then loads `buildConfig.includedShells` — every default shell. The server's own
+`--shell all` means something entirely different: `src/index.ts` builds `shellsToLoad` as
+`[args.shell]`, so it tries to load a shell module literally named "all", which does not exist,
+leaving the entry with no usable shells. Mapping the CLI value onto the sentinel conflated a
+locked-down entry with a fully-enabled one, and a no-op save dropped the flag and enabled every
+default shell — a privilege escalation from an unrelated edit, which is why this is the round's P1.
+
+The fix diverts the exact value `all` to `extraArgs` verbatim (both the `--shell all` and
+`--shell=all` spellings) and leaves the form's shell field at its default, so a no-op save re-emits
+the entry unchanged. Choosing a real shell in the form still wins: the emission then strips the
+preserved copy (P61) and writes only the selected value. Any other spelling is a normal shell name
+and round-trips through the field as before.
+
+**Why:** Preserve-verbatim is the established answer for a CLI value the form cannot represent
+(P10, P59, P64, P70), and `all` is precisely that — the field has a slot named `all` but it means
+the opposite of what the server does with it. Diverting only the exact string keeps the change
+surgical, and routing it through `extraArgs` means the existing strip-on-emit rule already handles
+the "user picked a real shell" case with no extra logic. See
+[[analysis_64_preserve_nonpositive_security_limits]] and [[analysis_61_strip_preserved_value_flags]].
+
+**Commit:** bfa5c70 - fix(vscode): round-20 codex review follow-ups for PR #89 (P93-P97)

--- a/docs/tasks/autodetect_mcp_source/analysis_97_stop_conflict_stripping_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_97_stop_conflict_stripping_at_separator.md
@@ -1,0 +1,22 @@
+# Analysis 97 - Stop conflict stripping at the option separator
+
+## Decision: Valid — fix applied
+
+P74 taught the parser to stop at `--` and round-trip the positional remainder verbatim, but the
+three conflict strippers in `argsBuilder` — `stripValueFlag`, `stripConfigArgs`,
+`stripTransportArgs` — still scanned the whole `extraArgs` list. So for `--shell cmd -- --shell bash`
+the parser correctly modeled `cmd` and preserved `-- --shell bash` as positionals, and then, because
+a shell WAS emitted, `stripValueFlag` deleted the positional `--shell bash` and the save wrote a
+truncated `--shell cmd --`. The strippers exist to prevent yargs seeing a duplicate OPTION; a token
+after the separator is not an option at all, so there was never anything to prevent there.
+
+All three strippers now copy `--` and everything after it verbatim and stop matching. The
+duplicate-prevention behavior before the separator is unchanged.
+
+**Why:** Every scanner in this feature has to respect the same option/positional boundary yargs does
+— P74 fixed the parse loop, P75 the suffix scan, P79 the safety-conflict scan, and the strippers
+were the last ones reading past it. Copying the remainder rather than dropping the separator keeps
+the round-trip exact, which is what makes a no-op save a no-op. See
+[[analysis_74_stop_parsing_after_double_dash]] and [[analysis_61_strip_preserved_value_flags]].
+
+**Commit:** bfa5c70 - fix(vscode): round-20 codex review follow-ups for PR #89 (P93-P97)

--- a/docs/tasks/autodetect_mcp_source/analysis_98_count_valueless_scalar_flags.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_98_count_valueless_scalar_flags.md
@@ -1,0 +1,28 @@
+# Analysis 98 - Count valueless scalar flags as duplicate occurrences
+
+## Decision: Valid — fix applied
+
+The duplicate pre-scan counted an occurrence only when a value token followed the flag, but yargs
+defines the key from the flag's PRESENCE: verified against the installed parser, `--shell` with no
+value gives `shell: ''`, and `--shell --debug --shell bash` gives `shell: ['', 'bash']`. An array is
+not a usable shell name, so that entry enables no shell at all. The pre-scan saw one occurrence, so
+`bash` was modeled into the field, the valueless `--shell` was preserved in `extraArgs` (P44), and
+because the field was then emitted, `stripValueFlag` deleted the preserved copy — a no-op save
+rewrote the entry as a single `--shell bash` and enabled command execution through Bash. Same shape
+as P96 in the previous round, and P1 for the same reason: an unrelated edit widens what the server
+can run.
+
+The fix counts a scalar option on presence, whatever follows it, and does the same for a trailing
+`c` in a single-dash bundle (`-c --debug` also defines config as `''`). Both occurrences are then
+preserved verbatim, the field stays unset, nothing is emitted for it and nothing is stripped, so the
+entry round-trips and still enables no shell. A single valueless flag is unaffected (count 1) and
+keeps its existing P44 preservation.
+
+**Why:** The pre-scan answers "would yargs see this key more than once?", which is about the flags
+present, not the values they carry — the same correction as P90 (diverted values) and P93 (negative
+values), now applied to the last case where a syntactically present occurrence was invisible.
+Counting presence is also the simplest possible rule, which is what makes it hard to get wrong
+again. See [[analysis_93_count_negative_numeric_values]] and
+[[analysis_96_preserve_explicit_shell_all]].
+
+**Commit:** 3981170 - fix(vscode): round-21 codex review follow-up for PR #89 (P98)

--- a/docs/tasks/autodetect_mcp_source/analysis_99_consume_greedy_array_values.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_99_consume_greedy_array_values.md
@@ -1,0 +1,32 @@
+# Analysis 99 - Consume every greedy array value
+
+## Decision: Valid — fix applied
+
+The parser consumed exactly one value token per option, but yargs' `greedy-arrays` (default true)
+makes an array option swallow every following value. Verified against the installed parser:
+`--blockedCommand rm del --debug` gives `['rm', 'del']`, and the attached form
+`--blockedCommand=rm del` does too. The server declares all four of these options with `array: true`
+(`src/index.ts`), so this is what a real launch does. Modeling only `rm` left `del` in `extraArgs`,
+and the rebuilt args put it after the modeled pair (`--blockedCommand rm --debug del`), where yargs
+reads it as a positional — the blocklist quietly lost an entry on an unrelated save. The same applies
+to `--allowedDir`, where losing a value narrows the allowed set, and to the blocked
+argument/operator lists.
+
+A `consumeGreedyArrayValues` helper now models the remaining values after both the space and attached
+forms, and `isPureServerFlagRun` consumes them too, so a wrapper suffix like
+`wrapper target --blockedCommand rm del` is still detected instead of failing on the "orphan" second
+value. Only `array` kinds are greedy — the csv options (`--http-allowed-origins`) take a single
+comma-separated token, matching their `type: 'string'` server declaration.
+
+While testing this I confirmed a limit worth recording: yargs does NOT take a dash-prefixed
+non-numeric token as an array value — `--blockedArgument -rf` leaves the array EMPTY and parses `-rf`
+as short flags. The parser reproduces that (the run is preserved verbatim), and only the attached
+`--blockedArgument=-rf` carries such a value, which round-trips attached via P73.
+
+**Why:** Every value the parser fails to model becomes a token the rebuild can misplace, and for
+these four options a misplaced token is a security setting that silently disappears — the same
+shape as P96 and P98. Reading the rule off the installed parser rather than the flag's appearance is
+what the last several rounds have converged on. See [[analysis_93_count_negative_numeric_values]] and
+[[analysis_98_count_valueless_scalar_flags]].
+
+**Commit:** 2ed694c - fix(vscode): round-22 codex review follow-up for PR #89 (P99)

--- a/docs/tasks/autodetect_mcp_source/analysis_9_preserve_non_string_env.md
+++ b/docs/tasks/autodetect_mcp_source/analysis_9_preserve_non_string_env.md
@@ -1,0 +1,17 @@
+# Analysis 9 - Preserve non-string env values on file saves
+
+## Decision: Valid — fix applied
+
+When saving a file source, the stdio entry's `env` is now taken verbatim from the loaded
+raw entry (`baseEntry.env`) rather than the string-filtered settings env. Because `env` is
+not form-editable, this round-trips VS Code-allowed non-string values (numbers, `null`)
+unchanged, while the existing "Include/Omit environment" prompt still lets the user strip
+it (the omit path drops `env` entirely).
+
+**Why:** `asStringMap` drops non-string values when building the settings baseline, so an
+unrelated save rewrote the entry without them (e.g. `env: { PORT: 3000 }` lost `PORT`) and
+showed no env prompt because the baseline looked empty. Sourcing env from the raw entry
+fixes both. Covered by unit tests asserting non-string env round-trips and that the omit
+choice still drops it.
+
+**Commit:** 87784c3 — fix(vscode): address review feedback for PR #89 (round 2)

--- a/docs/tasks/autodetect_mcp_source/comment_100_preserve_unsupported_shell_names.md
+++ b/docs/tasks/autodetect_mcp_source/comment_100_preserve_unsupported_shell_names.md
@@ -1,0 +1,9 @@
+# P100 - Preserve unsupported shell names
+
+In `vscode-extension/src/configSource.ts:540`, every shell name outside the form's fixed choices is
+unrepresentable, not only the explicit `all` case: `--shell fish` is modeled into `settings.shell`,
+but assigning `fish` to the `<select>` leaves it with the empty/Inherit value, the form is
+immediately considered changed, and a no-op Save drops `--shell`. The server previously disabled
+every known shell because none matched `fish`, whereas the rewritten entry restores the default
+enabled shells, so every value not offered by the shell select must be diverted rather than only
+`all`.

--- a/docs/tasks/autodetect_mcp_source/comment_101_revalidate_file_after_prompts.md
+++ b/docs/tasks/autodetect_mcp_source/comment_101_revalidate_file_after_prompts.md
@@ -1,0 +1,8 @@
+# P101 - Revalidate the file after save-time prompts
+
+In `vscode-extension/src/commands.ts:529`, the single up-front snapshot is taken before several
+awaited modal prompts, including the environment prompt and the JSONC-comment warning; if another
+editor changes `.vscode/mcp.json` while one of those prompts is open, the eventual write still
+serializes the old snapshot and silently discards that edit, including changes to unrelated servers.
+The file must be re-read and compared immediately before writing, or a document/version-based atomic
+update must be used.

--- a/docs/tasks/autodetect_mcp_source/comment_102_match_yargs_negative_numbers.md
+++ b/docs/tasks/autodetect_mcp_source/comment_102_match_yargs_negative_numbers.md
@@ -1,0 +1,8 @@
+# P102 - Match yargs when recognizing negative numeric tokens
+
+In `vscode-extension/src/configSource.ts:266`, the negative-number predicate also accepts scientific
+notation and trailing-dot forms that the installed yargs parser does not consume as option values:
+yargs parses `--shell -1e2` as an empty `shell` plus the short options `1` and `e`, so the server
+keeps its default shells, while this reverse parser models `-1e2` as the shell value and rebuilds it
+as `--shell=-1e2`, which disables every known shell on a no-op Save. The predicate must be restricted
+to the negative decimal forms yargs actually consumes.

--- a/docs/tasks/autodetect_mcp_source/comment_103_preserve_empty_allowed_dir.md
+++ b/docs/tasks/autodetect_mcp_source/comment_103_preserve_empty_allowed_dir.md
@@ -1,0 +1,9 @@
+# P103 - Preserve empty allowed-directory entries
+
+In `vscode-extension/src/argsBuilder.ts:442` (the `allowedDirectories` loop in `buildServerArgs`), a
+file entry containing `--allowedDir ""` makes yargs supply `allowedDirs` as `['']`, so
+`applyCliShellAndAllowedDirs` enables working-directory restriction with an effectively empty
+allowlist; the reverse parser retains that empty element, but `pathValue` returns `undefined` and the
+loop omits it, so a no-op save removes the CLI restriction and restores the config/default allowed
+paths, potentially enabling commands in directories the authored entry denied. The empty array value
+must be preserved verbatim rather than filtered out here.

--- a/docs/tasks/autodetect_mcp_source/comment_104_preserve_blank_allowed_dir_rows.md
+++ b/docs/tasks/autodetect_mcp_source/comment_104_preserve_blank_allowed_dir_rows.md
@@ -1,0 +1,12 @@
+# P104 - Preserve blank allowed-directory rows in the webview
+
+In `vscode-extension/src/webview.ts:1483` (`collect()` in the browser-side script), the client
+normalizes a loaded `allowedDirectories: ['']` to `[]`: the textarea renders the single empty value
+as blank and `filter(Boolean)` removes it during `collectChanged()`. The review states that the form
+is consequently immediately dirty, so saving any unrelated edit submits the empty array and removes
+`--allowedDir ""`, after which the server falls back from an effectively empty allowlist to its
+configured/default allowed paths, widening command access, and asks for a lossless representation of
+authored empty entries in the file-source collector.
+
+This finding arrived in the review BODY rather than as a review thread, so it has no thread to
+resolve.

--- a/docs/tasks/autodetect_mcp_source/comment_105_parse_direct_wcli0_arg_list.md
+++ b/docs/tasks/autodetect_mcp_source/comment_105_parse_direct_wcli0_arg_list.md
@@ -1,0 +1,13 @@
+# P105 - Parse direct wcli0 arguments as one server argument list
+
+In `vscode-extension/src/configSource.ts:413` (`serverFlagSuffixStart`), a direct entry containing a
+positional between a boolean and its later negation -- `command: "wcli0", args: ["--allowAllDirs",
+"marker", "--no-allowAllDirs"]` -- fails the index-zero purity check on `marker`, but the loop
+continues and selects the final negation as a separate server suffix; `parseMcpEntry` consequently
+stores the enabling flag in `customArgs` while modeling the suffix as false, and a no-op save omits
+the false value and writes only `--allowAllDirs marker`, changing the server from restricted to
+unrestricted directories. This is distinct from the earlier repeated-boolean parser case because the
+positional causes the split before `parseServerArgs` runs; for a recognized direct wcli0 command the
+complete argument list must be parsed or preserved rather than searching for a later suffix.
+
+Reported in the review of 2026-08-23T19:28:04Z, on thread `PRRT_kwDOO7ppps6bhlg_`.

--- a/docs/tasks/autodetect_mcp_source/comment_106_keep_valueless_scalar_before_positional.md
+++ b/docs/tasks/autodetect_mcp_source/comment_106_keep_valueless_scalar_before_positional.md
@@ -1,0 +1,9 @@
+# P106 - Keep valueless scalar flags ahead of following positionals
+
+In `vscode-extension/src/configSource.ts:969` (the space-separated value path in `parseServerArgs`),
+a plain Node entry such as `node dist/index.js --shell --debug cmd` parses in yargs as an empty
+`shell`, an enabled `debug`, and a positional `cmd`. This branch preserves `--shell` and later
+preserves `cmd`, but the builder emits the modeled `--debug` before `extraArgs`, producing
+`--debug --shell cmd`; yargs now treats `cmd` as the shell value, changing the enabled-shell set on a
+no-op save. The original valueless-option sequence must be preserved or rejected when a modeled flag
+intervenes before the positional.

--- a/docs/tasks/autodetect_mcp_source/comment_107_reject_delimiters_in_transport_host.md
+++ b/docs/tasks/autodetect_mcp_source/comment_107_reject_delimiters_in_transport_host.md
@@ -1,0 +1,8 @@
+# P107 - Reject delimiters in edited transport hosts
+
+In `vscode-extension/src/commands.ts:830`, when editing an HTTP/SSE file source the host field is
+interpolated into the URL without validating that it is an authority host: entering
+`gateway.example/api` reports a successful save but writes `http://gateway.example/api:9444/mcp`, and
+on reload `parseHttpUrl` reads the host as only `gateway.example` with no explicit port, so the
+accepted edit is lost and the endpoint path is malformed. Host values containing path, query,
+fragment or userinfo delimiters must be rejected before the URL is constructed.

--- a/docs/tasks/autodetect_mcp_source/comment_108_exclude_attached_negations_from_suffix.md
+++ b/docs/tasks/autodetect_mcp_source/comment_108_exclude_attached_negations_from_suffix.md
@@ -1,0 +1,9 @@
+# P108 - Exclude attached negations from modeled suffix evidence
+
+In `vscode-extension/src/configSource.ts:249` (`isRecognizedServerFlag`), a custom wrapper ending in a
+token such as `wrapper target --no-debug=false` has that token treated as a modeled boolean and split
+into the server suffix. The installed yargs-parser handles `--name=value` before boolean negation, so
+this defines the unrelated `no-debug` key rather than negating `debug`, and `parseServerArgs` likewise
+preserves it as an extra argument; after the user edits a real field such as Shell, saving changes the
+order to `target --shell cmd --no-debug=false`, potentially changing the wrapper invocation. Attached
+`--no-*=` forms must not prove that a wrapper has a wcli0 server suffix.

--- a/docs/tasks/autodetect_mcp_source/comment_109_preserve_valueless_array_before_positional.md
+++ b/docs/tasks/autodetect_mcp_source/comment_109_preserve_valueless_array_before_positional.md
@@ -1,0 +1,9 @@
+# P109 - Preserve valueless array flags before later positionals
+
+In `vscode-extension/src/configSource.ts:943`, the same guard separates valueless ARRAY flags from
+later positional tokens: `node dist/index.js --allowedDir --debug C:\work` initially gives yargs an
+empty `allowedDir` array and leaves `C:\work` positional (`allowedDir` is declared as an array at
+`src/index.ts`), but a no-op save emits `--debug --allowedDir C:\work`; yargs then consumes the path
+as an allowed directory, and `applyCliShellAndAllowedDirs` enables working-directory restriction and
+disables injection protection. The original sequence must be preserved or rejected instead of moving
+the valueless array flag next to a positional.

--- a/docs/tasks/autodetect_mcp_source/comment_10_preserve_socket_pipe_urls.md
+++ b/docs/tasks/autodetect_mcp_source/comment_10_preserve_socket_pipe_urls.md
@@ -1,0 +1,9 @@
+# P10 - Preserve socket and pipe URLs instead of rewriting them
+
+For supported HTTP/SSE entries that use a socket-style URL such as
+`unix:///tmp/server.sock#/mcp` or `pipe:///pipe/name`, `parseHttpUrl` returns undefined
+and `parseMcpEntry` only adds a note, leaving `transportUrl` unset. An unchanged Save
+then uses the default host/port and rewrites the entry to `http://127.0.0.1:9444/mcp`,
+breaking the configured socket/named-pipe server. Keep the original URL whenever it
+cannot be decomposed into host and port.
+File: `vscode-extension/src/configSource.ts:330`.

--- a/docs/tasks/autodetect_mcp_source/comment_110_reject_concurrent_launch_method_change.md
+++ b/docs/tasks/autodetect_mcp_source/comment_110_reject_concurrent_launch_method_change.md
@@ -1,0 +1,10 @@
+# P110 - Reject incompatible concurrent launch-method changes
+
+In `vscode-extension/src/webview.ts:439`, when another editor changes the entry's launch method while
+the panel is open, the overlay can silently discard a method-specific edit from the form: if the panel
+loaded an npx entry and the user edits only `launch.packageSpec`, but the file concurrently changes to
+a node entry, `currentFileParsed.settings` supplies `launchMethod: 'node'` while the submitted package
+value is overlaid onto it; the writer then emits the node launch unchanged, reports success, and the
+user's package edit disappears on reparse. The existing transport-mode conflict guard handles the
+analogous incompatibility, so the save should likewise reject a changed launch method when the
+submitted fields belong to the previously loaded method.

--- a/docs/tasks/autodetect_mcp_source/comment_111_count_trailing_valueless_numeric_duplicates.md
+++ b/docs/tasks/autodetect_mcp_source/comment_111_count_trailing_valueless_numeric_duplicates.md
@@ -1,0 +1,9 @@
+# P111 - Preserve trailing valueless numeric duplicates
+
+In `vscode-extension/src/configSource.ts` (line 623) the duplicate-scalar pre-scan counts a
+number option only when a value token follows it, so a trailing valueless repeat such as
+`--maxCommandLength 1000000 --maxCommandLength` is not counted; yargs is order-sensitive and
+resolves that pair to the array `[1000000, null]`, which the server ignores in favour of its
+safer default, yet the parser models `1000000` and the builder then strips the preserved
+valueless token, so saving an unrelated field silently activates the much weaker
+command-length limit (and the same shape can activate a long command timeout).

--- a/docs/tasks/autodetect_mcp_source/comment_112_keep_positionals_out_of_rebuilt_arrays.md
+++ b/docs/tasks/autodetect_mcp_source/comment_112_keep_positionals_out_of_rebuilt_arrays.md
@@ -1,0 +1,9 @@
+# P112 - Keep positionals out of rebuilt allowed-directory arrays
+
+In `vscode-extension/src/configSource.ts` (line 988) a bare positional argument is preserved in
+`extraArgs`, and because `buildServerArgs` appends `extraArgs` after the flags it generates from
+the typed fields, a direct entry such as `wcli0 marker --allowedDir C:/trusted` - which yargs
+reads as the positional `marker` plus the single allowed directory `C:/trusted` - is rebuilt as
+`--allowedDir C:/trusted marker`, where yargs greedily consumes `marker` as a second allowed
+directory, so saving any unrelated field silently expands the server's permitted
+working-directory scope.

--- a/docs/tasks/autodetect_mcp_source/comment_113_track_valueless_init_config.md
+++ b/docs/tasks/autodetect_mcp_source/comment_113_track_valueless_init_config.md
@@ -1,0 +1,10 @@
+# P113 - Track valueless init-config before reordering extras
+
+In `vscode-extension/src/configSource.ts` (line 1036) `makeExtrasReorderSafe` consults
+`VALUE_OPTIONS` only, but the server also declares `--init-config` as a string option
+(`src/index.ts:79-82`), so for a direct entry such as `args: ["--init-config", "--debug", "path"]` -
+which yargs reads as an empty `init-config` plus the positional `path`, letting the server run
+normally - the token is never marked valueless, the rebuild emits the modeled `--debug` ahead of
+the extras as `["--debug", "--init-config", "path"]`, and yargs then makes `path` the option value,
+so after an unrelated save the server writes a default config to that path and exits
+(`src/index.ts:1590-1598`).

--- a/docs/tasks/autodetect_mcp_source/comment_114_preserve_boolean_like_positionals.md
+++ b/docs/tasks/autodetect_mcp_source/comment_114_preserve_boolean_like_positionals.md
@@ -1,0 +1,9 @@
+# P114 - Preserve boolean-like positionals before boolean flags
+
+In `vscode-extension/src/argsBuilder.ts` (line 660) the guard that relocates a leading run of
+positionals preserved in `extraArgs` fires only when a greedy array option was emitted, so a direct
+entry such as `args: ["false", "--enableTruncation=true"]` - parsed as the positional `false` plus
+truncation enabled - is rebuilt as `["--enableTruncation", "false"]`, where yargs consumes the
+following `false` as the boolean option's value (the behavior already documented at
+`configSource.ts:646-654`), so saving an unrelated field disables truncation and drops the
+positional.

--- a/docs/tasks/autodetect_mcp_source/comment_115_stop_suffix_scan_at_leading_separator.md
+++ b/docs/tasks/autodetect_mcp_source/comment_115_stop_suffix_scan_at_leading_separator.md
@@ -1,0 +1,8 @@
+# P115 - Stop wrapper suffix scanning at a leading separator
+
+In `vscode-extension/src/configSource.ts` (line 394) `serverFlagSuffixStart` begins at index 1 and
+therefore never observes a `--` options separator at index 0, so for a custom launcher such as
+`command: "node", args: ["--", "wrapper.js", "--debug"]` - where node documents `--` as the end of
+its own options and hands `--debug` to the wrapper - the parser removes `--debug` from `customArgs`
+and presents it as wcli0's Debug setting, and turning that displayed setting off saves
+`["--", "wrapper.js"]`, deleting the wrapper's own option.

--- a/docs/tasks/autodetect_mcp_source/comment_11_clear_stale_notes.md
+++ b/docs/tasks/autodetect_mcp_source/comment_11_clear_stale_notes.md
@@ -1,0 +1,9 @@
+# P11 - Clear stale file-source notes after clean reloads
+
+When a loaded file produces notes, later reloads or saves that produce no notes never
+clear the old text because the host only posts a `notes` message when `notes.length` is
+non-zero, and the webview keeps `sourceNotes` visible while still in `mcpJson` mode. For
+example, after loading a custom URL warning and then saving a canonical URL, the warning
+remains even though it no longer applies. The host should send an empty notes update (or
+the webview should clear notes) on every file-source init.
+File: `vscode-extension/src/webview.ts:286`.

--- a/docs/tasks/autodetect_mcp_source/comment_12_preserve_stdio_only_fields.md
+++ b/docs/tasks/autodetect_mcp_source/comment_12_preserve_stdio_only_fields.md
@@ -1,0 +1,9 @@
+# P12 - Preserve stdio-only VS Code fields when saving
+
+Existing stdio entries can include VS Code-supported fields such as `envFile`, `dev`, or
+`sandboxEnabled`, but saving from the file source rebuilds the entry with only `type`,
+`command`, `args`, optional `cwd`, and optional `env`. An unrelated form edit therefore
+deletes those fields, so env files stop loading, development mode is disabled, or
+sandboxing is turned off. The save path should merge the generated launch fields into the
+loaded entry rather than reconstructing it.
+File: `vscode-extension/src/commands.ts:340`.

--- a/docs/tasks/autodetect_mcp_source/comment_13_allow_vscode_variable_config.md
+++ b/docs/tasks/autodetect_mcp_source/comment_13_allow_vscode_variable_config.md
@@ -1,0 +1,9 @@
+# P13 - Allow VS Code input variables in loaded --config paths
+
+When a loaded stdio entry contains a VS Code-substituted config argument such as
+`--config ${input:cfg}`, the parser maps it into `settings.configFile` and the file-source
+save validation treats the unresolved `${...}` as a blocking, unanchorable path. That means
+an otherwise valid `.vscode/mcp.json` entry that VS Code resolves at launch cannot be saved
+after any unrelated edit. File-source saves should preserve those argv values and skip the
+local loadability/anchorability checks for variable-backed paths from `mcp.json`.
+File: `vscode-extension/src/commands.ts:248`.

--- a/docs/tasks/autodetect_mcp_source/comment_14_preserve_node_runtime_args.md
+++ b/docs/tasks/autodetect_mcp_source/comment_14_preserve_node_runtime_args.md
@@ -1,0 +1,9 @@
+# P14 - Preserve node runtime arguments when loading entries
+
+When an existing stdio entry launches with Node options, e.g. `command: "node",
+args: ["--inspect", "dist/index.js", ...]`, the parser assumed the first argument is the
+script path. A no-op Save then regenerated the entry with `${workspaceFolder}/--inspect`
+as the script and moved the real script after the server flags, so the previously valid
+MCP server no longer started. Treat such entries as custom and preserve the raw launcher
+args unless the first arg is actually the script.
+File: `vscode-extension/src/configSource.ts:370`.

--- a/docs/tasks/autodetect_mcp_source/comment_15_preserve_custom_wrapper_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_15_preserve_custom_wrapper_flags.md
@@ -1,0 +1,10 @@
+# P15 - Avoid stealing wrapper options that look like server flags
+
+For a custom stdio entry whose wrapper has its own `--config`, `--transport`, or similar
+option before invoking wcli0, the split treated the first recognized flag as the start of
+wcli0's flags. Loading then saving mapped the wrapper option into extension settings and
+regenerated it after the launcher args, changing the wrapper's command line (e.g.
+`mywrapper --config wrapper.json wcli0 --shell cmd` became a different launch). The
+file-source round trip must preserve custom launcher arguments even when their names
+overlap wcli0 flags.
+File: `vscode-extension/src/configSource.ts:386`.

--- a/docs/tasks/autodetect_mcp_source/comment_16_repost_detection_on_folder_change.md
+++ b/docs/tasks/autodetect_mcp_source/comment_16_repost_detection_on_folder_change.md
@@ -1,0 +1,8 @@
+# P16 - Re-post source detection after workspace changes
+
+When the panel is open and the primary workspace folder is added or changed, the handler
+posted the old cached `detectedSources` and then refreshed the cache without sending
+another update. In the common case of opening a folder that already has `.vscode/mcp.json`,
+the "Load & edit" banner and source-menu row stayed absent until some unrelated event
+posted again, so auto-detection did not work for workspace changes.
+File: `vscode-extension/src/webview.ts:541`.

--- a/docs/tasks/autodetect_mcp_source/comment_17_preserve_npx_launcher_options.md
+++ b/docs/tasks/autodetect_mcp_source/comment_17_preserve_npx_launcher_options.md
@@ -1,0 +1,9 @@
+# P17 - Preserve npx launcher options before the package
+
+Existing mcp.json entries can use npx launcher options before the package (e.g.
+`npx --package=<pkg> -- <cmd>`). The parser only skipped a literal `-y`, so loading
+`npx --package=wcli0 -- wcli0 --shell cmd` treated `--package=wcli0` as the package spec
+and moved the rest into server/extra args; a Save rewrote a valid launcher command into a
+different argument order that may not run wcli0. Preserve leading npx options or fall back
+to custom parsing instead of assuming arg 0 is the package.
+File: `vscode-extension/src/configSource.ts:364`.

--- a/docs/tasks/autodetect_mcp_source/comment_18_variables_in_all_launch_fields.md
+++ b/docs/tasks/autodetect_mcp_source/comment_18_variables_in_all_launch_fields.md
@@ -1,0 +1,9 @@
+# P18 - Allow VS Code variables in all file-source launch fields
+
+File-source saves only exempted `settings.configFile` from local resolution. If a loaded
+stdio entry used VS Code launch variables in other fields that VS Code resolves at runtime,
+such as `cwd: "${env:PROJECT}"` or a node script `${input:script}`, `validateLaunchSpec`
+still treated them as unresolved and rejected an otherwise no-op Save even though
+`buildLaunchSpec(..., { resolvePaths: false })` would round-trip them verbatim. Apply the
+same file-source variable bypass to the other mcp.json launch fields that are preserved.
+File: `vscode-extension/src/commands.ts:331`.

--- a/docs/tasks/autodetect_mcp_source/comment_19_drop_stale_transport_fields.md
+++ b/docs/tasks/autodetect_mcp_source/comment_19_drop_stale_transport_fields.md
@@ -1,0 +1,9 @@
+# P19 - Drop stale transport-only fields when changing modes
+
+When switching a loaded entry from HTTP/SSE to stdio or the reverse, the stale-key lists
+omitted the unmodeled transport-specific fields that the merge now preserves. An HTTP entry
+with `headers`/`oauth` switched to stdio kept those auth fields in the committed stdio
+server, and a stdio entry with `envFile`/`dev`/`sandboxEnabled` switched to HTTP kept stale
+local-launch fields. Remove the other transport's whole field set on mode changes instead
+of only `url` or `command`/`args`/`cwd`/`env`.
+File: `vscode-extension/src/commands.ts:257`.

--- a/docs/tasks/autodetect_mcp_source/comment_1_export_persists_file_source.md
+++ b/docs/tasks/autodetect_mcp_source/comment_1_export_persists_file_source.md
@@ -1,0 +1,12 @@
+# P1 - Prevent export actions from persisting file-source edits
+
+When the active source is `.vscode/mcp.json`, only the main Save button is
+redirected to `saveToFile`; the Export tab buttons (`Show launch command`,
+`Generate config.json`, `Write .vscode/mcp.json`) still call `exportAction`,
+which posts `values`/`target` and makes the host run `applySettings` before
+exporting. Editing the loaded file entry and clicking an export action writes the
+partial file-source diff into `wcli0.*` settings and generates output from
+settings rather than the loaded file baseline, corrupting the user's settings.
+
+Reference: `vscode-extension/src/webview.ts` around line 1528 (export handler /
+`exportAction`).

--- a/docs/tasks/autodetect_mcp_source/comment_20_merge_current_on_disk_entry.md
+++ b/docs/tasks/autodetect_mcp_source/comment_20_merge_current_on_disk_entry.md
@@ -1,0 +1,9 @@
+# P20 - Detect stale wcli0 entry changes before saving
+
+If `.vscode/mcp.json` is edited after the panel loads it, the save path still merged onto
+the original `loadedFileEntry`. `writeMcpJsonFromSettings` rereads the file but then
+replaced `servers.wcli0` with the entry built from that stale base, so an unrelated Save
+could silently discard external additions to the same entry (for example new `headers`,
+`envFile`, or `oauth` fields) even though other servers were preserved. Re-read and merge
+against the current on-disk entry before writing.
+File: `vscode-extension/src/webview.ts:394`.

--- a/docs/tasks/autodetect_mcp_source/comment_21_parse_url_userinfo.md
+++ b/docs/tasks/autodetect_mcp_source/comment_21_parse_url_userinfo.md
@@ -1,0 +1,8 @@
+# P21 - Parse URL userinfo before extracting host and port
+
+For HTTP/SSE URLs with credentials, such as `https://user:pass@example.com:9444/mcp`, the
+regex treated `user` as the host and missed the explicit port because it did not skip the
+`userinfo@` portion. The file-source form then displayed the wrong host/default port, a
+port-only edit was ignored while preserving the old URL, and a host edit rewrote the URL
+without the credentials. Skip the userinfo before deriving the editable host and port.
+File: `vscode-extension/src/configSource.ts:412`.

--- a/docs/tasks/autodetect_mcp_source/comment_22_toggle_dirty_indicator.md
+++ b/docs/tasks/autodetect_mcp_source/comment_22_toggle_dirty_indicator.md
@@ -1,0 +1,7 @@
+# P22 - Toggle the dirty indicator on edits
+
+`#dirtyMsg` (the "Unsaved changes" span) is initialized with `display:none` and
+nothing ever toggles it: the only dirty-state refresh path, `reflectDirty`, just
+enables/disables the Revert button. So editing the `.vscode/mcp.json` source never
+shows the promised indicator and the form gives no visible dirty status.
+Reference: vscode-extension/src/webview.ts:839.

--- a/docs/tasks/autodetect_mcp_source/comment_23_preserve_on_disk_env.md
+++ b/docs/tasks/autodetect_mcp_source/comment_23_preserve_on_disk_env.md
@@ -1,0 +1,8 @@
+# P23 - Preserve current on-disk env on file saves
+
+When a file source is open and another process adds or changes `servers.wcli0.env`
+before the user saves, the save still takes `env` from the stale `baseEntry` loaded
+when the panel opened. The later current-on-disk merge treats `env` as a form-owned
+stdio key and deletes the on-disk value before applying the stale/empty one, so newly
+added environment variables are silently dropped without even showing the environment
+warning. Reference: vscode-extension/src/commands.ts:488.

--- a/docs/tasks/autodetect_mcp_source/comment_24_parse_valued_extra_args.md
+++ b/docs/tasks/autodetect_mcp_source/comment_24_parse_valued_extra_args.md
@@ -1,0 +1,9 @@
+# P24 - Parse custom suffixes with valued extraArgs
+
+For custom stdio entries whose wcli0 flag suffix ends with an unrecognized extra
+argument that has a separate value, e.g. `['wcli0', '--shell', 'cmd', '--futureFlag', 'x']`,
+the `return false` for the bare `x` token rejects the whole suffix. `serverFlagSuffixStart`
+then treats the modeled flags (`--shell cmd`) as launcher arguments instead of parsing
+them, so the form loads default values and a later edit can save stale launcher flags
+plus newly generated flags rather than preserving `extraArgs` as intended.
+Reference: vscode-extension/src/configSource.ts:158.

--- a/docs/tasks/autodetect_mcp_source/comment_25_push_source_reset.md
+++ b/docs/tasks/autodetect_mcp_source/comment_25_push_source_reset.md
@@ -1,0 +1,9 @@
+# P25 - Push source resets through dirty file forms
+
+When the primary workspace changes while a loaded `.vscode/mcp.json` form is dirty,
+the host resets `currentSource` to settings, but the subsequent `post(true)` is treated
+as an external reload and the webview returns before applying `setActiveSource`. The UI
+therefore continues to show and save as the stale file source until the user trips the
+rejected save path; the host should use a non-external source reset or a dedicated
+source-change message for this workspace-change case.
+Reference: vscode-extension/src/webview.ts:530.

--- a/docs/tasks/autodetect_mcp_source/comment_26_describe_comment_handling.md
+++ b/docs/tasks/autodetect_mcp_source/comment_26_describe_comment_handling.md
@@ -1,0 +1,8 @@
+# P26 - Describe the comment handling accurately
+
+The README says comment-bearing `mcp.json` files are refused, but the writer only
+refuses non-object/malformed files and instead prompts the user to continue before
+rewriting a commented JSONC file as plain JSON. Users relying on this text may think
+comments are always protected from removal, so it should say comments trigger a
+warning/confirmation rather than being refused.
+Reference: vscode-extension/README.md:49.

--- a/docs/tasks/autodetect_mcp_source/comment_27_preserve_cwd_relative_config.md
+++ b/docs/tasks/autodetect_mcp_source/comment_27_preserve_cwd_relative_config.md
@@ -1,0 +1,12 @@
+# P27 - Preserve cwd-relative --config when saving file sources
+
+When editing an existing stdio `.vscode/mcp.json` entry that has a non-workspace `cwd`
+and a relative `--config` argument, an otherwise unrelated Save regenerates `args` and
+the merge replaces the original argv. `buildLaunchSpec(..., { resolvePaths: false })`
+rewrites `--config config.json` to `${workspaceFolder}/config.json`, but the original
+server process would resolve `config.json` under its `cwd` (for example
+`${workspaceFolder}/server/config.json`). The saved entry then launches with a different
+config file than the one that was loaded, which can change shells or safety settings
+unexpectedly. The `resolvePaths: false` workspace-anchoring in `pathValue` must not apply
+to relative path args when the entry carries an explicit `cwd`.
+File: `vscode-extension/src/commands.ts:524`, `vscode-extension/src/argsBuilder.ts:285`.

--- a/docs/tasks/autodetect_mcp_source/comment_28_guard_dirty_edits_to_settings.md
+++ b/docs/tasks/autodetect_mcp_source/comment_28_guard_dirty_edits_to_settings.md
@@ -1,0 +1,12 @@
+# P28 - Avoid retargeting dirty file edits to settings
+
+When the primary workspace changes while a `.vscode/mcp.json` source is dirty, the
+`sourceReset` handler switches the client back to the settings source but deliberately
+leaves the old file values and the file-relative dirty baseline in the form. The next
+click on the now-renamed "Save settings" button posts a normal `save` message, so the
+unsaved edits from the old file are written into `wcli0.*` settings for the current scope
+instead of being discarded or reloaded. This can corrupt workspace/user settings after
+exactly the folder-change scenario the reset is meant to protect. The webview should
+guard a settings save whose baseline came from a now-gone file source behind an explicit
+confirmation.
+File: `vscode-extension/src/webview.ts:1985`.

--- a/docs/tasks/autodetect_mcp_source/comment_29_refuse_unsavable_file_edits.md
+++ b/docs/tasks/autodetect_mcp_source/comment_29_refuse_unsavable_file_edits.md
@@ -1,0 +1,11 @@
+# P29 - Refuse file-source shell/profile edits that cannot be saved
+
+When editing a `.vscode/mcp.json` source that references a loadable `--config`, changes
+made on the Shells or Profiles tabs are overlaid onto the loaded baseline and can pass the
+"Write anyway" warning, but `writeMcpJsonFromSettings` only writes the mcp.json entry and
+never updates the referenced config file where those settings would have to live. The
+subsequent reparse from disk drops those edits while still showing a successful save, so
+users silently lose the per-shell/profile changes they just made in the file-source form.
+A file-source save that carries per-shell or profile edits should be refused with a clear
+message pointing the user at the referenced config file.
+File: `vscode-extension/src/webview.ts:394`, `vscode-extension/src/commands.ts:389`.

--- a/docs/tasks/autodetect_mcp_source/comment_2_reset_file_source_primary_folder.md
+++ b/docs/tasks/autodetect_mcp_source/comment_2_reset_file_source_primary_folder.md
@@ -1,0 +1,12 @@
+# P2 - Reset file source when the primary folder changes
+
+The workspace-folders subscription only clears the `.vscode/mcp.json` source when
+no folders remain. In a multi-root workspace, or after removing/reordering
+folders so `primaryWorkspaceFolder()` changes but still returns a folder,
+`currentSource` stays `mcpJson` and `loadedFileSettings` still holds the old
+folder's entry; the next `saveToFile` targets the new primary folder and can
+overwrite that workspace's `.vscode/mcp.json` with the previous workspace's
+config.
+
+Reference: `vscode-extension/src/webview.ts` around line 430 (the
+`onDidChangeWorkspaceFolders` handler).

--- a/docs/tasks/autodetect_mcp_source/comment_30_transport_flags_corrupt_stdio_entry.md
+++ b/docs/tasks/autodetect_mcp_source/comment_30_transport_flags_corrupt_stdio_entry.md
@@ -1,0 +1,22 @@
+# P30 - Transport flags in a stdio entry's args flip the type and delete command/args on save
+
+A `.vscode/mcp.json` entry whose `type` is `stdio` but whose `args` carry a
+`--transport http` (or `--transport sse`) flag is silently converted into an
+http/sse entry on save, deleting its `command`/`args`/`cwd`/`env`.
+`parseMcpEntry` sets `transportMode = 'stdio'` from the entry `type`, then runs
+`parseServerArgs` over the args and `Object.assign`s the result back onto the
+settings. `--transport` is a recognized value-option, so the parsed
+`transportMode` overwrites the value derived from `type`. On save,
+`writeMcpJsonFromSettings` then takes the http/sse branch, generates
+`{ type, url }`, and `mergeEntryOntoBase` deletes the entire stdio field set
+(`command`, `args`, `cwd`, `env`, `envFile`, `dev`, `sandboxEnabled`) — so the
+launcher that was in the file is gone, replaced by a default URL, with no
+warning. The same root cause also drops `--http-host`/`--http-port`/
+`--sse-host`/`--sse-port`/`--http-allowed-origins`/`--sse-allowed-origins` that
+appear in a stdio entry's args: they are consumed into `transportHost`/
+`transportPort`/`transportAllowedOrigins`, but the forward builder never emits
+those flags for stdio, so they vanish on a no-op save. An entry's `type` is
+authoritative for an mcp.json server entry; transport flags in the args must not
+override it.
+Reference: `vscode-extension/src/configSource.ts:381,422-423` and
+`vscode-extension/src/commands.ts:548-570`.

--- a/docs/tasks/autodetect_mcp_source/comment_31_unknown_transport_type_coerced_stdio.md
+++ b/docs/tasks/autodetect_mcp_source/comment_31_unknown_transport_type_coerced_stdio.md
@@ -1,0 +1,15 @@
+# P31 - An unrecognized transport `type` is silently rewritten to stdio on save
+
+`parseMcpEntry` treats any `entry.type` that is not exactly `'http'` or
+`'sse'` as stdio: `const type = asString(entry.type) || 'stdio'` followed by a
+case-sensitive `if (type === 'http' || type === 'sse')` check. So an entry
+written with `type: "HTTP"` (uppercase), `type: "websocket"`, or any future/
+typo transport value falls through to the stdio branch with `transportMode =
+'stdio'` and no note. On save, `mergeEntryOntoBase` deletes `type` (it is in
+both owned-key lists) and writes the generated `type` (`'stdio'` or
+`'http'`/`'sse'`), so the original type is overwritten and the entry's transport
+is corrupted without any prompt. This contradicts the preserve-or-warn principle
+already applied to URLs (P5/P8/P10): a value the form cannot model should be
+preserved verbatim or surfaced with a note, not silently coerced.
+Reference: `vscode-extension/src/configSource.ts:333-335` and
+`vscode-extension/src/commands.ts:283-286`.

--- a/docs/tasks/autodetect_mcp_source/comment_32_short_config_alias_unrecognized.md
+++ b/docs/tasks/autodetect_mcp_source/comment_32_short_config_alias_unrecognized.md
@@ -1,0 +1,18 @@
+# P32 - The short-form `-c` / `--c` config alias is not recognized when loading an entry
+
+The server's `config` option has alias `c`, and the forward builder's
+`stripConfigArgs` recognizes every form yargs accepts (`-c X`, `--c X`,
+`-c=X`, `--c=X`, `-cX` bundling, `--no-c`). But the reverse parser's
+`VALUE_OPTIONS` table only lists `'--config'`. An entry authored with the short
+form (e.g. `args: ["-y", "wcli0@latest", "-c", "config.json"]`) therefore parses
+`-c` and `config.json` into `extraArgs`, leaving `configFile` empty. The
+consequences: the form's Config-file field shows empty even though the entry
+references a config file; the "references a config file via --config" parse note
+never fires; and the `configFileLoadable` validation is skipped
+(`resolvedConfigFilePath` returns undefined for an empty `configFile`, so the
+loadability check defaults to loadable), letting a `-c` that points at a
+missing/broken file save without the warning a `--config` pin would get. The
+data itself survives via `extraArgs`, but the form/validation asymmetry with the
+forward builder is the bug.
+Reference: `vscode-extension/src/configSource.ts:121-142` versus
+`vscode-extension/src/argsBuilder.ts:225-267`.

--- a/docs/tasks/autodetect_mcp_source/comment_33_nonstring_args_coerced_empty.md
+++ b/docs/tasks/autodetect_mcp_source/comment_33_nonstring_args_coerced_empty.md
@@ -1,0 +1,13 @@
+# P33 - Non-string `args` elements are silently coerced to empty string
+
+`parseMcpEntry` normalizes each arg with `asString`, which returns `''` for any
+non-string: `entry.args.map((a) => asString(a))`. So an entry with a numeric arg
+such as `args: ["--inspect", 9229]` becomes `["--inspect", ""]`, and the next
+save writes `"--inspect", ""` — the `9229` is corrupted to an empty string.
+This is inconsistent with how `env` is handled: P9 fixed the file-source save to
+round-trip the raw on-disk `env` verbatim (including numbers/null), but `args`
+are always rebuilt from the coerced settings. Node's own `child_process.spawn`
+stringifies numbers via `String()`, so `asString` returning `''` is strictly
+more lossy than what the server would do with the original value.
+Reference: `vscode-extension/src/configSource.ts:383` (and `asString` at
+`:304-306`).

--- a/docs/tasks/autodetect_mcp_source/comment_34_invalid_numeric_blocks_save.md
+++ b/docs/tasks/autodetect_mcp_source/comment_34_invalid_numeric_blocks_save.md
@@ -1,0 +1,17 @@
+# P34 - An invalid numeric flag value is consumed into a typed field and blocks every save
+
+`parseServerArgs` parses a number option with `const n = Number(value);
+out[key] = Number.isFinite(n) ? n : value`. When the value is non-numeric (e.g.
+`--commandTimeout abc`), it stores the raw string `'abc'` in the
+`number | null` field and consumes the flag (it never reaches `extraArgs`).
+`Object.assign` then puts a string into `s.commandTimeout`. On save,
+`validateLaunchSpec` checks `!(value > 0)` → `!('abc' > 0)` → `!NaN` → blocking
+problem, so the save is refused with "wcli0.commandTimeout (abc) must be a
+positive number" — and because the flag was consumed rather than passed through,
+the user cannot save ANY unrelated edit to the entry without first manually
+clearing that field (clearing it works only because an empty number maps back to
+null). A value the parser cannot model should round-trip verbatim via
+`extraArgs`, the same escape hatch used for unknown flags, instead of poisoning
+the typed field.
+Reference: `vscode-extension/src/configSource.ts:233-236` and
+`vscode-extension/src/argsBuilder.ts:1010-1030`.

--- a/docs/tasks/autodetect_mcp_source/comment_35_p29_gate_missing_http_sse.md
+++ b/docs/tasks/autodetect_mcp_source/comment_35_p29_gate_missing_http_sse.md
@@ -1,0 +1,17 @@
+# P35 - The P29 refusal is nested inside the stdio branch, so http/sse file sources silently drop shells/profiles
+
+`writeMcpJsonFromSettings` gates the P29 refusal
+(`fileSource && (hasPerShellConfig(settings) || hasProfilesConfig(settings))`)
+inside the `if (settings.transportMode === 'stdio')` block, alongside the
+second guard and the sync warning. The http/sse `else` branch only validates the
+port and never checks for per-shell/profile config. So when a file source is set
+to http or sse and the user configures per-shell settings or environment
+profiles in the form, the save is not refused: it writes an entry containing
+only `{ type, url }` (plus preserved `headers`/`oauth`), the shells/profiles the
+user added have nowhere to live (an http/sse entry carries no `--config` and no
+shells/profiles), and the function returns success while silently dropping them.
+Profiles are not academic here — the server still honors a selected profile's
+`env` over http/sse transport — yet nothing in the entry can carry them. The
+refusal (or a transport-aware variant) should cover every file-source save, not
+only stdio.
+Reference: `vscode-extension/src/commands.ts:365,389,464`.

--- a/docs/tasks/autodetect_mcp_source/comment_36_p29_bypass_ignore_mask.md
+++ b/docs/tasks/autodetect_mcp_source/comment_36_p29_bypass_ignore_mask.md
@@ -1,0 +1,19 @@
+# P36 - The ignore-inherited masks bypass the P29 refusal and silently drop shells/profiles on a file save
+
+On a file source the "Inherited per-shell config" / "Inherited profiles"
+selects stay editable: `applyScopeAvailability` disables them only for User
+scope, and `setActiveSource` never touches them, so at Workspace scope (the
+retained scope while the radio is hidden) the user can set either to Ignore. The
+P29 refusal calls `hasPerShellConfig(settings)` / `hasProfilesConfig(settings)`,
+both of which short-circuit to `false` when the corresponding mask is set. So a
+file-source save that adds per-shell settings or profiles AND enables the mask
+passes the gate: the entry is written without shells/profiles (an mcp.json
+`servers.wcli0` entry cannot carry them), the edits are silently dropped, and
+the save reports success ("saved to .vscode/mcp.json"). Setting either mask
+alone is also silently dropped — the entry format has no field for it and
+`parseMcpEntry` never reads it back. The masks are a scope-merge affordance
+with no meaning for a scope-less file source, so the form should not let them
+affect (or bypass) a file save.
+Reference: `vscode-extension/src/commands.ts:389` (via
+`vscode-extension/src/settings.ts:328,393`) and
+`vscode-extension/src/webview.ts:1806-1823,1898-1944`.

--- a/docs/tasks/autodetect_mcp_source/comment_37_toctou_split_file_reads.md
+++ b/docs/tasks/autodetect_mcp_source/comment_37_toctou_split_file_reads.md
@@ -1,0 +1,17 @@
+# P37 - The env source and the merge base come from two separate file reads straddling the env-prompt modal
+
+For a file-source stdio save, `writeMcpJsonFromSettings` reads the entry once
+for the env (`await readWcli0Entry(folder)`) BEFORE the Include/Omit
+`showWarningMessage` modal, then reads the whole file again (`readFile`) AFTER
+the modal to build the merge base. If an external process (an editor auto-save,
+git, another extension) changes `.vscode/mcp.json` during that modal window, the
+two reads diverge. If env was added in between, the prompt counted keys from the
+first read only and the second read's newer env is deleted by the merge (env is
+an owned stdio key) — a silent loss of the kind P23 was meant to prevent,
+re-introduced by the split read. If the file is deleted between the two reads,
+`readFile` throws `FileNotFound`, `existing` becomes `{}`, the merge falls back
+to `baseEntry`, and the write recreates the file with only `servers.wcli0` —
+every other server present at the first read is lost with no warning. Read the
+file once and derive both the env and the merge base from the same parsed
+document.
+Reference: `vscode-extension/src/commands.ts:516,523-535,576,633-636`.

--- a/docs/tasks/autodetect_mcp_source/comment_38_sourceReset_false_positive.md
+++ b/docs/tasks/autodetect_mcp_source/comment_38_sourceReset_false_positive.md
@@ -1,0 +1,19 @@
+# P38 - `sourceReset` unconditionally arms the P28 flag, producing a false confirmation on a clean form
+
+When the primary workspace folder changes, `wsSub` sends `post(true)` (an
+external init) and THEN the `sourceReset` message. For a DIRTY form the external
+init is skipped (the dirty guard), so `sourceReset` arming
+`resetFromFileSource = true` is correct (P28). But for a CLEAN form the external
+init is applied: it re-baselines the form to real settings values and sets
+`resetFromFileSource = false`, whereupon the immediately-following `sourceReset`
+handler unconditionally sets it back to `true`. The form now holds settings
+values against a settings baseline yet is flagged as file-derived, so the next
+"Save settings" trips the P28 modal ("these values came from a .vscode/mcp.json
+source that is no longer active ... save them anyway?") — a false positive. If
+the user trusts the warning and declines, a legitimate settings edit is
+abandoned. The existing P28 test dispatches `sourceReset` before a non-external
+init on a dirty form, so it does not exercise the real init-then-sourceReset
+ordering on a clean form. Gate the flag on whether the form is still dirty.
+Reference: `vscode-extension/src/webview.ts:2017` (handler) versus
+`vscode-extension/src/webview.ts:561,567-568` (ordering) and `:2054` (init clears
+the flag).

--- a/docs/tasks/autodetect_mcp_source/comment_39_dont_report_mask_edits_saved.md
+++ b/docs/tasks/autodetect_mcp_source/comment_39_dont_report_mask_edits_saved.md
@@ -1,0 +1,12 @@
+# P39 - Don't report inherited-mask edits as saved to mcp.json
+
+When editing a stdio `.vscode/mcp.json` source, the `ignoreInheritedShells` and
+`ignoreInheritedProfiles` controls can be changed, but those booleans are
+settings-only and are not emitted into any mcp.json entry. The file-source save
+guard only rejects raw `shells`/`profiles`, so changing just one of the
+inherited-mask toggles lets Save succeed; the post-save reparse then drops the
+change (it is not read back) and shows the user a misleading "saved" state while
+nothing about those masks was persisted. Treat these masks as unsavable for a
+file source (refuse or disable them there). This is the same root issue as
+[[comment_36_p29_bypass_ignore_mask]] (Codex independently flagged it).
+Reference: `vscode-extension/src/commands.ts:445` (the file-source save guards).

--- a/docs/tasks/autodetect_mcp_source/comment_3_preserve_custom_launcher_args.md
+++ b/docs/tasks/autodetect_mcp_source/comment_3_preserve_custom_launcher_args.md
@@ -1,0 +1,13 @@
+# P3 - Preserve dash-prefixed custom launcher args
+
+For custom launch entries, treating the first dash-prefixed argument as the start
+of wcli0 server flags breaks valid `wcli0.launch.customArgs` values that are
+themselves options, such as `command: "node"` with
+`customArgs: ["--inspect", "dist/index.js"]` or wrapper commands like
+`uvx --from ...`. Loading and saving such an entry moves those launcher arguments
+into `extraArgs` after the generated server flags, changing the command order and
+often making the saved `.vscode/mcp.json` no longer launch the intended
+wrapper/server.
+
+Reference: `vscode-extension/src/configSource.ts` around line 319 (custom branch
+of `parseMcpEntry`).

--- a/docs/tasks/autodetect_mcp_source/comment_40_preserve_uneditable_argv.md
+++ b/docs/tasks/autodetect_mcp_source/comment_40_preserve_uneditable_argv.md
@@ -1,0 +1,14 @@
+# P40 - Preserve current uneditable argv settings on file saves
+
+For a file-source stdio save the whole `args` array is regenerated from the
+loaded settings snapshot, and the on-disk merge (P20) refreshes only
+`extraArgs`-adjacent unmodeled *entry* fields — not the argv-derived settings the
+form does not edit (`customArgs`, `blockedCommands`/`blockedArguments`/
+`blockedOperators`, `--maxReturnLines`, `--http/sse-allowed-origins`). So if
+another editor adds one after the panel loads (e.g. `--blockedCommand rm`), an
+unrelated save rebuilds `args` from the stale snapshot and silently removes that
+on-disk change. Reparse the current on-disk entry and carry forward every
+uneditable argv-derived field, not just `extraArgs` (the args-equivalent of P23,
+which already does this for `env`).
+Reference: `vscode-extension/src/commands.ts:578` (the file-source stdio
+`args` regeneration and on-disk merge).

--- a/docs/tasks/autodetect_mcp_source/comment_41_preserve_current_custom_urls.md
+++ b/docs/tasks/autodetect_mcp_source/comment_41_preserve_current_custom_urls.md
@@ -1,0 +1,13 @@
+# P41 - Preserve current custom URLs on file saves
+
+The http/sse URL preservation decision (`preservedFileUrl`) still uses the
+`baseEntry` snapshot captured when the panel loaded, even though the current
+on-disk entry has already been re-read for the merge. If another editor changes
+only an unmodeled part of the URL after load (the scheme, path, or default-port
+form) while leaving the same host/port the form shows, a later no-op or
+unrelated save writes the old `baseEntry.url` back and discards the current
+on-disk change. Use the current on-disk entry for URL preservation when its
+modeled host/port still match the form (the URL-equivalent of the P20 on-disk
+merge).
+Reference: `vscode-extension/src/commands.ts:653` (the http/sse file-source
+URL preservation and `servers.wcli0` assignment).

--- a/docs/tasks/autodetect_mcp_source/comment_42_parse_modeled_before_multiple_extras.md
+++ b/docs/tasks/autodetect_mcp_source/comment_42_parse_modeled_before_multiple_extras.md
@@ -1,0 +1,14 @@
+# P42 - Parse modeled flags before multiple valued extras
+
+`isPureServerFlagRun` only lets the FINAL unknown flag consume a following bare
+value (the P24 trailing-value rule). When a custom wrapper's server suffix
+contains more than one unknown value-bearing flag — e.g.
+`wcli0 --shell cmd --future x --another y` — the detector therefore fails to
+recognize the suffix that starts at `--shell`, splits later (at `--another`),
+and leaves `--shell cmd` stranded in `customArgs`. The form then shows the
+default shell, and a later shell edit appends a SECOND `--shell` instead of
+updating the existing one. The suffix parser must let each unknown `--flag`
+consume one following non-flag value, so multiple unknown flag/value pairs do
+not hide the modeled flags before them.
+Reference: `vscode-extension/src/configSource.ts:178-180`
+(`isPureServerFlagRun`).

--- a/docs/tasks/autodetect_mcp_source/comment_43_continue_scan_after_launcher_flag.md
+++ b/docs/tasks/autodetect_mcp_source/comment_43_continue_scan_after_launcher_flag.md
@@ -1,0 +1,12 @@
+# P43 - Keep scanning after ambiguous launcher-only flags
+
+When a custom (non-wcli0) launcher has a valueless wrapper flag before the wcli0
+suffix, e.g. `wrapper --no-cache --shell bash`, `isPureServerFlagRun(args.slice(0))`
+succeeds because the unknown `--no-cache` is accepted as an extra leading flag, so
+`serverFlagSuffixStart` returns `0`. The index-0 guard for non-wcli0 commands then
+treats the entire argv as launcher args, so the loaded form shows the default shell
+(`shell=all`) and changing the shell appends a second `--shell` instead of replacing
+the existing one. The split must continue looking for a later suffix that begins with
+a modeled flag instead of giving up when the index-0 run is rejected.
+Reference: `vscode-extension/src/configSource.ts:269-276`
+(`serverFlagSuffixStart`) and `:560-562` (the index-0 guard).

--- a/docs/tasks/autodetect_mcp_source/comment_44_dont_consume_flag_as_value.md
+++ b/docs/tasks/autodetect_mcp_source/comment_44_dont_consume_flag_as_value.md
@@ -1,0 +1,11 @@
+# P44 - Do not consume another flag as a missing option value
+
+For a loaded hand-written entry where a value option is missing its value and is
+followed by another flag, the space-separated parse path consumes that flag as the
+value. For example, yargs parses `--blockedCommand --debug` as `blockedCommand=[]`
+with `debug=true`, but this code models `blockedCommands=["--debug"]` and drops
+`debug`; a no-op save then rewrites it as `--blockedCommand=--debug`, changing the
+server behavior. The space-separated value path should preserve the option when the
+next token is another flag, like `argsBuilder.stripConfigArgs` already does.
+Reference: `vscode-extension/src/configSource.ts:389-401`
+(`parseServerArgs`, the space-separated value branch).

--- a/docs/tasks/autodetect_mcp_source/comment_45_parse_bundled_config_alias.md
+++ b/docs/tasks/autodetect_mcp_source/comment_45_parse_bundled_config_alias.md
@@ -1,0 +1,12 @@
+# P45 - Parse bundled config aliases as configFile
+
+The server registers `config` with alias `c`, and `argsBuilder.stripConfigArgs`
+documents that yargs accepts bundled forms such as `-c/other.json` and
+`-xc /other.json`, but the reverse `VALUE_OPTIONS` table only recognizes `-c` as a
+separate token (plus `=` forms handled later). A loaded entry using a bundled alias
+keeps the real config pin hidden in `extraArgs`, so the Config file field and
+loadability checks think there is no `--config` while the server will still load
+one; handle the bundled `c` forms in `parseServerArgs` the same way the forward
+stripper does.
+Reference: `vscode-extension/src/configSource.ts:124-147` (`VALUE_OPTIONS`) and
+`argsBuilder.ts:250-263` (`stripConfigArgs` bundle handling).

--- a/docs/tasks/autodetect_mcp_source/comment_46_merge_from_single_snapshot.md
+++ b/docs/tasks/autodetect_mcp_source/comment_46_merge_from_single_snapshot.md
@@ -1,0 +1,11 @@
+# P46 - Merge from a single file snapshot
+
+For file-source saves, the early `readWcli0Entry` supplies the env/argv/url
+preservation data, but the merge base is read again later (from the full-file read)
+after validation and user-facing modals. If `.vscode/mcp.json` changes between those
+awaits, the generated `args`/`env` are built from the stale up-front snapshot and
+then merged onto the newer entry from the later read, producing an incoherent mix
+that can drop externally added env or flags. Derive the preservation data and the
+merge base from the same parsed file snapshot (the single up-front read).
+Reference: `vscode-extension/src/commands.ts:461-462` (the up-front read) and
+`:756-758` (the merge base re-read at write).

--- a/docs/tasks/autodetect_mcp_source/comment_47_recognize_kebab_case_aliases.md
+++ b/docs/tasks/autodetect_mcp_source/comment_47_recognize_kebab_case_aliases.md
@@ -1,0 +1,11 @@
+# P47 - Recognize yargs kebab-case option aliases
+
+The server uses yargs camel-case expansion, so a hand-written entry with
+`--max-command-length 1000` populates `args.maxCommandLength` and is applied by the
+server, but the reverse `VALUE_OPTIONS` table only recognizes `--maxCommandLength`.
+Loading such an entry hides the existing value in `extraArgs`; if the user then sets
+Max command length in the form, the save emits both spellings and yargs parses the
+scalar as an array, causing the server to ignore the override. Add the kebab-case
+aliases for the camelCase options (and boolean flags) the form models.
+Reference: `vscode-extension/src/configSource.ts:124-160`
+(`VALUE_OPTIONS` and `BOOLEAN_FLAGS`).

--- a/docs/tasks/autodetect_mcp_source/comment_48_compare_transport_type_case_insensitive.md
+++ b/docs/tasks/autodetect_mcp_source/comment_48_compare_transport_type_case_insensitive.md
@@ -1,0 +1,9 @@
+# P48 - Compare file source transport types case-insensitively
+
+`parseMcpEntry` intentionally accepts `type: "HTTP"` by lowercasing it, but the
+`preservedFileUrl` preservation check compares the edited mode to the raw `type`
+string. For an uppercase `HTTP`/`SSE` entry with a custom or default-port URL, a
+no-op Save treats it as a mode switch and rebuilds the URL to the canonical
+`http://host:port/...` form, losing the URL shape the parser promised to preserve.
+Lowercase `base.type` before comparing it to `settings.transportMode`.
+Reference: `vscode-extension/src/commands.ts:238-242` (`preservedFileUrl`).

--- a/docs/tasks/autodetect_mcp_source/comment_49_disable_masks_for_file_sources.md
+++ b/docs/tasks/autodetect_mcp_source/comment_49_disable_masks_for_file_sources.md
@@ -1,0 +1,9 @@
+# P49 - Disable settings-only masks for file sources
+
+When `source` is `mcpJson` and the loaded entry is stdio, the source switch leaves
+`ignoreInheritedShells` and `ignoreInheritedProfiles` editable whenever the prior
+settings scope was Workspace; only http/sse file entries lock those panels. Those
+masks are settings-only and are not emitted to `.vscode/mcp.json`, so changing just
+one of them lets `Save to file` succeed and then the post-save reparse drops the edit
+while showing Saved. Disable or reject these controls while editing any file source.
+Reference: `vscode-extension/src/webview.ts:1960` (`setActiveSource` / `applyScopeAvailability`).

--- a/docs/tasks/autodetect_mcp_source/comment_4_clear_omitted_env_baseline.md
+++ b/docs/tasks/autodetect_mcp_source/comment_4_clear_omitted_env_baseline.md
@@ -1,0 +1,12 @@
+# P4 - Clear omitted env from the saved file baseline
+
+When editing a file entry that already has `env`, `writeMcpJsonFromSettings` lets
+the user choose `Omit environment` and writes the entry without `env`, but the
+`saveToFile` path still stores the pre-write settings (including `env`) as the
+loaded baseline. On the next Save, because `env` is not modeled by the form,
+`overlaySettings` resurrects that old environment and rewrites/prompts for it
+again, so a secret the user explicitly omitted can be reintroduced by a later
+unrelated edit.
+
+Reference: `vscode-extension/src/webview.ts` around lines 327/360 (the
+`saveToFile` handler).

--- a/docs/tasks/autodetect_mcp_source/comment_50_treat_oversized_ports_invalid.md
+++ b/docs/tasks/autodetect_mcp_source/comment_50_treat_oversized_ports_invalid.md
@@ -1,0 +1,9 @@
+# P50 - Treat oversized URL ports as invalid
+
+For a file entry such as `url: "http://localhost:70000/mcp"`, the parser treats the
+explicit port as fully modeled because it is `> 0`, so the webview loads `70000` into
+an `<input max="65535">`. From there any unrelated save is blocked by client-side
+number validation until the user notices and edits the port; the recovery behavior
+only handles `:0`. Treat ports outside `1..65535` like the unusable-port case so
+loading a malformed URL does not strand the form in an invalid state.
+Reference: `vscode-extension/src/configSource.ts:536` (`parseMcpEntry` http/sse branch).

--- a/docs/tasks/autodetect_mcp_source/comment_51_preserve_stdio_transport_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_51_preserve_stdio_transport_flags.md
@@ -1,0 +1,10 @@
+# P51 - Preserve stdio transport flags on file saves
+
+For a stdio file source whose `args` include a hand-written `--transport http` (or
+`--transport=sse`), `parseMcpEntry` now keeps that token in `extraArgs`, but the save
+path feeds it through `buildLaunchSpec`; `buildServerArgs` always strips `--transport`
+from stdio `extraArgs`. A no-op Save to file therefore rewrites the entry and drops
+that authored flag, leaving any companion `--http-*` arguments orphaned instead of
+round-tripping the file verbatim.
+Reference: `vscode-extension/src/commands.ts:618` (`buildLaunchSpec` call) and
+`vscode-extension/src/argsBuilder.ts:420` (`stripExtraTransport`).

--- a/docs/tasks/autodetect_mcp_source/comment_52_refuse_unknown_transport_types.md
+++ b/docs/tasks/autodetect_mcp_source/comment_52_refuse_unknown_transport_types.md
@@ -1,0 +1,10 @@
+# P52 - Refuse saves for unknown transport types
+
+When an entry uses a future or custom `type` such as `websocket`, the parser only
+adds a note after modeling it as stdio; if the entry also has valid `command`/`args`,
+Save to file is allowed and `mergeEntryOntoBase` replaces the original `type` with
+`stdio` (and can delete URL-like fields). For unsupported transport types, the file
+source should refuse saving or preserve the original type rather than silently
+normalizing it after an unrelated edit.
+Reference: `vscode-extension/src/configSource.ts:650` (`parseMcpEntry` unknown-type note)
+and `vscode-extension/src/commands.ts` (`writeMcpJsonFromSettings`).

--- a/docs/tasks/autodetect_mcp_source/comment_53_preserve_current_wslmountpoint.md
+++ b/docs/tasks/autodetect_mcp_source/comment_53_preserve_current_wslmountpoint.md
@@ -1,0 +1,9 @@
+# P53 - Preserve current wslMountPoint on file saves
+
+For a stdio file source, `--wslMountPoint` is parsed and re-emitted but has no form
+control, so the uneditable-argv carry-forward list must also refresh it from the
+current on-disk entry. If another process adds or changes `--wslMountPoint` after the
+panel loaded, an unrelated Save to file rebuilds `args` from the stale loaded value
+and drops that current option, despite this block's goal of preserving uneditable
+argv fields.
+Reference: `vscode-extension/src/commands.ts:604` (the carry-forward `buildSettings`).

--- a/docs/tasks/autodetect_mcp_source/comment_54_reject_all_profile_edits_for_file_sources.md
+++ b/docs/tasks/autodetect_mcp_source/comment_54_reject_all_profile_edits_for_file_sources.md
@@ -1,0 +1,10 @@
+# P54 - Reject all profile edits for file sources
+
+The file-source guard only rejects profiles that `hasRawProfilesConfig` considers
+launch-meaningful, but the Profiles editor accepts any JSON object. On a stdio file
+source, entering a non-empty but non-emittable profile such as
+`{"p":{"description":"x","env":{}}}` lets Save to file succeed; the entry cannot store
+profiles, the reparse returns an empty profiles map, and the UI reports Saved while
+discarding the edit. For file sources, reject any non-empty profiles object rather
+than only meaningful ones.
+Reference: `vscode-extension/src/commands.ts:450` (the P29 file-source guard).

--- a/docs/tasks/autodetect_mcp_source/comment_55_refuse_stale_network_field_edits.md
+++ b/docs/tasks/autodetect_mcp_source/comment_55_refuse_stale_network_field_edits.md
@@ -1,0 +1,10 @@
+# P55 - Refuse stale edits before locking network file fields
+
+Disabling the non-transport tab controls when a file entry switches to `http`/`sse`
+does not discard edits the user already made while the entry was still `stdio`. If
+they change `safetyMode` or `configFile`, then switch Transport to a network mode and
+click Save to file, `collectChanged()` still submits those values, but the network save
+writes only `{type, url}` and reports success, so the post-save reparse silently drops
+the edits behind a misleading "Saved" indicator. The save must clear or reject
+non-transport changes when writing a network file entry.
+File: `vscode-extension/src/webview.ts:1539` (`applyFileTransportLock`).

--- a/docs/tasks/autodetect_mcp_source/comment_56_keep_unknown_only_suffix_with_wrapper.md
+++ b/docs/tasks/autodetect_mcp_source/comment_56_keep_unknown_only_suffix_with_wrapper.md
@@ -1,0 +1,10 @@
+# P56 - Keep unknown-only suffix flags with wrapper args
+
+When a custom non-`wcli0` command has its own trailing option after a positional, such
+as `wrapper target --verbose`, `isPureServerFlagRun` returns true even though the suffix
+contains no modeled wcli0 flag, so `parseMcpEntry` moves `--verbose` into `extraArgs`. A
+later unrelated edit then emits generated server flags before that extra arg
+(`target --shell cmd --verbose`), changing the wrapper invocation. An unknown-only suffix
+should stay in `customArgs` unless there is evidence of a modeled server-flag suffix.
+File: `vscode-extension/src/configSource.ts:281` (`isPureServerFlagRun` /
+`serverFlagSuffixStart`).

--- a/docs/tasks/autodetect_mcp_source/comment_57_preserve_allow_all_dirs.md
+++ b/docs/tasks/autodetect_mcp_source/comment_57_preserve_allow_all_dirs.md
@@ -1,0 +1,30 @@
+# P57 - Preserve --allowAllDirs on a file save when --initialDir (or --allowedDir) is set
+
+A hand-authored `.vscode/mcp.json` stdio entry that carries both `--allowAllDirs` and
+`--initialDir` loses the `--allowAllDirs` flag on an unrelated save, silently tightening the
+server from "all directories allowed" to "restricted to the initial directory".
+
+`parseServerArgs` models `--allowAllDirs` as `allowAllDirs = true` (a `BOOLEAN_FLAG`, so it is
+NOT kept in `extraArgs`) and `--initialDir /work` as `initialDir = '/work'`. On save,
+`buildServerArgs` computes
+`dirsConfigured = s.allowedDirectories.some((d) => d.trim()) || s.initialDir.trim().length > 0`
+and emits `--allowAllDirs` only when `!dirsConfigured`, so with an initialDir set the flag is
+dropped. `allowAllDirs` is a modeled, form-editable field that is NOT in the file-source
+on-disk carry-forward list, so it follows the regenerated value and disappears behind a
+misleading "Saved"; the post-write reparse then flips the "Allow all directories" tri-select
+off.
+
+The two arg lists are not equivalent at the server. With no config file,
+`loadConfig(config, disableIfEmpty = Boolean(--allowAllDirs))` clears `restrictWorkingDirectory`
+BEFORE the CLI `--initialDir` is applied (the config-file `initialDir` is still unset at that
+point), and `applyCliInitialDir` then skips adding `/work` to `allowedPaths` because the
+restriction is already off. So the ORIGINAL entry runs unrestricted; the ROUND-TRIPPED entry
+(no `--allowAllDirs`) keeps the restriction and confines the server to `/work`. An unrelated
+edit (e.g. toggling Debug) silently changes the working-directory security posture.
+
+The `dirsConfigured` suppression is only correct for `--allowedDir` (where the server's
+`applyCliShellAndAllowedDirs` re-enables the restriction regardless, making the drop
+server-inert but still flipping the form's tri-select on reparse); the
+`|| s.initialDir.trim().length > 0` clause is the defect. A flag present in the loaded entry
+that the form shows as set must survive an unrelated save.
+File: `vscode-extension/src/argsBuilder.ts:415-418` (`buildServerArgs` `dirsConfigured`).

--- a/docs/tasks/autodetect_mcp_source/comment_58_allow_subsecond_timeout.md
+++ b/docs/tasks/autodetect_mcp_source/comment_58_allow_subsecond_timeout.md
@@ -1,0 +1,24 @@
+# P58 - Don't strand file saves on a sub-1-second commandTimeout/maxCommandLength
+
+A hand-authored stdio entry with `--commandTimeout 0.5` (the server accepts any value > 0)
+cannot be round-tripped: every "Save to file" is refused because the form's number input
+carries `min="1"`.
+
+`parseServerArgs` models `--commandTimeout 0.5` into the typed `commandTimeout` field as `0.5`.
+The `commandTimeout` input is rendered with `min="1"` (`webview.ts:1074`; `maxCommandLength`
+the same at `1075`), and the save handler runs `validateNumbers()` first, which calls
+`checkValidity()` on every enabled `input[type=number]`. For a stdio file source the Limits &
+Safety panel is not locked, so the untouched `0.5` value fails `rangeUnderflow`,
+`reportValidity()` fires, and `validateNumbers()` returns false — the `saveToFile` message is
+never posted. An unrelated edit (e.g. changing the Config file path) cannot be saved until the
+user changes `commandTimeout` to >= 1, altering a field they never intended to touch and
+corrupting a valid value.
+
+The host write path would accept `0.5`: for a non-managed/file launch `validateLaunchSpec`
+blocks only `!(value > 0)`, `buildServerArgs` emits the flag when `> 0`, and the server's
+`applyCliSecurityOverrides` applies any value > 0. The form's `min="1"` is the
+managed/config-file bound (`validateConfig` rejects values between 0 and 1) wrongly applied to a
+CLI-flag/file entry, whose bound is `> 0`. The same mismatch strands `--maxCommandLength 0.5`.
+File: `vscode-extension/src/webview.ts:1074-1075` (the `commandTimeout` / `maxCommandLength`
+number inputs `min="1"`) and `webview.ts:1752-1761` (`validateNumbers` gating `save` /
+`saveToFile`).

--- a/docs/tasks/autodetect_mcp_source/comment_59_allow_out_of_range_log_limits.md
+++ b/docs/tasks/autodetect_mcp_source/comment_59_allow_out_of_range_log_limits.md
@@ -1,0 +1,26 @@
+# P59 - Don't refuse file-source saves over an out-of-range CLI log limit (maxReturnLines)
+
+A hand-authored stdio entry with `--maxReturnLines 50000` (server-valid) makes every "Save to
+file" fail, and the value cannot be fixed from the form because `maxReturnLines` has no control.
+
+`parseServerArgs` models `--maxReturnLines 50000` into the typed `maxReturnLines` field as
+`50000` (a finite number, so P34's "unparseable -> extraArgs" route does NOT apply). On save,
+`writeMcpJsonFromSettings` runs `validateLaunchSpec(validateSettings, false, false, cfgLoadable)`,
+and `validateLaunchSpec` pushes a blocking problem because `isValidLogLimit(50000)` is false:
+`wcli0.maxReturnLines (50000) must be an integer between 1 and 10000; the server rejects other
+values at startup.` The save is refused. `maxReturnLines` is not in `FIELD_KEYS`/`FIELD_TO_PROP`
+and has no form input, so `overlaySettings` keeps the loaded value on any unrelated edit and the
+user cannot correct it — the entry is permanently unsavable from the panel. The same gate blocks
+`--maxReturnLines 0` (which the server simply ignores).
+
+The "rejects at startup" claim is false for the CLI/mcp.json path. The server validates logging
+ranges only inside `loadConfig` -> `validateLoggingConfig`, which runs on the file/default config
+BEFORE `applyCliLogging` applies the CLI override, and `applyCliLogging` applies any
+`maxReturnLines > 0` with no upper-bound/integer check and no re-validation. So
+`--maxReturnLines 50000` runs (the server uses 50000) and `--maxReturnLines 0` is ignored
+(default 500) — both are server-valid. The 1..10000-integer bound is the config-file
+(`managed`) bound; `validateLaunchSpec` applies it unconditionally for `maxReturnLines` /
+`maxOutputLines`, ignoring `managed`, even on the non-managed file-source path
+(`commands.ts:550` passes `managed = false`).
+File: `vscode-extension/src/argsBuilder.ts:1021-1026` (`maxReturnLines`; `1015-1019`
+`maxOutputLines`), triggered from `vscode-extension/src/commands.ts:550-556`.

--- a/docs/tasks/autodetect_mcp_source/comment_5_preserve_http_sse_urls.md
+++ b/docs/tasks/autodetect_mcp_source/comment_5_preserve_http_sse_urls.md
@@ -1,0 +1,12 @@
+# P5 - Preserve full HTTP/SSE URLs when round-tripping
+
+For an existing `type: "http"` or `"sse"` entry whose URL is not exactly the
+extension-generated `http://host:port/mcp` or `/sse` shape, the load path keeps
+only host and port. A subsequent Save reconstructs the URL from those fields, so
+entries such as `https://gateway.example/custom/mcp` are silently downgraded to
+`http://gateway.example:<port>/mcp` (or become unsaveable when the original URL
+relied on a default port). Preserve the original URL parts or refuse editing URLs
+the form cannot model.
+
+Reference: `vscode-extension/src/configSource.ts` around line 282 (http/sse branch
+of `parseMcpEntry`) and `writeMcpJsonFromSettings` URL reconstruction.

--- a/docs/tasks/autodetect_mcp_source/comment_60_preserve_wildcard_url_host.md
+++ b/docs/tasks/autodetect_mcp_source/comment_60_preserve_wildcard_url_host.md
@@ -1,0 +1,28 @@
+# P60 - Preserve a user-authored wildcard URL host on a port-only file save
+
+Editing only the port of an http/sse `.vscode/mcp.json` entry whose URL host is a wildcard
+(`0.0.0.0` or `[::]`) silently rewrites the untouched host to loopback on save.
+
+A committed entry `{"type":"http","url":"http://0.0.0.0:9444/mcp"}` parses to
+`transportHost = '0.0.0.0'`, `transportPort = 9444`, with NO note (a canonical
+`http://host:port/mcp` URL is treated as fully modeled by `isCanonicalTransportUrl`). A no-op
+save preserves it verbatim through `preservedFileUrl` (host AND port match). But changing only
+`transport.port` (9444 -> 8080) makes `preservedFileUrl` return `undefined` (the port no longer
+matches), so the shared rebuild branch runs
+`http://${clientHost(settings.transportHost)}:${port}/mcp`, and `clientHost('0.0.0.0')` returns
+`127.0.0.1`. The written entry becomes `http://127.0.0.1:8080/mcp`: the host the user never
+touched is silently changed, `ok = true`, no error, and no note. The post-save reparse then
+loads `127.0.0.1` back into the form. The IPv6 wildcard `[::]` is likewise rewritten to `[::1]`,
+and a user who types `0.0.0.0` / `[::]` directly into the Host field hits the same
+corrupt-on-save.
+
+Only the field the user edited (port) should change: the save should write
+`http://0.0.0.0:8080/mcp`, preserving the untouched host verbatim — consistent with the no-op
+save, which DOES preserve `0.0.0.0`. The `clientHost` bind-host -> connect-host normalization
+belongs to the settings-driven export (which builds a fresh connectable URL from a bind
+setting), not to the file-source rebuild, where the host came from a user-authored connect URL
+and must round-trip. `isCanonicalTransportUrl` also wrongly assumes a wildcard URL round-trips
+losslessly through host/port (it emits no note warning that editing the port will move the
+host).
+File: `vscode-extension/src/commands.ts:727-733` (the file-source URL rebuild, `clientHost` at
+line 731); contrast `preservedFileUrl` at `commands.ts:261`.

--- a/docs/tasks/autodetect_mcp_source/comment_61_strip_preserved_value_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_61_strip_preserved_value_flags.md
@@ -1,0 +1,13 @@
+# P61 - Strip preserved value flags when replacing them
+
+In `vscode-extension/src/argsBuilder.ts` (around line 538) the duplicate-cleanup that
+runs after a file-source round-trip only stripped the log-limit flags
+(`--maxOutputLines` / `--maxReturnLines`). When a loaded entry contained a malformed
+modeled option the parser kept verbatim in `extraArgs` — for example
+`--commandTimeout bad` (unparseable number) or `--logDirectory --debug` (value is a
+flag) — and the user then set that same field in the form, the save emitted both the new
+typed flag and the preserved extra flag. yargs parses the repeated scalar option declared
+in `src/index.ts` as an array, while `applyCliSecurityOverrides` / `applyCliLogging` expect
+a number/string, so the edited value is ignored or can crash the server instead of
+replacing the bad argument. The builder must strip every modeled value flag it is about to
+emit, not just the two log-limit lines.

--- a/docs/tasks/autodetect_mcp_source/comment_62_dont_fabricate_config_from_short_bundle.md
+++ b/docs/tasks/autodetect_mcp_source/comment_62_dont_fabricate_config_from_short_bundle.md
@@ -1,0 +1,12 @@
+# P62 - Don't fabricate config paths from short bundles
+
+In `vscode-extension/src/configSource.ts` (around line 482) a hand-written entry with a
+single-dash bundle such as `args: ["-cfoo"]` had everything after `c` treated as the config
+path. But the server's yargs `config` alias in `src/index.ts` parses `-cfoo` as an empty
+`-c` plus separate short booleans (`-f -o -o`), not as `config: "foo"`. Loading that entry
+therefore filled `wcli0.configFile` with a file the server was not using, so a no-op save
+could start emitting `--config foo` (or reject the save because `foo` is not loadable) and
+change the launched configuration. The parser must only model the bundle remainder as
+`configFile` in the shapes yargs actually reads as the config string (a numeric value, or a
+value whose first character is a non-word, non-dot path separator), and otherwise preserve
+the token verbatim.

--- a/docs/tasks/autodetect_mcp_source/comment_63_consume_negated_boolean_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_63_consume_negated_boolean_flags.md
@@ -1,0 +1,9 @@
+# P63 - Consume negated boolean flags before preserving extras
+
+In `vscode-extension/src/configSource.ts` (around line 446), `parseServerArgs`
+does not recognize the yargs negations of the server's boolean options
+(`--no-debug`, `--no-allowAllDirs`, `--no-yolo`, `--no-unsafe`), so they fall
+through to `extraArgs`. When the user then enables the same option in the form,
+`buildServerArgs` emits the positive flag before the preserved negation, and
+yargs applies the later negation (`--debug --no-debug` parses as `debug: false`),
+silently ignoring the user's edit. The negated forms must be consumed/modeled.

--- a/docs/tasks/autodetect_mcp_source/comment_64_preserve_nonpositive_security_limits.md
+++ b/docs/tasks/autodetect_mcp_source/comment_64_preserve_nonpositive_security_limits.md
@@ -1,0 +1,10 @@
+# P64 - Preserve ignored security-limit values instead of blocking saves
+
+In `vscode-extension/src/configSource.ts` (around line 435), the `divertNumber`
+helper returns false for finite `--commandTimeout`/`--maxCommandLength` values,
+so a loaded `--commandTimeout 0` or `--maxCommandLength=-1` is modeled into the
+typed field. The webview/host validation then rejects every save (a negative
+fails the number input, zero fails `validateLaunchSpec`), even though the server
+simply ignores those non-positive CLI overrides and keeps running. These values
+should be diverted to `extraArgs` like the other unrepresentable numerics so an
+unrelated edit can round-trip the existing entry.

--- a/docs/tasks/autodetect_mcp_source/comment_65_strip_negated_scalar_aliases.md
+++ b/docs/tasks/autodetect_mcp_source/comment_65_strip_negated_scalar_aliases.md
@@ -1,0 +1,10 @@
+# P65 - Strip negated scalar aliases when replacing preserved flags
+
+In `vscode-extension/src/argsBuilder.ts` (around line 300), `stripValueFlag`
+only matches the positive option names. When a loaded file entry has a yargs
+negation for a scalar option in `extraArgs` (e.g. `--no-shell`,
+`--no-logDirectory`, `--no-commandTimeout`) and the user sets that same field in
+the form, the negated token is appended after the generated value. Yargs then
+parses arrays such as `shell: ['cmd', false]` or `logDirectory: ['/tmp', false]`,
+so the edited value is ignored or even crashes the server. The corresponding
+`--no-*` forms must be stripped whenever the positive scalar is emitted.

--- a/docs/tasks/autodetect_mcp_source/comment_66_reject_nonnumeric_url_ports.md
+++ b/docs/tasks/autodetect_mcp_source/comment_66_reject_nonnumeric_url_ports.md
@@ -1,0 +1,10 @@
+# P66 - Reject non-numeric URL ports instead of treating them as omitted
+
+In `vscode-extension/src/configSource.ts` (around line 753), `parseHttpUrl`'s
+optional digit-only port group can fail while the overall regex still returns the
+host with `port: undefined`. For a hand-authored http/sse entry whose URL has an
+explicit but non-numeric port (`http://host:abc/mcp`, `http://host:-1/mcp`), the
+save path treats that as an omitted/default-port URL and preserves it verbatim
+whenever the host is unchanged, so editing only the port field cannot fix the
+malformed URL. An explicit malformed port must be detected as invalid rather than
+classified as omitted.

--- a/docs/tasks/autodetect_mcp_source/comment_67_rebuild_default_port_url_on_port_change.md
+++ b/docs/tasks/autodetect_mcp_source/comment_67_rebuild_default_port_url_on_port_change.md
@@ -1,0 +1,10 @@
+# P67 - Rebuild default-port URLs when the port changes
+
+In `vscode-extension/src/commands.ts:255` (`preservedFileUrl`), a loaded http/sse file
+entry whose URL omits an explicit port (for example `https://gateway.example/custom/mcp`)
+is preserved verbatim whenever the host is unchanged, regardless of the port field. The
+webview still accepts a pure `transport.port` edit and the host reports the save as
+savable, so a port-only edit reports "Saved" while writing the original URL back unchanged;
+the subsequent reparse then drops the user's edited port. A port change must be treated as a
+reason to rebuild the canonical `http://host:port/<mcp|sse>` URL (mirroring the existing
+host-edit behavior) rather than silently discarding the edit.

--- a/docs/tasks/autodetect_mcp_source/comment_68_honor_explicit_false_boolean_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_68_honor_explicit_false_boolean_flags.md
@@ -1,0 +1,11 @@
+# P68 - Honor explicit false values for boolean flags
+
+In `vscode-extension/src/configSource.ts:474` (`parseServerArgs`), a loaded entry that uses
+a yargs-accepted explicit boolean value such as `--debug false` is mis-modeled: the parser
+records `debug=true` and leaves the `false` token as an extra arg. yargs declares
+`allowAllDirs`/`debug`/`yolo`/`unsafe`/`enableTruncation`/`enableLogResources` as
+`type:'boolean'` (`src/index.ts`), and a boolean option consumes a following bare
+`true`/`false` token as its value (verified: `--debug false` parses to `debug=false`). The
+form therefore shows the opposite of what the server will run, and the preserved extra value
+can defeat a later edit. The parser must consume and model these explicit boolean values
+instead of treating every bare flag as true.

--- a/docs/tasks/autodetect_mcp_source/comment_69_file_source_single_snapshot.md
+++ b/docs/tasks/autodetect_mcp_source/comment_69_file_source_single_snapshot.md
@@ -1,0 +1,11 @@
+# P69 - Keep file-source saves on one file snapshot
+
+In `vscode-extension/src/commands.ts:507` (`writeMcpJsonFromSettings`), a file-source save
+reads only `servers.wcli0` up front (before the env/comment warning modals), but the
+function later rereads the whole file and treats `FileNotFound` as a fresh file. If the user
+or another editor deletes or recreates `.vscode/mcp.json` while a modal is open, the save
+still merges from the stale up-front entry and writes a new file containing only
+`servers.wcli0`, dropping every other server that was present in the originally loaded file.
+The save must use one full-file snapshot for both the merge base and `existing.servers` (or
+abort when the loaded file disappears during a file-source save) so a concurrent
+delete/recreate cannot silently drop the other servers.

--- a/docs/tasks/autodetect_mcp_source/comment_6_reject_stale_file_saves.md
+++ b/docs/tasks/autodetect_mcp_source/comment_6_reject_stale_file_saves.md
@@ -1,0 +1,10 @@
+# P6 - Reject stale file-source saves after workspace changes
+
+If the primary workspace folder changes while a `.vscode/mcp.json` form has unsaved
+edits, `wsSub` clears `currentSource`/`loadedFileSettings`/`loadedFileFolder` and posts
+an external init, but the webview ignores that init while dirty and still sends
+`saveToFile`. The host fallback then overlays the stale form values onto
+`defaultSettings()` and writes them to the new primary folder, which is exactly the
+wrong-folder overwrite the reset is meant to avoid. The host should reject `saveToFile`
+unless it is still in `mcpJson` mode and `loadedFileFolder === folder.uri.fsPath`.
+File: `vscode-extension/src/webview.ts:362`.

--- a/docs/tasks/autodetect_mcp_source/comment_70_preserve_conflicting_safety_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_70_preserve_conflicting_safety_flags.md
@@ -1,0 +1,10 @@
+# P70 - Preserve mutually exclusive safety flags
+
+In `vscode-extension/src/configSource.ts:482` (`parseServerArgs`), a hand-authored stdio
+entry that contains both `--yolo` and `--unsafe` is rejected by the server, which declares
+those options conflicting (`.conflicts('unsafe','yolo')` in `src/index.ts`). The reverse
+parser, however, collapses the pair to whichever flag appears last and drops the other, so a
+no-op or unrelated save turns a previously failing entry into a valid unsafe/yolo launch the
+user never chose. When both positive flags are present the parser must preserve (or refuse)
+the conflicting state — round-tripping both flags verbatim — instead of silently normalizing
+it to a single working safety mode.

--- a/docs/tasks/autodetect_mcp_source/comment_71_preserve_false_safety_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_71_preserve_false_safety_flags.md
@@ -1,0 +1,11 @@
+# P71 - Preserve false safety flags in conflict round-trips
+
+In `vscode-extension/src/configSource.ts:474` (`parseServerArgs`), a loaded stdio entry such
+as `--yolo false --unsafe` or `--no-yolo --unsafe` is still rejected by the server because
+`src/index.ts` declares `.conflicts('unsafe','yolo')` and yargs' conflict check fails whenever
+both keys are defined (yargs-parser sets an explicit boolean `false` for `--yolo false` and
+`--no-yolo`). The `safetyConflict` helper only treats both *positive* flags as a conflict, so
+it counts the false/negated side as absent, models the entry as plain `unsafe`, and a no-op
+save rewrites the args to only `--unsafe` — silently turning a previously rejected hand-authored
+launch into a valid unsafe launch. The conflict must be detected whenever both safety keys are
+present in any form, and all safety-family tokens must round-trip verbatim.

--- a/docs/tasks/autodetect_mcp_source/comment_72_model_attached_boolean_assignments.md
+++ b/docs/tasks/autodetect_mcp_source/comment_72_model_attached_boolean_assignments.md
@@ -1,0 +1,11 @@
+# P72 - Model attached boolean assignments before saving
+
+In `vscode-extension/src/configSource.ts:591` (`parseServerArgs`), the attached-form branch
+treats a yargs boolean assignment such as `--debug=true` or `--enableTruncation=false` (both
+declared `type:'boolean'` in `src/index.ts`) as an unknown extra arg instead of modeling it.
+The form then shows the option's default value, and if the user changes that same setting the
+builder emits its own flag while the preserved `--debug=false` / `--enableTruncation=false`
+remains later in argv; yargs last-wins lets the stale attached value override the edit, so the
+setting cannot be changed from the form. The parser must model attached boolean assignments
+(`--debug=true/false`, the tri-states, `--allowAllDirs`, and the safety flags) the same way it
+models their bare spellings.

--- a/docs/tasks/autodetect_mcp_source/comment_73_keep_dash_prefixed_paths_attached.md
+++ b/docs/tasks/autodetect_mcp_source/comment_73_keep_dash_prefixed_paths_attached.md
@@ -1,0 +1,11 @@
+# P73 - Keep dash-prefixed file paths attached
+
+In `vscode-extension/src/argsBuilder.ts:368` (`buildServerArgs` via `pathValue`), a file-source
+round-trip preserves a relative path value verbatim, but `buildServerArgs` then emits scalar
+path options as the space-separated `--logDirectory <value>` / `--initialDir <value>` form. If
+the original entry used a valid attached value that starts with a dash, for example
+`--logDirectory=--unsafe` (a directory literally named `--unsafe`), a no-op save rewrites it to
+`--logDirectory --unsafe`; yargs then parses `--unsafe` as a separate safety flag rather than
+the directory name, changing the launch semantics and potentially disabling protections. Scalar
+path options must be emitted with the dash-aware `--opt=value` form (like `pushOption` already
+does for the blocked-list options) so a dash-prefixed value stays attached to its flag.

--- a/docs/tasks/autodetect_mcp_source/comment_74_stop_parsing_after_double_dash.md
+++ b/docs/tasks/autodetect_mcp_source/comment_74_stop_parsing_after_double_dash.md
@@ -1,0 +1,8 @@
+# P74 - Stop parsing args after the `--` separator
+
+In `vscode-extension/src/configSource.ts:520` (`parseServerArgs`), the main loop keeps modeling
+tokens after the `--` options separator as wcli0 flags. yargs-parser treats every token after `--`
+as a positional, not an option, so a plain `node dist/index.js -- --shell cmd` entry is launched
+with `--shell`/`cmd` as positionals, but the reverse parser loads it as `shell=cmd`; a no-op save
+then re-emits an active `--shell cmd`, changing the launch behavior. The parser must preserve `--`
+and the remainder verbatim and stop option parsing.

--- a/docs/tasks/autodetect_mcp_source/comment_75_no_server_suffix_past_double_dash.md
+++ b/docs/tasks/autodetect_mcp_source/comment_75_no_server_suffix_past_double_dash.md
@@ -1,0 +1,9 @@
+# P75 - Do not scan past `--` for a server suffix
+
+In `vscode-extension/src/configSource.ts:327` (`serverFlagSuffixStart`), although
+`isPureServerFlagRun` rejects a candidate suffix that starts with `--`, the loop advances to the
+next token and can treat flags after the separator as wcli0 options. With a direct entry like
+`command: "wcli0", args: ["--", "--debug"]`, yargs-parser leaves `--debug` positional, but the
+reverse parser splits at index 1 and a no-op save enables debug. Once the scan reaches the wcli0
+binary's own `--`, the rest should stay with the launcher/positionals rather than being considered
+a server-flag suffix.

--- a/docs/tasks/autodetect_mcp_source/comment_76_attached_boolean_modeled_suffix.md
+++ b/docs/tasks/autodetect_mcp_source/comment_76_attached_boolean_modeled_suffix.md
@@ -1,0 +1,9 @@
+# P76 - Count attached boolean flags as modeled suffixes
+
+In `vscode-extension/src/configSource.ts:229` (`isRecognizedServerFlag`), for custom wrapper
+entries `requireModeled` only treats attached `--opt=value` tokens as modeled when the flag is in
+`VALUE_OPTIONS`, so boolean forms like `wrapper target --debug=true` or `--enableTruncation=false`
+stay in `customArgs` instead of being parsed. The form then shows the default value and saving an
+attempted change leaves the original attached boolean in the launcher args, so the user cannot
+reliably disable or edit that flag from the loaded file source. The suffix detector must recognize
+attached boolean assignments (literal `=true`/`=false`) just like their bare spellings.

--- a/docs/tasks/autodetect_mcp_source/comment_77_stdio_transport_not_suffix_evidence.md
+++ b/docs/tasks/autodetect_mcp_source/comment_77_stdio_transport_not_suffix_evidence.md
@@ -1,0 +1,10 @@
+# P77 - Do not let stdio transport flags prove a server suffix
+
+In `vscode-extension/src/configSource.ts:274` (`isPureServerFlagRun` / the suffix detector), a stdio
+entry deliberately does not model `--transport`/`--http-*`/`--sse-*` flags (the entry's `type` is
+authoritative), but the suffix detector still treats any `VALUE_OPTIONS` flag as modeled evidence.
+A wrapper command like `wrapper target --transport fast` therefore gets split even though there are
+no editable wcli0 flags; after the user changes any real form field, the regenerated flags are
+inserted before that wrapper option (`target --shell cmd --transport fast`), changing the wrapper
+invocation order. In a stdio context transport flags must not count as modeled evidence of a wcli0
+server suffix.

--- a/docs/tasks/autodetect_mcp_source/comment_78_preserve_duplicate_scalar_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_78_preserve_duplicate_scalar_flags.md
@@ -1,0 +1,10 @@
+# P78 - Preserve duplicate scalar flags instead of last-wins
+
+In `vscode-extension/src/configSource.ts:417` (`parseServerArgs` / `applyValue`), when a loaded
+entry repeats a scalar option this assignment overwrites the earlier value, but yargs parses
+repeated scalars as arrays and the server often handles that very differently. For example,
+`--config a --config b` is not equivalent to `--config b` (config loading treats the array path
+differently), and `--shell cmd --shell bash` is not equivalent to only `bash`; a no-op save
+currently collapses those hand-authored entries to the last value and silently changes launch
+behavior. The parser must detect duplicate scalar options and preserve/refuse them rather than
+modeling them as last-wins.

--- a/docs/tasks/autodetect_mcp_source/comment_79_stop_conflict_scan_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/comment_79_stop_conflict_scan_at_separator.md
@@ -1,0 +1,9 @@
+# P79 - Stop conflict scanning at the option separator
+
+In `vscode-extension/src/configSource.ts:582` (`parseServerArgs`), the `--yolo` / `--unsafe` presence
+scans run over the whole `args` array, so an entry such as `args: ["--unsafe", "--", "--yolo"]` is
+flagged as a safety conflict even though yargs treats the token after the `--` separator as a
+positional and runs the server in unsafe mode; the parser consequently preserves the safety tokens
+verbatim and leaves `safetyMode` at `safe`, so the form misreports the active protection level and
+selecting another safety mode from that form can introduce a real `--yolo`/`--unsafe` conflict the
+server rejects. Both presence scans must be limited to the tokens before the first `--`.

--- a/docs/tasks/autodetect_mcp_source/comment_7_preserve_http_auth_fields.md
+++ b/docs/tasks/autodetect_mcp_source/comment_7_preserve_http_auth_fields.md
@@ -1,0 +1,9 @@
+# P7 - Preserve HTTP/SSE auth fields when saving
+
+For an existing HTTP/SSE `servers.wcli0` entry that uses VS Code-supported fields such
+as `headers` or `oauth`, saving from the file source replaces the whole entry with only
+`{ type, url }`, dropping the authentication/configuration metadata even when the user
+edits an unrelated form field. The remote MCP server can then stop connecting after a
+load/save round trip. The write path should merge the generated fields into the loaded
+entry instead of reconstructing it from scratch.
+File: `vscode-extension/src/commands.ts:354`.

--- a/docs/tasks/autodetect_mcp_source/comment_80_preserve_concurrent_modeled_args.md
+++ b/docs/tasks/autodetect_mcp_source/comment_80_preserve_concurrent_modeled_args.md
@@ -1,0 +1,9 @@
+# P80 - Preserve concurrent changes to unchanged modeled arguments
+
+In `vscode-extension/src/commands.ts:677` (`writeMcpJsonFromSettings`), a file-source save re-derives
+only the uneditable argv fields from the current on-disk entry and spreads the stale form-derived
+`settings` for everything else, so when `.vscode/mcp.json` changes after the panel loads -- another
+editor changing `--shell cmd` to `--shell bash` while the user changes only Debug -- `buildLaunchSpec`
+replaces the entire `args` array and silently restores the old shell. Unchanged modeled fields must be
+based on the current parsed entry (overlaying only the submitted form changes), or the stale save must
+be rejected.

--- a/docs/tasks/autodetect_mcp_source/comment_81_reject_host_port_edits_for_opaque_urls.md
+++ b/docs/tasks/autodetect_mcp_source/comment_81_reject_host_port_edits_for_opaque_urls.md
@@ -1,0 +1,8 @@
+# P81 - Reject host and port edits for opaque transport URLs
+
+In `vscode-extension/src/commands.ts:251` (`preservedFileUrl`), a loaded HTTP/SSE entry whose URL is
+opaque -- such as `unix:///tmp/server.sock#/mcp`, for which `parseHttpUrl` returns undefined -- keeps
+its original URL regardless of the form's host or port, yet those controls remain editable and their
+changes are accepted as network-savable edits, so changing either one reports a successful save while
+writing the original URL back and the subsequent reparse discards the edit. Host/port changes must be
+disabled or rejected for such URLs, or an accepted edit must actually affect the serialized URL.

--- a/docs/tasks/autodetect_mcp_source/comment_82_preserve_npx_install_confirmation.md
+++ b/docs/tasks/autodetect_mcp_source/comment_82_preserve_npx_install_confirmation.md
@@ -1,0 +1,9 @@
+# P82 - Preserve npx's installation confirmation behavior
+
+In `vscode-extension/src/configSource.ts:966` (`parseMcpEntry`), a valid hand-written entry such as
+`command: "npx", args: ["wcli0@1.2.3"]` enters the npx fast path even though it omitted `-y`, but
+`buildLaunchSpec` always rewrites npx launches as `npx -y ...`, so an unrelated Save turns a
+potentially interactive installation into one that automatically accepts the download. The installed
+npm documentation (`docs/content/commands/npx.md`) states that npx prompts before installing and that
+`-y` suppresses this prompt, so the modeled fast path must only be used when `-y` was present, or its
+absence must be preserved explicitly.

--- a/docs/tasks/autodetect_mcp_source/comment_83_stop_wrapper_scan_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/comment_83_stop_wrapper_scan_at_separator.md
@@ -1,0 +1,10 @@
+# P83 - Stop scanning generic wrappers after option separators
+
+In `vscode-extension/src/configSource.ts:363` (`serverFlagSuffixStart`), a custom launch whose `--`
+belongs to the invoked program -- `node --inspect dist/index.js -- --debug` -- keeps the suffix scan
+running past the separator and models `--debug` as an active wcli0 flag, contradicting
+`parseServerArgs`' own separator handling and the yargs usage in `src/index.ts`, where subsequent
+tokens are positional; the form consequently reports Debug as enabled, and newly saved settings such
+as `--shell cmd` are appended after the same separator, report as saved on reload, but remain
+positional and never take effect. The scan must stop at `--` for generic custom commands unless a
+specifically recognized wrapper syntax proves it is a pass-through separator.

--- a/docs/tasks/autodetect_mcp_source/comment_84_keep_dash_prefixed_shell_attached.md
+++ b/docs/tasks/autodetect_mcp_source/comment_84_keep_dash_prefixed_shell_attached.md
@@ -1,0 +1,10 @@
+# P84 - Keep dash-prefixed shell values attached
+
+In `vscode-extension/src/configSource.ts:772` (the attached `--opt=value` path) together with
+`buildServerArgs`, a loaded file entry using an attached shell value that begins with a dash, such as
+`--shell=--unsafe`, is modeled as `shell="--unsafe"` and then rewritten as the two tokens
+`--shell --unsafe`; yargs reads the original as a shell name but the rewritten form as an empty shell
+value plus the active `unsafe` boolean, so a no-op Save can turn a nonfunctional hand-authored launch
+into one with all safety restrictions disabled. The unrepresentable shell value must be
+preserved/refused, or emitted through the same attached-value helper used for the other dash-prefixed
+scalars.

--- a/docs/tasks/autodetect_mcp_source/comment_85_require_nonempty_npx_package.md
+++ b/docs/tasks/autodetect_mcp_source/comment_85_require_nonempty_npx_package.md
@@ -1,0 +1,9 @@
+# P85 - Require a nonempty package for the npx fast path
+
+In `vscode-extension/src/configSource.ts:981` (`parseMcpEntry`), an entry with `command: "npx"` and
+`args: ["-y"]` (or `args: ["-y", ""]`) still selects the modeled npx launch even though no package was
+authored; the installed `npx --help` requires a package or an explicit call, while `buildLaunchSpec`
+substitutes an empty `packageSpec` with `wcli0@latest`, so a no-op Save changes the original
+incomplete npx invocation into an automatic installation and execution of wcli0. Missing or empty
+package tokens must be treated as a custom launch, or the save must be refused, instead of applying
+the settings-only fallback.

--- a/docs/tasks/autodetect_mcp_source/comment_86_strip_bom_before_parsing_jsonc.md
+++ b/docs/tasks/autodetect_mcp_source/comment_86_strip_bom_before_parsing_jsonc.md
@@ -1,0 +1,8 @@
+# P86 - Strip UTF-8 BOMs before parsing detected JSONC
+
+In `vscode-extension/src/configSource.ts:68` (`detectWorkspaceMcpJson`), a `.vscode/mcp.json` saved
+with VS Code's UTF-8-with-BOM encoding keeps its leading `U+FEFF` through `Buffer.toString('utf8')`,
+and the home-grown `parseJsonc` passes it to `JSON.parse`, which throws; the catch then reports the
+file as having no detectable wcli0 entry, and `readWcli0Entry` fails the same way, so the new
+load/edit feature is unavailable for an otherwise VS Code-readable JSONC file. A leading BOM must be
+removed before parsing, preferably centrally in that parser.

--- a/docs/tasks/autodetect_mcp_source/comment_87_model_every_attached_boolean.md
+++ b/docs/tasks/autodetect_mcp_source/comment_87_model_every_attached_boolean.md
@@ -1,0 +1,10 @@
+# P87 - Model every attached boolean assignment
+
+In `vscode-extension/src/configSource.ts:770` (the attached `--opt=value` path in
+`parseServerArgs`), a loaded stdio entry using another yargs-valid attached value such as `--debug=0`
+or `--enableTruncation=0` has its token preserved in `extraArgs` instead of being modeled; the
+installed yargs parser's `processValue` maps every string other than exactly `"true"` to `false`
+(`node_modules/yargs-parser/build/lib/yargs-parser.js:566-570`), so enabling the field later emits
+`--debug` before the preserved `--debug=0` and the later false value still defeats the edit. These
+assignments must be modeled according to yargs semantics, or the preserved assignment must be
+stripped when that boolean is emitted.

--- a/docs/tasks/autodetect_mcp_source/comment_88_refuse_network_entry_without_url.md
+++ b/docs/tasks/autodetect_mcp_source/comment_88_refuse_network_entry_without_url.md
@@ -1,0 +1,8 @@
+# P88 - Refuse network entries without a usable URL
+
+In `vscode-extension/src/commands.ts:807` (the http/sse branch of `writeMcpJsonFromSettings`), a
+loaded `http`/`sse` entry with no string `url` -- `{ "type": "http" }` or `url: ""` -- has no URL to
+preserve, so the canonical fallback silently writes `http://127.0.0.1:9444/mcp` (or `/sse`) on an
+otherwise no-op Save, turning an invalid or intentionally incomplete entry into a live local endpoint
+without the user editing host or port. A file-source save must reject the missing URL or preserve the
+original invalid state rather than manufacturing the defaults.

--- a/docs/tasks/autodetect_mcp_source/comment_89_clear_safety_mode_on_later_false.md
+++ b/docs/tasks/autodetect_mcp_source/comment_89_clear_safety_mode_on_later_false.md
@@ -1,0 +1,8 @@
+# P89 - Clear a prior safety mode when a later value is false
+
+In `vscode-extension/src/configSource.ts:711` (`parseServerArgs`), when the same safety option occurs
+more than once a later false value never resets the mode an earlier occurrence set: yargs parses
+`--unsafe --unsafe=false` as `unsafe: false`, so the server keeps its safety protections, but this
+parser produces `safetyMode: 'unsafe'` and a no-op file save rewrites the arguments to only
+`--unsafe`, disabling all protections. `safe` must be assigned when the final `--unsafe` / `--yolo`
+value is false, just as the negated spellings already do.

--- a/docs/tasks/autodetect_mcp_source/comment_8_default_port_url_port_zero.md
+++ b/docs/tasks/autodetect_mcp_source/comment_8_default_port_url_port_zero.md
@@ -1,0 +1,9 @@
+# P8 - Avoid loading default-port URLs as invalid port 0
+
+When a loaded HTTP/SSE URL omits an explicit port (for example
+`https://gateway.example/custom/mcp`), `parseMcpEntry` stores `transportPort` as `0`.
+That value is rendered into the webview's `transport.port` input, which has `min="1"`,
+so `validateNumbers()` blocks Save before the host-side `transportUrl` preservation logic
+can round-trip the URL. Users therefore cannot save an otherwise unchanged default-port
+HTTP/SSE entry.
+File: `vscode-extension/src/configSource.ts:401`.

--- a/docs/tasks/autodetect_mcp_source/comment_90_count_diverted_numeric_duplicates.md
+++ b/docs/tasks/autodetect_mcp_source/comment_90_count_diverted_numeric_duplicates.md
@@ -1,0 +1,10 @@
+# P90 - Count diverted numeric occurrences when detecting duplicates
+
+In `vscode-extension/src/configSource.ts:560` (the duplicate-scalar pre-scan in `parseServerArgs`),
+mixed representable/unrepresentable repeats are excluded from the count: with
+`--commandTimeout bad --commandTimeout 5` yargs produces the array `[NaN, 5]`, which
+`applyCliSecurityOverrides` ignores because it is not a number, yet this pre-scan counts only the
+second occurrence, after which the builder strips the preserved malformed copy and saves only
+`--commandTimeout 5`, changing an otherwise no-op launch. Every syntactically present scalar
+occurrence must be counted for duplicate preservation, even when one value is diverted from the typed
+field.

--- a/docs/tasks/autodetect_mcp_source/comment_91_trim_urls_before_decomposing.md
+++ b/docs/tasks/autodetect_mcp_source/comment_91_trim_urls_before_decomposing.md
@@ -1,0 +1,9 @@
+# P91 - Trim URLs consistently before decomposing them
+
+In `vscode-extension/src/configSource.ts:926` (`parseMcpEntry`), a network entry whose URL has leading
+whitespace, such as `" http://gateway.example:8443/mcp"`, fails to parse and leaves the form showing
+the default host and port, while the save path's `preservedFileUrl` trims the same raw URL before
+parsing it, sees `gateway.example:8443`, and declines preservation because that differs from the
+displayed defaults -- so an otherwise no-op Save rewrites the endpoint to `http://127.0.0.1:9444/mcp`.
+The same trimmed value must be parsed here, or both paths must preserve the original URL using the
+same decomposition rules.

--- a/docs/tasks/autodetect_mcp_source/comment_92_preserve_variable_bearing_urls.md
+++ b/docs/tasks/autodetect_mcp_source/comment_92_preserve_variable_bearing_urls.md
@@ -1,0 +1,10 @@
+# P92 - Preserve variable-bearing network URLs
+
+In `vscode-extension/src/configSource.ts:1119` (`parseHttpUrl`), a valid mcp.json URL using VS Code
+substitution inside its authority, such as `http://${input:host}:8080/mcp` or
+`http://host:${input:port}/mcp`, has the colon inside `${input:...}` treated as the host/port
+delimiter and is reported as having a malformed port; the form then holds a truncated host and the
+default port while `preservedFileUrl` refuses to retain the original URL, so a no-op Save can rewrite
+the first example as `http://${input:9444/mcp`, destroying the launch-time variable and the endpoint.
+These supported VS Code variable tokens must be detected and the URL preserved verbatim when its host
+or port cannot be resolved until launch.

--- a/docs/tasks/autodetect_mcp_source/comment_93_count_negative_numeric_values.md
+++ b/docs/tasks/autodetect_mcp_source/comment_93_count_negative_numeric_values.md
@@ -1,0 +1,9 @@
+# P93 - Count negative numeric values as scalar occurrences
+
+In `vscode-extension/src/configSource.ts:557` (the duplicate-scalar pre-scan), yargs consumes a
+negative numeric token as the value of the preceding number option, but this guard excludes every
+dash-prefixed value: for `--commandTimeout -1 --commandTimeout 5` yargs produces
+`commandTimeout: [-1, 5]`, which the server ignores because it is not a scalar number, yet the
+reverse parser counts only the second occurrence and a no-op save emits `--commandTimeout 5 -1`,
+changing the launch to apply a five-second timeout. Negative numeric tokens must be treated as values
+when counting occurrences of number options.

--- a/docs/tasks/autodetect_mcp_source/comment_94_recognize_all_attached_booleans.md
+++ b/docs/tasks/autodetect_mcp_source/comment_94_recognize_all_attached_booleans.md
@@ -1,0 +1,9 @@
+# P94 - Recognize all attached boolean values in wrapper suffixes
+
+In `vscode-extension/src/configSource.ts:247` (`isRecognizedServerFlag`), `parseServerArgs` now models
+every attached value other than exactly `true` as false, but this suffix detector still recognizes
+only the literals `true` and `false`, so a custom launch such as `wrapper target
+--enableTruncation=0` leaves the flag in `customArgs` and the form displays the server default
+(enabled) even though yargs disables truncation; values such as `yes` behave the same way. Every
+attached assignment for a declared boolean must count as modeled evidence so wrapper-only suffixes
+reach the boolean parser.

--- a/docs/tasks/autodetect_mcp_source/comment_95_single_snapshot_for_file_saves.md
+++ b/docs/tasks/autodetect_mcp_source/comment_95_single_snapshot_for_file_saves.md
@@ -1,0 +1,9 @@
+# P95 - Use the same snapshot for overlaying and writing file edits
+
+In `vscode-extension/src/webview.ts:418` (the `saveToFile` handler), one current entry is read and
+parsed for unchanged modeled fields, but `writeMcpJsonFromSettings` immediately reads the file again
+at `commands.ts:518` and uses that second snapshot as the merge base; if another editor changes a
+modeled argument between those reads -- for example `--shell cmd` to `--shell bash` while this form
+changes only Debug -- the settings passed to the writer still contain `cmd`, so rebuilding `args` onto
+the newer snapshot silently overwrites `bash`. The first full snapshot must be passed into the
+writer, or the save must be rejected if the entry changes before writing.

--- a/docs/tasks/autodetect_mcp_source/comment_96_preserve_explicit_shell_all.md
+++ b/docs/tasks/autodetect_mcp_source/comment_96_preserve_explicit_shell_all.md
@@ -1,0 +1,9 @@
+# P96 - Preserve an explicit `--shell all` argument
+
+In `vscode-extension/src/configSource.ts:135`, a hand-authored entry containing `--shell all` has the
+CLI value mapped onto the form's `all` sentinel, but the forward builder interprets that sentinel as
+"omit `--shell`"; these are not equivalent, because the server enables a shell only when its name
+equals the supplied value, so the explicit CLI value `all` disables every known shell whereas dropping
+the flag restores the configured/default enabled shells. A no-op file save therefore turns an entry
+with no usable shells into one that can execute through all default shells, so the explicit value must
+be preserved verbatim rather than modeled as the omission sentinel.

--- a/docs/tasks/autodetect_mcp_source/comment_97_stop_conflict_stripping_at_separator.md
+++ b/docs/tasks/autodetect_mcp_source/comment_97_stop_conflict_stripping_at_separator.md
@@ -1,0 +1,9 @@
+# P97 - Stop conflict stripping at the option separator
+
+In `vscode-extension/src/argsBuilder.ts:312` (`stripValueFlag`, and likewise `stripConfigArgs` and
+`stripTransportArgs`), the reverse parser now preserves `--` and its remainder, but these conflict
+strippers still scan through that preserved positional region: for `--shell cmd -- --shell bash`
+parsing correctly leaves the second `--shell bash` positional, yet because the modeled shell is
+emitted `stripValueFlag` deletes those positional tokens and a no-op save writes only
+`--shell cmd --`. Each stripper must copy `--` and the entire remainder verbatim without matching
+reserved flags there.

--- a/docs/tasks/autodetect_mcp_source/comment_98_count_valueless_scalar_flags.md
+++ b/docs/tasks/autodetect_mcp_source/comment_98_count_valueless_scalar_flags.md
@@ -1,0 +1,9 @@
+# P98 - Count valueless scalar flags as duplicate occurrences
+
+In `vscode-extension/src/configSource.ts:578` (the duplicate-scalar pre-scan), a scalar occurrence is
+ignored when its next token is another option: for `--shell --debug --shell bash` the installed yargs
+parser used by `src/index.ts` produces `shell: ['', 'bash']`, so the server enables no shell, but this
+parser models only `bash`, preserves the first `--shell`, and the builder later strips that preserved
+token when emitting the modeled value -- a no-op save consequently rewrites the entry to a single
+`--shell bash`, enabling command execution through Bash. The valueless string occurrence must be
+counted so the entire duplicate sequence is preserved.

--- a/docs/tasks/autodetect_mcp_source/comment_99_consume_greedy_array_values.md
+++ b/docs/tasks/autodetect_mcp_source/comment_99_consume_greedy_array_values.md
@@ -1,0 +1,11 @@
+# P99 - Consume every greedy array value
+
+In `vscode-extension/src/configSource.ts:915` (the space-separated value path in `parseServerArgs`),
+an array option followed by multiple values consumes only the first, even though the server marks
+`--blockedCommand`, `--blockedArgument`, `--blockedOperator` and `--allowedDir` as arrays and
+yargs-parser documents that `greedy-arrays` defaults to true and consumes multiple following
+positionals. For example `--blockedCommand rm del --debug` initially blocks both commands, but a
+no-op file save models only `rm`, preserves `del` as `extraArgs`, and rebuilds
+`--blockedCommand rm --debug del`; yargs then treats `del` as positional, silently removing it from
+the blocklist. All consecutive values for array options must be consumed so the save preserves their
+security semantics.

--- a/docs/tasks/autodetect_mcp_source/comment_9_preserve_non_string_env.md
+++ b/docs/tasks/autodetect_mcp_source/comment_9_preserve_non_string_env.md
@@ -1,0 +1,8 @@
+# P9 - Preserve non-string env values on file saves
+
+VS Code MCP entries allow `env` values such as numbers or `null`, but `asStringMap`
+drops every non-string value before the loaded file baseline is stored. If an existing
+stdio entry has `env: { PORT: 3000 }`, an unrelated Save to file rewrites the entry
+without `PORT` and shows no environment prompt because the baseline now appears empty.
+The save path should preserve the raw env values rather than filtering them out.
+File: `vscode-extension/src/configSource.ts:287`.

--- a/docs/tasks/autodetect_mcp_source/implementation_plan.md
+++ b/docs/tasks/autodetect_mcp_source/implementation_plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Auto-detect and load .vscode/mcp.json as an editable configuration source
+
+## Overview
+
+Build the feature in four dependency-ordered phases: a pure source model + reverse parser, then the
+webview UI for the source bar/banner, then the host wiring that loads and saves a file source, then
+integration and documentation. The pure logic lands first so the UI and host phases have a tested
+foundation to call.
+
+```mermaid
+flowchart TB
+    P1["Phase 1: Source model + reverse parser"] --> P2["Phase 2: Webview source bar + messaging"]
+    P1 --> P3["Phase 3: Host load/save wiring"]
+    P2 --> P3
+    P3 --> P4["Phase 4: Integration + docs"]
+```
+
+## Affected Files
+
+| File | Change Type | Description |
+| ---- | ----------- | ----------- |
+| vscode-extension/src/configSource.ts | Create | Source kinds, `detectWorkspaceMcpJson`, `parseServerArgs`, `parseMcpEntry` |
+| vscode-extension/src/argsBuilder.ts | Update | Export small helpers the reverse parser shares (flag tables), if needed |
+| vscode-extension/src/commands.ts | Update | Extract `writeMcpJsonFromSettings`; export `parseJsonc` reuse |
+| vscode-extension/src/webview.ts | Update | Source bar, detection banner, switcher, new message handling, save routing |
+| vscode-extension/src/extension.ts | Update | Pass workspace/context needed for detection; optional `editMcpJson` command |
+| vscode-extension/test/unit/configSource.test.cjs | Create | Detection + reverse-parser + round-trip tests |
+| vscode-extension/test/unit/commands.test.cjs | Update | `writeMcpJsonFromSettings` tests |
+| vscode-extension/test/unit/webview.test.cjs | Update | Source-bar / load / save-to-file / guard tests |
+| vscode-extension/test/integration/mcpJson.test.js | Update | Detect + round-trip with a fixture file |
+| vscode-extension/README.md | Update | Document the source switcher and round trip |
+
+## Phase 1: Source model and reverse parser
+
+### Implementation Work (source model)
+
+- Create `src/configSource.ts`:
+  - `type ConfigSourceKind = 'settings' | 'mcpJson'` and a `ConfigSource` descriptor
+    (`kind`, `uri?`, `label`, `readOnly?`, `pointer?` e.g. `servers.wcli0`).
+  - `detectWorkspaceMcpJson(folder)`: read `${folder}/.vscode/mcp.json` via `vscode.workspace.fs`,
+    parse with `parseJsonc` (imported from `commands.ts`), return `{ uri, hasWcli0 }`; swallow
+    not-found/parse errors into `hasWcli0: false` so detection never throws.
+  - `parseServerArgs(args: string[]): { settings: Partial<Wcli0Settings>; extraArgs: string[] }`: the
+    inverse of `buildServerArgs`. Recognize `--shell`, repeated `--allowedDir`, `--initialDir`,
+    `--commandTimeout`, `--maxCommandLength`, `--wslMountPoint`, `--blockedCommand/Argument/Operator`,
+    `--maxOutputLines`, `--maxReturnLines`, `--enableTruncation` / `--no-enableTruncation`,
+    `--enableLogResources` / `--no-...`, `--logDirectory`, `--allowAllDirs`, `--yolo` / `--unsafe`,
+    `--debug`, `--config`, `--transport` + `--http-host/-port`, `--sse-host/-port`, allowed-origins.
+    Accept both `--opt value` and `--opt=value`. Unknown tokens -> `extraArgs`.
+  - `parseMcpEntry(entry): { settings: Wcli0Settings; notes: string[] }`: infer transport from
+    `entry.type`; for stdio infer launch method from `command` (`npx` + `-y` -> npx/packageSpec;
+    `node` -> node/nodeScriptPath; else custom/customCommand+customArgs); merge `parseServerArgs`
+    output; map `cwd` -> `launch.cwd`, `env` -> `launch.env`; for http/sse derive host/port from the URL.
+    Emit a note when `--config` (or per-shell/profiles) is present and cannot be fully represented.
+
+### Test Work (source model)
+
+- Create `test/unit/configSource.test.cjs`:
+  - Detection: present-with-wcli0, present-without-wcli0, absent, malformed JSON, no workspace.
+  - `parseServerArgs`: each recognized flag, `=`-form, repeated flags, negations, unknown passthrough.
+  - `parseMcpEntry`: npx/node/custom stdio, http and sse URL parsing, `--config` note.
+  - Round trip: for representative settings, `buildLaunchSpec(s)` -> `parseMcpEntry(entry)` reproduces the
+    modeled fields; leftover/unknown flags appear in `extraArgs`.
+
+### Verification (source model)
+
+- `npx tsc --noEmit -p ./` clean.
+- `node --require ./test/stubs/hook.cjs --test test/unit/configSource.test.cjs` passes.
+
+## Phase 2: Webview source bar and messaging
+
+### Implementation Work (source bar)
+
+- In `src/webview.ts` `renderHtml`: add the source bar above the tab nav — active-source chip (kind +
+  path/pointer), a "Switch source" menu, and a detection banner placeholder. Nest the existing
+  `Save to: Workspace / User` radio under the `settings` source; when a file source is active, hide the
+  radio and relabel Save to "Save to file" with a Revert action and a dirty indicator.
+- In the webview script: render `init.source` and `init.detected`; build the switcher menu (Settings,
+  detected `.vscode/mcp.json` tagged when `hasWcli0`, read-only home config as disabled,
+  "New config from current settings" -> existing export, "Open another file..." placeholder); post
+  `selectSource` / `loadSource` and `saveToFile`; track dirty state and request confirmation on a source
+  switch with unsaved edits (reuse the `scopeChangeRequest` round-trip shape).
+
+### Test Work (source bar)
+
+- Update `test/unit/webview.test.cjs`: HTML contains the source bar and banner nodes; given an `init`
+  with a detected wcli0 source the banner is shown; switching to the file source posts `loadSource`;
+  saving a file source posts `saveToFile`; the home config entry is rendered disabled.
+
+### Verification (source bar)
+
+- `npx tsc --noEmit -p ./` clean.
+- `node --require ./test/stubs/hook.cjs --test test/unit/webview.test.cjs` passes.
+
+## Phase 3: Host load and save wiring
+
+### Implementation Work (host wiring)
+
+- In `src/commands.ts`: extract the post-resolution body of `writeWorkspaceMcpJson` into
+  `writeMcpJsonFromSettings(settings, folder, configFileLoadable?)`; have `writeWorkspaceMcpJson` build
+  settings from scope and delegate (no behavior change). The file-source save calls the same function
+  with form-derived settings and must not touch `config.update`.
+- In `src/webview.ts` `setupWebview`: add `currentSource` state next to `currentScope`. On `ready`,
+  detect the workspace mcp.json (`detectWorkspaceMcpJson`) and include `source` + `detected` in the
+  `init` payload. Handle `loadSource` (read the file, `parseMcpEntry`, post an `init` populated from the
+  file, set `currentSource` to the file, surface any notes) and `saveToFile` (collect form values like
+  the `save` path, build a `Wcli0Settings`, call `writeMcpJsonFromSettings`, then mark saved). Reject a
+  read-only/home source as a load or save target. Gate the external `post(true)` reload so it does not
+  overwrite an active file source from settings.
+
+### Test Work (host wiring)
+
+- Update `test/unit/commands.test.cjs`: `writeMcpJsonFromSettings` preserves a second server, refuses a
+  non-object root / non-object `servers`, warns on comments, and never calls `config.update`.
+- Update `test/unit/webview.test.cjs`: `ready` posts detected sources; `loadSource` populates the form
+  from a fake file; `saveToFile` writes via the file writer; home config rejected as a save target;
+  external settings change does not clobber a file source.
+
+### Verification (host wiring)
+
+- `npx tsc --noEmit -p ./` clean.
+- `node --require ./test/stubs/hook.cjs --test test/unit/*.test.cjs` passes.
+
+## Phase 4: Integration and documentation
+
+### Implementation Work (integration and docs)
+
+- Update `test/integration/mcpJson.test.js` (or fixture under `test/integration/fixtures/ws/.vscode/`) to
+  include a `.vscode/mcp.json` with a `servers.wcli0` entry plus a second server, then assert detection
+  and a save-back round trip preserving the second server.
+- Update `README.md`: document the configuration-source switcher, auto-detection of
+  `.vscode/mcp.json`, the `load -> edit -> save` round trip, and that the home config is read-only and
+  side-by-side editing is a future addition.
+
+### Test Work (integration and docs)
+
+- `npx vscode-test` passes including the new detection/round-trip assertions.
+- `npx markdownlint-cli2 "docs/tasks/autodetect_mcp_source/*.md"` passes.
+
+### Verification (integration and docs)
+
+- Full suites green; markdownlint clean; `tsc --noEmit` clean.
+
+## Dependency Graph
+
+```mermaid
+flowchart TB
+    P1["Phase 1"] --> P2["Phase 2"]
+    P1 --> P3["Phase 3"]
+    P2 --> P3
+    P3 --> P4["Phase 4"]
+```
+
+## Estimated Scope
+
+| Phase | Source Files | Test Files | Effort |
+| ----- | ------------ | ---------- | ------ |
+| Phase 1: Source model + reverse parser | 1-2 | 1 | Medium |
+| Phase 2: Webview source bar + messaging | 1 | 1 | Medium |
+| Phase 3: Host load/save wiring | 2 | 2 | Medium |
+| Phase 4: Integration + docs | 2 | 1 | Small |

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -1,0 +1,555 @@
+# Progress: Auto-detect and load .vscode/mcp.json as an editable configuration source
+
+## Status Legend
+
+| Marker | Meaning |
+| ------ | ------- |
+| `[ ]` | Not started |
+| `[x]` | Complete |
+| `[~]` | In progress |
+| `[!]` | Blocked or needs decision |
+| `[-]` | Skipped / not applicable |
+
+## Planning Checklist
+
+- [x] Analyze current behavior.
+- [x] Create analysis.md
+- [x] Create PRD.md
+- [x] Create implementation_plan.md
+- [x] Create verification.md
+- [x] Create progress.md
+
+## Phase 1: Source model and reverse parser
+
+- [x] Create `src/configSource.ts` with source kinds and `ConfigSource` descriptor.
+- [x] Implement `detectWorkspaceMcpJson(folder)` (JSONC-tolerant, never throws).
+- [x] Implement `parseServerArgs(args)` inverse of `buildServerArgs` (=-form, repeated, negations).
+- [x] Implement `parseMcpEntry(entry)` (transport, launch method, cwd/env, notes).
+- [x] Create `test/unit/configSource.test.cjs` (detection, parser, round-trip).
+- [x] `tsc --noEmit` clean; phase tests pass (22 new tests).
+
+## Phase 2: Webview source bar and messaging
+
+- [x] Render the source bar (active-source chip, switcher, detection banner) in `renderHtml`.
+- [x] Nest the scope radio under the settings source; file source shows Save to file / Revert / dirty.
+- [x] Webview script: render `init.source` / `init.detected`, build switcher menu, post messages.
+- [x] Unsaved-changes guard on source switch (reuse `scopeChangeRequest` pattern).
+- [x] Update `test/unit/webview.test.cjs` for source bar / banner / messages.
+- [x] `tsc --noEmit` clean; phase tests pass.
+
+## Phase 3: Host load and save wiring
+
+- [x] Extract `writeMcpJsonFromSettings(settings, folder, ...)` from `writeWorkspaceMcpJson`.
+- [x] `setupWebview`: add `currentSource`; detect on `ready`; include `source`/`detected` in `init`.
+- [x] Handle source switch (read + `parseMcpEntry` + populated `init` + notes).
+- [x] Handle `saveToFile` (overlay form values onto loaded baseline -> file writer; no `config.update`).
+- [x] Reject home/read-only source as a load or save target.
+- [x] Keep external re-post synchronous; refresh detection cache without racing a save (P96).
+- [x] Update `test/unit/commands.test.cjs` and `test/unit/webview.test.cjs`.
+- [x] `tsc --noEmit` clean; full unit suite passes (431).
+
+## Phase 4: Integration and documentation
+
+- [x] Integration test merges the wcli0 entry into an existing file and preserves other servers
+  (the shared `writeMcpJsonFromSettings` save path the file source also uses).
+- [x] Update `test/integration/mcpJson.test.js`; full integration suite passes (16).
+- [x] Update `README.md` (source switcher, auto-detect, round trip, home read-only, side-by-side future).
+- [x] `vscode-test` passes; markdownlint clean.
+
+## Notes
+
+- The webview is the only surface for load/save (no command), so detection/load/save are covered by
+  unit tests against the host message handlers; the integration test covers the shared file-write
+  merge path in a real Extension Host.
+- Deferred (non-requirements, per the PRD): arbitrary file browse, in-place `config.json` editing,
+  and the side-by-side settings/file view.
+
+## Review Feedback
+
+(Section appears when PR review feedback arrives. Each comment gets a checkbox.)
+
+### Review Feedback (PR #89)
+
+- [x] P1: Prevent export actions from persisting file-source edits (fixed — host
+  export handler refuses while `currentSource === 'mcpJson'`; webview disables the
+  export buttons in file mode)
+- [x] P2: Reset file source when the primary folder changes (fixed — track
+  `loadedFileFolder` and reset the file source whenever the primary folder's fsPath
+  no longer matches it)
+- [x] P3: Preserve dash-prefixed custom launcher args (fixed — split custom args at
+  the first recognized wcli0 flag via `isServerFlag`, not the first dash)
+- [x] P4: Clear omitted env from the saved file baseline (fixed — re-baseline
+  `saveToFile` from the entry re-read off disk after writing)
+- [x] P5: Preserve full HTTP/SSE URLs when round-tripping (fixed — preserve the
+  verbatim `transportUrl` and write it back unless host/port were edited; note
+  non-canonical URLs)
+
+### Review Feedback (PR #89, round 2)
+
+- [x] P6: Reject stale file-source saves after workspace changes (fixed — `saveToFile`
+  proceeds only while still in `mcpJson` mode for the same `loadedFileFolder` with the
+  loaded entry intact)
+- [x] P7: Preserve HTTP/SSE auth fields when saving (fixed — merge the regenerated
+  fields onto the loaded raw entry via `mergeEntryOntoBase`, keeping `headers`/`oauth`)
+- [x] P8: Avoid loading default-port URLs as invalid port 0 (fixed — keep the valid
+  default port, preserve the verbatim URL, and note the port field is inert for it)
+- [x] P9: Preserve non-string env values on file saves (fixed — round-trip the loaded
+  entry's raw `env` verbatim instead of the string-filtered settings env)
+- [x] P10: Preserve socket and pipe URLs (fixed — retain the verbatim `transportUrl`
+  when it cannot be decomposed; `preservedFileUrl` writes it back unchanged)
+- [x] P11: Clear stale file-source notes after clean reloads (fixed — carry notes in
+  every file-source `init` and clear them when empty)
+- [x] P12: Preserve stdio-only VS Code fields (fixed — `mergeEntryOntoBase` keeps
+  `envFile`/`dev`/`sandboxEnabled` and removes the opposite mode's keys)
+- [x] P13: Allow VS Code input variables in loaded --config paths (fixed — validate
+  file-source saves with a VS Code-variable `--config` path blanked; emit it verbatim)
+
+### Review Feedback (PR #89, round 3)
+
+- [x] P14: Preserve node runtime arguments (fixed — gate the node fast path on a
+  non-option first arg; node-with-options parses as custom)
+- [x] P15: Avoid stealing wrapper options that look like server flags (fixed — split
+  custom args at the start of the longest pure server-flag suffix)
+- [x] P16: Re-post source detection after workspace changes (fixed — push a dedicated
+  `detected` message after the async detection refresh)
+- [x] P17: Preserve npx launcher options (fixed — gate the npx fast path on a
+  non-option package token; npx-with-options parses as custom)
+- [x] P18: Allow VS Code variables in all file-source launch fields (fixed —
+  `neutralizeVscodeVariableLaunchFields` bypasses validation for every preserved field)
+- [x] P19: Drop stale transport-only fields on mode changes (fixed — remove the other
+  transport's full field set, including `headers`/`oauth` and `envFile`/`dev`)
+- [x] P20: Merge against the current on-disk entry before saving (fixed — re-derive the
+  merge base from the re-read entry so external additions survive)
+- [x] P21: Parse URL userinfo before host/port (fixed — `parseHttpUrl` skips an optional
+  `userinfo@` segment)
+
+### Review Feedback (PR #89, round 4)
+
+- [x] P22: Toggle the dirty indicator on edits (fixed — `reflectDirty` toggles `#dirtyMsg`
+  on a dirty file form, hidden on the settings source)
+- [x] P23: Preserve current on-disk env on file saves (fixed — round-trip `env` from the
+  current on-disk entry via `readWcli0Entry`, not the panel snapshot)
+- [x] P24: Parse custom suffixes with valued extraArgs (fixed — `isPureServerFlagRun`
+  consumes a trailing bare token as the value of a valued extraArg)
+- [x] P25: Push source resets through dirty file forms (fixed — host posts a dedicated
+  `sourceReset` message the webview applies even while dirty)
+- [x] P26: Describe the comment handling accurately (fixed — README says commented files
+  are rewritten as plain JSON only after confirmation, not refused)
+
+### Review Feedback (PR #89, round 5)
+
+- [x] P27: Preserve cwd-relative --config when saving file sources (fixed — a
+  `preserveRelativePaths` build option keeps a file source's relative path args and `cwd`
+  verbatim instead of anchoring them to `${workspaceFolder}`)
+- [x] P28: Avoid retargeting dirty file edits to settings (fixed — a settings save whose
+  baseline came from a reset file source is flagged `fromResetFileSource`; the host
+  confirms before writing, and the flag clears on any re-baseline)
+- [x] P29: Refuse file-source shell/profile edits that cannot be saved (fixed —
+  `writeMcpJsonFromSettings` refuses a file-source save carrying `wcli0.shells` /
+  `wcli0.profiles`, which the entry cannot persist, instead of dropping them on reparse)
+
+### Review Feedback (PR #89, round 6)
+
+P30-P38 were found by re-auditing the round trip; P39-P42 are the matching
+unresolved Codex review threads (P39 is the same root issue as P36). Each has an
+`analysis_N_*.md` + `comment_N_*.md` pair in this folder.
+
+Note: a concurrent session landed its own round-6 commits on the branch first
+(the hoisted refusal with `hasRawPerShellConfig`/`hasRawProfilesConfig` for
+P35/P36/P39, the http/sse non-transport tab lock, the `parseHttpUrl`
+port-`undefined` distinction, and the index-0 wrapper-flag guard). This batch was
+rebased on top of that work, so the entries below reflect the MERGED state: some
+were satisfied by the prior commits and the rest are added here.
+
+- [x] P30: Transport flags in a stdio entry's args flip the type and delete
+  command/args on save (fixed — `parseServerArgs` takes a `stdio` option that
+  routes `--transport`/`--http-*`/`--sse-*` to `extraArgs` so the authoritative
+  `type` wins and the flags round-trip verbatim)
+- [x] P31: An unrecognized transport `type` is silently rewritten to stdio
+  (fixed — `type` is matched case-insensitively; an unrecognized non-empty type
+  is noted rather than silently coerced)
+- [x] P32: The short-form `-c`/`--c` config alias is not recognized on load
+  (fixed — the alias forms are added to the reverse parser's option table,
+  matching the forward `stripConfigArgs`)
+- [x] P33: Non-string `args` elements are coerced to empty string (fixed — args
+  are stringified via `String()` like node's spawn, so a numeric arg survives)
+- [x] P34: An invalid numeric flag value blocks every save (fixed — an
+  unparseable numeric value falls through to `extraArgs` instead of poisoning the
+  typed field)
+- [x] P35: The P29 refusal is nested in the stdio branch (fixed by the prior
+  round-6 commit — the file-source refusal is hoisted above the stdio/http split
+  so http/sse sources are covered)
+- [x] P36: The ignore-inherited masks bypass P29 on a file source (fixed by the
+  prior round-6 commit — the hoisted gate uses `hasRawPerShellConfig` /
+  `hasRawProfilesConfig`, which ignore the masks, so a mask cannot suppress the
+  refusal)
+- [x] P37: TOCTOU — env and merge base from two file reads (addressed — the
+  on-disk entry is read once up front and reused for the env round-trip, the
+  uneditable-argv carry-forward, and URL preservation, removing the separate
+  pre-modal env read)
+- [x] P38: `sourceReset` unconditionally arms the P28 flag (fixed — the flag is
+  armed only when the form is still dirty, so a clean re-baseline is not falsely
+  flagged)
+- [x] P39: Don't report inherited-mask edits as saved to mcp.json (fixed by the
+  same `hasRaw*` refusal as P36 — a mask edit on a file source is blocked rather
+  than misreported as saved)
+- [x] P40: Preserve current uneditable argv settings on file saves (fixed —
+  extends the prior commit's `extraArgs`-only carry-forward to ALL uneditable
+  argv fields: customArgs, blocked lists, `--maxReturnLines`, allowed-origins)
+- [x] P41: Preserve current custom URLs on file saves (fixed — URL preservation
+  uses the current on-disk entry read up front, so a concurrent URL edit survives
+  when its modeled host/port still match)
+- [x] P42: Parse modeled flags before multiple valued extras (fixed —
+  `isPureServerFlagRun` lets every unknown `--flag` consume one following value
+  once the modeled portion has begun, so a suffix with several `--unknown value`
+  pairs no longer hides the modeled flags)
+
+### Review Feedback (PR #89, round 7)
+
+P43-P48 are the unresolved Codex review threads from the round-6 re-review. Each
+has an `analysis_N_*.md` + `comment_N_*.md` pair in this folder.
+
+- [x] P43: Keep scanning after ambiguous launcher-only flags (fixed —
+  `serverFlagSuffixStart` takes `allowIndexZero` and skips index 0 for non-wcli0
+  commands, so a wrapper flag before the modeled flags no longer strands the
+  server suffix in `customArgs`)
+- [x] P44: Don't consume another flag as a missing option value (fixed — the
+  space-separated value path consumes the next token only when it is not another
+  flag, so `--blockedCommand --debug` preserves both instead of swallowing
+  `--debug`)
+- [x] P45: Parse bundled config aliases as configFile (fixed — `parseServerArgs`
+  handles single-dash bundles carrying the `c` alias, e.g. `-c/other.json` /
+  `-xc /other.json`, mirroring the forward `stripConfigArgs`)
+- [x] P46: Merge from a single file snapshot (fixed — the write-step merge base
+  is the same up-front on-disk read used for env/argv/url preservation, so a
+  concurrent edit cannot pair a fresh base with stale generated env/args)
+- [x] P47: Recognize yargs kebab-case option aliases (fixed — kebab-case aliases
+  for the modeled camelCase value options and boolean flags are added to the
+  reverse parser tables, so `--max-command-length` etc. are modeled, not hidden)
+- [x] P48: Compare file source transport types case-insensitively (fixed —
+  `preservedFileUrl` lowercases `base.type` before comparing, so a no-op save of
+  an uppercase `HTTP`/`SSE` entry preserves its URL instead of rebuilding it)
+
+### Review Feedback (PR #89, round 8)
+
+P49-P54 are the unresolved Codex review threads from the round-7 re-review. Each
+has an `analysis_N_*.md` + `comment_N_*.md` pair in this folder.
+
+- [x] P49: Disable settings-only masks for file sources (fixed —
+  `applyScopeAvailability` disables `ignoreInheritedShells`/`ignoreInheritedProfiles`
+  on any file source, and `writeMcpJsonFromSettings` refuses a file save carrying a
+  non-default mask, so a stdio file source can no longer "Save" a dropped mask edit)
+- [x] P50: Treat oversized URL ports as invalid (fixed — `parseMcpEntry` gates the
+  fully-modeled branch on `1..65535`, so a `:70000` URL falls to the unusable-port
+  recovery like `:0` instead of stranding the form's number input)
+- [x] P51: Preserve stdio transport flags on file saves (fixed — a new
+  `preserveExtraTransport` build option skips the stdio `--transport` strip for a
+  file-source round-trip when no `--config` is emitted, so a hand-authored
+  `--transport http` and its companion `--http-*` args round-trip verbatim)
+- [x] P52: Refuse saves for unknown transport types (fixed —
+  `writeMcpJsonFromSettings` refuses a file save when the merge-base entry's `type`
+  is not stdio/http/sse, so a `websocket` entry is not silently normalized to stdio)
+- [x] P53: Preserve current wslMountPoint on file saves (fixed — `wslMountPoint` is
+  added to the on-disk uneditable-argv carry-forward, so an externally changed
+  `--wslMountPoint` survives an unrelated save instead of reverting to the stale load)
+- [x] P54: Reject all profile edits for file sources (fixed — the file-source guard
+  gates on any non-empty `settings.profiles` instead of only launch-meaningful ones,
+  so a non-emittable profile is refused rather than reported Saved and dropped)
+- [x] P55: Refuse stale edits before locking network file fields (fixed — the
+  `saveToFile` handler refuses a file save when the transport mode is http/sse and
+  `collectChanged()` carries any non-transport key, so a safety/config/launch edit made
+  while the entry was stdio is no longer dropped behind a misleading Saved)
+- [x] P56: Keep unknown-only suffix flags with wrapper args (fixed —
+  `serverFlagSuffixStart` now requires a modeled wcli0 flag in a non-wcli0 wrapper
+  suffix, so `wrapper target --verbose` keeps `--verbose` in customArgs instead of
+  reordering it after the generated server flags on save)
+
+### Review Feedback (PR #89, round 10)
+
+P57-P60 were found by an exhaustive multi-agent re-audit of the load -> edit ->
+save round trip (five finders across the parser / forward-builder / save-path /
+webview / url surfaces, each candidate adversarially double-verified for reality
+and novelty against the P1-P56 + P-named baseline, and cross-checked against the
+server's own CLI/config behavior). Each has an `analysis_N_*.md` + `comment_N_*.md`
+pair in this folder. All four are now fixed; each fix's load-bearing claim about the
+server's CLI/config behavior was independently re-verified against `src/utils/config.ts`
+and `src/index.ts`.
+
+- [x] P57: Preserve --allowAllDirs on a file save when --initialDir is set (fixed —
+  `buildServerArgs` emits `--allowAllDirs` whenever the form shows it set on a file-source
+  round trip (`opts.preserveRelativePaths`), so a hand-authored flag survives an unrelated
+  save instead of being dropped; the server applies `--allowAllDirs` before the CLI
+  `--initialDir`, so dropping it had silently re-restricted an unrestricted server. The
+  provider/settings-export paths keep the suppression)
+- [x] P58: Don't strand file saves on a sub-1-second commandTimeout/maxCommandLength
+  (fixed — the `commandTimeout`/`maxCommandLength` number inputs use `min="0"` instead of
+  `min="1"`, so a loaded server-valid `> 0` value passes the client `validateNumbers` guard;
+  the host `validateLaunchSpec` still enforces the per-mode bound (`> 0` CLI / `>= 1`
+  managed), so an actually-invalid value is rejected with a precise message)
+- [x] P59: Don't refuse file saves over an out-of-range CLI log limit (fixed —
+  `parseServerArgs` diverts a finite-but-out-of-range `maxReturnLines`/`maxOutputLines` to
+  `extraArgs` verbatim (`divertNumber`), so it round-trips without poisoning the typed field
+  or tripping `validateLaunchSpec`; `buildServerArgs` strips a duplicate diverted flag via
+  `stripValueFlag` when it emits the same log limit from the typed field, avoiding a
+  yargs-array hazard for the form-editable `maxOutputLines`)
+- [x] P60: Preserve a user-authored wildcard URL host on a port-only file save (fixed — the
+  file-source URL rebuild uses `fileSourceUrlHost` (the verbatim connect host, IPv6-bracketed)
+  instead of `clientHost`, so editing only the port keeps `0.0.0.0`/`[::]` instead of
+  rewriting it to `127.0.0.1`/`[::1]`; the settings-driven export keeps the `clientHost`
+  bind->connect mapping)
+
+### Review Feedback (PR #89, round 11)
+
+P61-P62 are round-11 Codex review comments on the load -> edit -> save round trip. Each has
+an `analysis_N_*.md` + `comment_N_*.md` pair in this folder. The P62 fix's load-bearing claim
+about yargs short-bundle parsing was verified empirically against the installed yargs-parser.
+
+- [x] P61: Strip preserved value flags when replacing them (fixed — `buildServerArgs` now
+  strips from `extraArgs` every modeled SCALAR value flag it emits from a typed field
+  (`--shell`, `--initialDir`, `--commandTimeout`, `--maxCommandLength`, `--wslMountPoint`,
+  `--maxOutputLines`, `--maxReturnLines`, `--logDirectory`, and the emitted transport
+  host/port/origin), not just the two log-limit lines. The parser diverts a malformed modeled
+  value (`--commandTimeout bad`, `--logDirectory --debug`) verbatim into `extraArgs`, so once
+  the field is set the form value wins instead of yargs merging duplicates into an array the
+  server's `applyCli*` helpers apply none of. Each strip is guarded by the emit condition so an
+  UNSET field still round-trips its preserved value; array options stay exempt)
+- [x] P62: Don't fabricate config paths from short bundles (fixed — `parseServerArgs` models a
+  single-dash `-c<remainder>` bundle as `configFile` only in the shapes yargs actually reads as
+  the config string (a fully numeric remainder, or a non-word non-dot path char with at least
+  one more char), via the new `yargsBundleConfigValue` helper. A word-character bundle like
+  `-cfoo`/`-cX` — which yargs parses as separate short boolean flags, leaving config empty — is
+  preserved verbatim in `extraArgs` instead of fabricating a path a no-op save would emit as
+  `--config <value>`. The P45 path cases still resolve)
+
+### Review Feedback (PR #89, round 12)
+
+P63-P66 are round-12 Codex review comments on the load -> edit -> save round trip, all about
+yargs negation/limit forms a loaded `.vscode/mcp.json` may carry. Each has an
+`analysis_N_*.md` + `comment_N_*.md` pair in this folder.
+
+- [x] P63: Consume negated boolean flags before preserving extras (fixed — `parseServerArgs`
+  now models the server's boolean negations (`--no-allowAllDirs`/`--no-allow-all-dirs`,
+  `--no-debug`, `--no-yolo`, `--no-unsafe`) instead of letting them fall through to `extraArgs`,
+  where a preserved `--no-debug` survived a save and yargs collapsed `--debug --no-debug` to
+  `debug: false`, dropping the user's edit. `allowAllDirs`/`debug` are set false; `--no-yolo`/
+  `--no-unsafe` clear `safetyMode` only when it matches, mirroring yargs last-wins without
+  clobbering an independent `--unsafe`. The tokens were added to `BOOLEAN_FLAGS` so the suffix
+  detector treats them like their positive forms)
+- [x] P64: Preserve ignored security-limit values instead of blocking saves (fixed —
+  `divertNumber` now diverts a non-positive `commandTimeout`/`maxCommandLength` to `extraArgs`
+  like the other unrepresentable numerics. The server ignores such a value and runs on its
+  default, but the form's number input rejects a negative and `validateLaunchSpec` blocks any
+  value <= 0, so modeling a loaded `--commandTimeout 0`/`--maxCommandLength=-1` stranded every
+  save; preserving it lets an unrelated edit round-trip the entry)
+- [x] P65: Strip negated scalar aliases when replacing preserved flags (fixed — `stripValueFlag`
+  now also drops the yargs negation of each scalar option it strips (`--no-shell`,
+  `--no-logDirectory`, `--no-commandTimeout`, ...). A loaded negation that survived made yargs
+  parse the option as an array (`shell: ['cmd', false]`) the server's scalar `applyCli*` helpers
+  apply none of; the strip is guarded by the same emit condition, so an UNSET field still
+  round-trips its preserved negation)
+- [x] P66: Reject non-numeric URL ports instead of treating them as omitted (fixed —
+  `parseHttpUrl` now captures an explicit port token even when malformed and reports `:abc`/`:-1`
+  as `NaN` (distinct from an omitted `undefined`). That routes a malformed-port URL through the
+  existing unusable-port branch — host modeled, default port kept, canonical URL rebuilt on save
+  from the editable port field — instead of preserving it verbatim as a default-port URL a port
+  edit could never fix. The port group stops at `/?#` so a valid numeric port is still read)
+
+### Review Feedback (PR #89, round 13)
+
+P67-P70 are round-13 Codex review comments on the load -> edit -> save round trip. Each has an
+`analysis_N_*.md` + `comment_N_*.md` pair in this folder.
+
+- [x] P67: Rebuild default-port URLs when the port changes (fixed — `preservedFileUrl`'s
+  default-port branch now preserves the verbatim URL only while the host is unchanged AND the
+  port field is still the form default (`defaultSettings().transportPort`). A port-only edit
+  therefore rebuilds the canonical `http://host:port/<mcp|sse>` URL instead of writing the
+  original back unchanged and dropping the edit on the next reparse. The `parseMcpEntry` note
+  was updated from "the port field does not affect it" to "editing the host or port rewrites it")
+- [x] P68: Honor explicit false values for boolean flags (fixed — `parseServerArgs` now consumes
+  a following bare `true`/`false` for every positive boolean/tri-state/safety flag, matching
+  yargs (`--debug false` => debug=false), instead of recording the flag as true and stranding
+  `false` in `extraArgs` where the form showed the opposite of what the server runs. Only an
+  exact `true`/`false` is consumed; any other following token stays a positional and the flag
+  reads true. The `--no-*` spellings are unchanged (they already mean false and consume nothing))
+- [x] P69: Keep file-source saves on one file snapshot (fixed — a file-source save now takes one
+  full-file snapshot up front via the new `readExistingMcpJson` helper and reuses it for the
+  merge base, the surrounding servers, and the comment-removal check. A concurrent
+  delete/recreate of `.vscode/mcp.json` during a warning modal can no longer make the write
+  start fresh and drop the file's other servers. The settings-driven export keeps its single
+  bottom read, so its behavior is unchanged)
+- [x] P70: Preserve mutually exclusive safety flags (fixed — when a loaded entry sets BOTH
+  `--yolo` and `--unsafe` (which the server rejects via `.conflicts`), `parseServerArgs` now
+  preserves both verbatim in `extraArgs` and leaves `safetyMode` at its default instead of
+  collapsing to whichever appears last. A no-op save therefore reproduces the same
+  server-rejected entry rather than silently turning it into a valid yolo/unsafe launch.
+  Conflict detection mirrors yargs last-wins, so a trailing `--no-yolo` or `--yolo false`
+  is not counted as positive)
+
+### Review Feedback (PR #89, round 14)
+
+P71-P73 are round-14 Codex review comments on the load -> edit -> save round trip. Each has an
+`analysis_N_*.md` + `comment_N_*.md` pair in this folder. P71 corrects the conflict semantics
+that the round-13 P70 fix modeled incorrectly (verified against the project's yargs).
+
+- [x] P71: Preserve false/negated safety flags in conflict round-trips (fixed — the server's
+  `.conflicts('unsafe','yolo')` rejects an entry whenever BOTH keys are defined, not just both
+  positive: `--yolo false --unsafe`, `--no-yolo --unsafe`, `--yolo=false --unsafe`, and even
+  `--no-yolo --no-unsafe` are all rejected (verified against yargs). `parseServerArgs` now detects
+  the conflict by presence of both families in any form and round-trips every safety token
+  verbatim — bare positives, consumed `true`/`false` values, `--no-*` negations, and attached
+  `--yolo=…` forms — leaving `safetyMode` at default so a no-op save reproduces the rejected entry
+  instead of collapsing it to a valid single-mode launch. The P63/P70 tests that asserted the old
+  last-wins behavior were corrected)
+- [x] P72: Model attached boolean assignments (fixed — the attached-form branch now models a yargs
+  boolean assignment such as `--debug=true` / `--enableTruncation=false` via the new
+  `applyAttachedBoolean` helper, instead of dumping it to `extraArgs` where the form showed the
+  default and a stale `--debug=false` later in argv defeated the user's edit. Safety flags are
+  modeled only when there is no conflict; a non-`true`/`false` attached value is still preserved
+  verbatim)
+- [x] P73: Keep dash-prefixed scalar path values attached (fixed — `buildServerArgs` now emits the
+  scalar path options `--config`/`--allowedDir`/`--initialDir`/`--logDirectory`/`--wslMountPoint`
+  through `pushOption`, so a dash-prefixed value such as a directory named `--unsafe` stays
+  attached as `--logDirectory=--unsafe` instead of being re-emitted space-separated and parsed by
+  yargs as a separate safety flag. Non-dash values are emitted unchanged)
+
+### Review Feedback (PR #89, round 15)
+
+P74-P78 are round-15 Codex review comments on the load -> edit -> save round trip, all in
+`vscode-extension/src/configSource.ts`. Each has an `analysis_N_*.md` + `comment_N_*.md` pair in
+this folder. P74/P75 close two faces of the `--` options separator; P76/P77 correct what the
+wrapper suffix detector counts as a modeled wcli0 flag; P78 stops collapsing repeated scalar
+options. All verified against the project's yargs semantics and covered by new unit tests.
+
+- [x] P74: Stop parsing args after the `--` separator (fixed — `parseServerArgs` now preserves `--`
+  and the entire remainder verbatim in `extraArgs` and stops parsing, so a `node script.js -- --shell
+  cmd` entry is not loaded as `shell=cmd` and a no-op save does not promote the positionals to active
+  flags)
+- [x] P75: Do not scan past `--` for a server suffix (fixed — `serverFlagSuffixStart` stops the scan
+  at the wcli0 binary's own `--`, so `command:"wcli0", args:["--","--debug"]` keeps `--debug` as a
+  positional in `customArgs`. Scoped to `allowIndexZero`: a wrapper's `--` is a pass-through
+  separator and the wrapped binary's flags still follow it, preserving the P17 npx case)
+- [x] P76: Count attached boolean flags as modeled suffixes (fixed — `isRecognizedServerFlag` now
+  recognizes an attached boolean assignment `--debug=true` / `--enableTruncation=false` as a modeled
+  wcli0 flag, so a wrapper suffix carrying only such a flag is detected and stays editable instead of
+  being stranded in `customArgs`. Restricted to literal `true`/`false`, matching the parser)
+- [x] P77: Do not let stdio transport flags prove a server suffix (fixed — a `stdio` flag threads
+  through `serverFlagSuffixStart`/`isPureServerFlagRun`/`isRecognizedServerFlag`; in stdio context a
+  transport flag consumes its value but does not count as modeled evidence, so `wrapper target
+  --transport fast` stays whole in `customArgs` and is not reordered on save. A suffix with a real
+  wcli0 flag still splits)
+- [x] P78: Preserve duplicate scalar flags instead of last-wins (fixed — a `duplicatedScalarKeys`
+  pre-scan flags any scalar option that appears twice, and each occurrence is then preserved verbatim
+  in `extraArgs` instead of collapsed, so `--config a --config b` / `--shell cmd --shell bash`
+  round-trip as the arrays yargs produces. Array-kind options and single occurrences are unaffected)
+- [x] P79: Stop conflict scanning at the option separator (fixed - the `--yolo`/`--unsafe` presence
+  scans now run only over the tokens before the first `--`, matching the parse loop and the
+  duplicate-scalar pre-scan, so `["--unsafe","--","--yolo"]` models the unsafe mode yargs really
+  applies instead of reporting a phantom conflict and showing `safe`. A pair written before the
+  separator is still preserved verbatim)
+- [x] P80: Preserve concurrent changes to unchanged modeled arguments (fixed - a file save now
+  overlays the submitted changed fields onto the CURRENT on-disk entry rather than the panel's load
+  snapshot, so a Debug-only save no longer reverts a `--shell bash` another editor wrote after the
+  load. A concurrent transport-mode switch is refused with a reload message instead of merged)
+- [x] P81: Reject host and port edits for opaque transport URLs (fixed - a file save whose on-disk
+  URL cannot be decomposed by `parseHttpUrl` (`unix:///tmp/server.sock#/mcp`) is refused when the
+  host or port differs from the form default, instead of writing the original URL back and letting
+  the reparse drop the edit behind a "Saved". A mode switch still rebuilds the URL from host/port)
+- [x] P82: Preserve npx's installation confirmation behavior (fixed - the npx fast path now requires
+  the leading `-y`; `npx wcli0@1.2.3` is parsed as a custom command so an unrelated save cannot add
+  `-y` and turn an interactive install into an automatic one. The server flags after the package
+  stay modeled and a parse note explains the custom-command display)
+- [x] P83: Stop scanning generic wrappers after option separators (fixed - the server-flag suffix
+  scan now stops at any `--`, except a wrapper separator followed by the wcli0 binary itself, the one
+  shape that proves a pass-through. `node --inspect dist/index.js -- --debug` keeps the positional
+  `--debug` in `customArgs` instead of modeling it, while the P17 npx case still splits)
+- [x] P84: Keep dash-prefixed shell values attached (fixed - `--shell` now goes through `pushOption`
+  like every other dash-capable scalar, so a loaded `--shell=--unsafe` re-emits attached instead of
+  as `--shell --unsafe`, which yargs would read as an empty shell plus an active unsafe flag. An
+  ordinary shell name still emits as two tokens)
+- [x] P85: Require a nonempty package for the npx fast path (fixed - `npx -y` and `npx -y ""` are
+  parsed as custom launches, so a save no longer substitutes `wcli0@latest` and turns an incomplete
+  invocation into an automatic install-and-run)
+- [x] P86: Strip UTF-8 BOMs before parsing detected JSONC (fixed - `parseJsonc` drops a leading
+  U+FEFF, so detection, entry loading and the save's merge read all work for a file saved as "UTF-8
+  with BOM"; the write path re-attaches the BOM so the file's encoding is not silently changed)
+- [x] P87: Model every attached boolean assignment (fixed - the attached `--opt=value` path now
+  offers EVERY value to `applyAttachedBoolean` with yargs' own coercion (`value === 'true'`), so
+  `--debug=0` / `--enableTruncation=0` are modeled as false instead of preserved in `extraArgs`,
+  where they resolved last-wins over a later "enable" edit and silently defeated it)
+- [x] P88: Refuse network entries without a usable URL (fixed - a file save keeps the url key of an
+  entry that has none exactly as found (absent, empty or non-string) while mode/host/port are
+  untouched, instead of manufacturing `http://127.0.0.1:9444/mcp` on a no-op save. A real host/port
+  edit or a mode switch still writes the rebuilt URL, and a parse note explains the state)
+- [x] P89: Clear a prior safety mode when a later value is false (fixed - both safety branches now
+  follow yargs' last-wins for a repeated boolean, so `--unsafe --unsafe=false` loads as safe and a
+  no-op save no longer re-emits a bare `--unsafe` that disables every protection. Verified against
+  the installed yargs-parser; the reverse order still selects the positive mode)
+- [x] P90: Count diverted numeric occurrences when detecting duplicates (fixed - the duplicate
+  pre-scan counts every syntactically present scalar occurrence, so `--commandTimeout bad
+  --commandTimeout 5` is preserved whole instead of being modeled as 5 with the malformed copy
+  stripped, which changed a launch the server ignored into one that applies 5)
+- [x] P91: Trim URLs consistently before decomposing them (fixed - `parseMcpEntry` trims the entry
+  URL exactly as `preservedFileUrl` does, so `" http://gateway.example:8443/mcp"` shows its real
+  host/port instead of the defaults and a no-op save no longer rewrites the endpoint)
+- [x] P92: Preserve variable-bearing network URLs (fixed - `parseHttpUrl` reports an authority
+  holding a `${...}` token as undecomposable, so `http://${input:host}:8080/mcp` is preserved
+  verbatim like a socket URL instead of being split at the colon inside the variable and rewritten
+  as `http://${input:9444/mcp` on save)
+- [x] P93: Count negative numeric values as scalar occurrences (fixed - a shared `isOptionValue` /
+  `isOptionValueToken` helper encodes yargs' real rule (any non-dash token, or a negative number),
+  so `--commandTimeout -1 --commandTimeout 5` is seen as a duplicate and preserved whole, and a
+  stripped option takes its negative value with it instead of leaving an orphan `-1`)
+- [x] P94: Recognize all attached boolean values in wrapper suffixes (fixed -
+  `isRecognizedServerFlag` accepts any attached assignment for a declared boolean, matching the
+  parser after P87, so `wrapper target --enableTruncation=0` is detected as a server-flag suffix and
+  the form shows truncation disabled instead of the server default)
+- [x] P95: Use the same snapshot for overlaying and writing file edits (fixed - the save handler
+  passes `expectedEntryJson`, the entry its settings were overlaid on, and the writer refuses when
+  its own snapshot differs, so a write landing between the two reads cannot be overwritten by stale
+  modeled fields. Both reads finding no entry still recreates it, as P23 expects)
+- [x] P96: Preserve an explicit `--shell all` argument (P1 - fixed - the CLI value `all` is diverted
+  to `extraArgs` verbatim instead of being modeled as the form's omit sentinel: the server loads
+  only a shell module named "all" (none exists, so no shells are usable) while omitting the flag
+  enables every default shell, so a no-op save no longer opens up an entry that had none. Choosing a
+  real shell in the form still strips the preserved copy and wins)
+- [x] P97: Stop conflict stripping at the option separator (fixed - `stripValueFlag`,
+  `stripConfigArgs` and `stripTransportArgs` copy `--` and its remainder verbatim, so the
+  positionals of `--shell cmd -- --shell bash` survive a save instead of being deleted as duplicate
+  options and written back as a truncated `--shell cmd --`)
+- [x] P98: Count valueless scalar flags as duplicate occurrences (P1 - fixed - the duplicate
+  pre-scan counts a scalar option on PRESENCE rather than only when a value follows, because yargs
+  defines the key either way (`--shell --debug --shell bash` => `['', 'bash']`, no usable shell). The
+  pair is now preserved whole instead of being modeled as `--shell bash`, which a no-op save wrote
+  back and thereby enabled command execution through Bash. A trailing `-c` bundle counts too)
+- [x] P99: Consume every greedy array value (P1 - fixed - an array option now models EVERY
+  following value, matching yargs' greedy-arrays default (`--blockedCommand rm del --debug` =>
+  ['rm','del'], attached form too). Modeling only the first left the rest in `extraArgs`, where the
+  rebuild placed them after the modeled pair and yargs read them as positionals - silently dropping
+  entries from a blocklist or the allowed-directory list. The wrapper-suffix detector consumes them
+  too, so a multi-value array option no longer looks like an orphan)
+- [x] P100: Preserve unsupported shell names (P1 - fixed - `divertShellValue` now models a
+  `--shell` value only when it is one of the five names the form's select offers, so `fish`, `zsh`,
+  `ALL` and `all` are all preserved verbatim. Modeling an unofferable name left the select empty,
+  marked the form dirty and let a save drop `--shell`, re-enabling every default shell on an entry
+  the server had matched to none)
+- [x] P101: Revalidate the file after save-time prompts (P1 - fixed - the save re-reads
+  .vscode/mcp.json immediately before writing and refuses when the bytes differ from the snapshot it
+  serialized, so an edit or delete landing while a modal was open is reported instead of overwritten.
+  This supersedes the write-anyway half of P69/P46, whose guarantees now hold more strictly: nothing
+  is written, so no server is dropped and no stale mix is produced)
+- [x] P102: Match yargs when recognizing negative numeric tokens (fixed - the predicate accepts only
+  the forms the installed parser consumes (`-1`, `-1.5`, `-.5`, `-0`, `-01`), not scientific notation
+  or a trailing dot, so `--shell -1e2` is no longer modeled and rebuilt as `--shell=-1e2`. Also
+  corrects P98 for number options: yargs drops a VALUELESS numeric option entirely, so it is counted
+  as an occurrence only when a value token follows)
+- [x] P103: Preserve empty allowed-directory entries (P1 - fixed - a file save now emits an
+  explicitly empty `--allowedDir ""` verbatim. yargs yields [''] and the server turns
+  restrictWorkingDirectory ON with that empty allowlist (denying every directory), but `pathValue`
+  dropped the blank, so a no-op save removed the restriction and restored the config/default allowed
+  paths. The settings/provider paths still drop blanks, where an empty line is editor noise)
+- [-] P104: Preserve blank allowed-directory rows in the webview (rejected - the client does
+  normalize a blank textarea to `[]`, but `initial = collect()` produces the dirty baseline with the
+  SAME normalization, so the field is never dirty and an unrelated save submits no
+  `allowedDirectories` key at all. Verified by running the shipped webview script: the posted
+  payload is exactly `{"commandTimeout":45}`. Three regression tests added - two client-side, one
+  end-to-end - proving `--allowedDir ""` survives an unrelated save)

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -554,21 +554,33 @@ options. All verified against the project's yargs semantics and covered by new u
   payload is exactly `{"commandTimeout":45}`. Three regression tests added - two client-side, one
   end-to-end - proving `--allowedDir ""` survives an unrelated save)
 
-## Post-merge follow-ups (PR #89 was merged with unresolved threads)
+## Re-land after the bad merge of PR #89
 
-The task-loop's thread query used `reviewThreads(first: 100)` with no pagination while the PR had
-106 threads, so the six newest findings were never returned and the PR was merged over them. They
-are addressed on follow-up branches.
+PR #89 was merged while six Codex threads were still unresolved (one P1, five P2): the task loop's
+query used `reviewThreads(first: 100)` with no pagination while the PR had 106 threads, so the newest
+findings were never returned and every check reported "0 unresolved". #89 was reverted from `main`
+(#92) and is re-landed here with all six fixed.
 
-- [x] P105: Parse direct wcli0 arguments as one server argument list (P1 - fixed - a direct
-  `command: "wcli0"` entry now hands its WHOLE arg list to `parseServerArgs` instead of scanning for
-  a suffix. A positional between a boolean and its negation (`--allowAllDirs marker
-  --no-allowAllDirs`) made the scan split at the wrong place, leaving the enabling flag in
-  `customArgs` and modeling false, so a no-op save wrote `--allowAllDirs marker` and flipped the
-  server to UNRESTRICTED directories. The scan is now wrapper-only and its dead `allowIndexZero`
-  parameter was removed)
-- [ ] P106: Keep valueless scalar flags ahead of following positionals (P2, configSource.ts:969)
-- [ ] P107: Reject delimiters in edited transport hosts (P2, commands.ts:830)
-- [ ] P108: Exclude attached negations from modeled suffix evidence (P2, configSource.ts:249)
-- [ ] P109: Preserve valueless array flags before later positionals (P2, configSource.ts:943)
-- [ ] P110: Reject incompatible concurrent launch-method changes (P2, webview.ts:439)
+- [x] P105: Parse direct wcli0 arguments as one server argument list (P1 - a direct
+  `command: "wcli0"` entry hands its WHOLE arg list to `parseServerArgs` instead of scanning for a
+  suffix. A positional between a boolean and its negation made the scan split at the wrong place,
+  leaving the enabling flag in `customArgs` and modeling false, so a no-op save wrote
+  `--allowAllDirs marker` and flipped the server to UNRESTRICTED directories)
+- [x] P106: Keep valueless scalar flags ahead of following positionals (a preserved valueless value
+  option is re-emitted in the form that cannot capture a following token - `--flag=` for string/csv,
+  dropped for the inert number/array cases, `-<letters> --config=` for a `c` bundle - but only when a
+  real positional follows, so every already-safe shape still round-trips byte-for-byte)
+- [x] P107: Reject delimiters in edited transport hosts (a host carrying `/ ? # @`, whitespace or an
+  embedded port is refused before it is interpolated into the URL, instead of writing
+  `http://gateway.example/api:9444/mcp` and losing the edit on reload. IPv6 literals and preserved
+  verbatim URLs are unaffected)
+- [x] P108: Exclude attached negations from modeled suffix evidence (`--no-debug=false` defines an
+  unrelated `no-debug` key in yargs rather than negating `debug`, so it no longer proves a wrapper
+  server suffix; a bare `--no-debug` still does)
+- [x] P109: Preserve valueless array flags before later positionals (the array half of P106: the
+  inert flag is dropped rather than re-emitted next to a positional, which would have turned the
+  path into an allowed directory and switched restrictWorkingDirectory ON and injection protection
+  OFF)
+- [x] P110: Reject incompatible concurrent launch-method changes (the P80 transport-mode guard one
+  level down: a save carrying a method-specific field is refused when the entry's launch method
+  changed on disk, unless the user is switching the method themselves)

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -593,3 +593,15 @@ findings were never returned and every check reported "0 unresolved". #89 was re
   of P106/P109: the builder re-emits `--allowedDir` / `--blocked*` after the leading run of
   positionals preserved in extraArgs, so `marker --allowedDir C:/trusted` no longer rebuilds into
   two allowed directories - and an edited list is safe too)
+- [x] P113: Track valueless `--init-config` before reordering extras (the server declares it as a
+  string option but the form models no field for it, so the reorder guard never saw it: a valueless
+  occurrence is now recorded and re-emitted as `--init-config=`, which cannot swallow a later
+  positional and make the server write a default config there and exit)
+- [x] P114: Preserve boolean-like positionals before boolean flags (yargs consumes a literal
+  `true`/`false` after a declared boolean as its value, so a generated bare boolean flag standing in
+  front of such a positional preserved in extraArgs is emitted attached as `--flag=true` instead -
+  in the plain append, the P112 array hoist and the managed-config launch)
+- [x] P115: Stop wrapper suffix scanning at a leading separator (the scan started at index 1 and so
+  never saw a `--` at index 0: `node -- wrapper.js --debug` no longer presents the wrapper's own
+  `--debug` as wcli0's Debug setting, while the P17 pass-through and the P-wrapperflags index-0 flag
+  rule are unchanged)

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -584,3 +584,12 @@ findings were never returned and every check reported "0 unresolved". #89 was re
 - [x] P110: Reject incompatible concurrent launch-method changes (the P80 transport-mode guard one
   level down: a save carrying a method-specific field is refused when the entry's launch method
   changed on disk, unless the user is switching the method themselves)
+- [x] P111: Preserve trailing valueless numeric duplicates (yargs drops a valueless number option
+  only while its key is undefined, so `--maxCommandLength 1000000 --maxCommandLength` is the array
+  `[1000000, null]` the server ignores; the pre-scan now counts such a repeat as a duplicate and
+  keeps both tokens verbatim instead of modeling the value and activating the weaker limit on an
+  unrelated save. The leading form of P102 is unchanged)
+- [x] P112: Keep positionals out of rebuilt allowed-directory arrays (the greedy-array counterpart
+  of P106/P109: the builder re-emits `--allowedDir` / `--blocked*` after the leading run of
+  positionals preserved in extraArgs, so `marker --allowedDir C:/trusted` no longer rebuilds into
+  two allowed directories - and an edited list is safe too)

--- a/docs/tasks/autodetect_mcp_source/progress.md
+++ b/docs/tasks/autodetect_mcp_source/progress.md
@@ -553,3 +553,22 @@ options. All verified against the project's yargs semantics and covered by new u
   `allowedDirectories` key at all. Verified by running the shipped webview script: the posted
   payload is exactly `{"commandTimeout":45}`. Three regression tests added - two client-side, one
   end-to-end - proving `--allowedDir ""` survives an unrelated save)
+
+## Post-merge follow-ups (PR #89 was merged with unresolved threads)
+
+The task-loop's thread query used `reviewThreads(first: 100)` with no pagination while the PR had
+106 threads, so the six newest findings were never returned and the PR was merged over them. They
+are addressed on follow-up branches.
+
+- [x] P105: Parse direct wcli0 arguments as one server argument list (P1 - fixed - a direct
+  `command: "wcli0"` entry now hands its WHOLE arg list to `parseServerArgs` instead of scanning for
+  a suffix. A positional between a boolean and its negation (`--allowAllDirs marker
+  --no-allowAllDirs`) made the scan split at the wrong place, leaving the enabling flag in
+  `customArgs` and modeling false, so a no-op save wrote `--allowAllDirs marker` and flipped the
+  server to UNRESTRICTED directories. The scan is now wrapper-only and its dead `allowIndexZero`
+  parameter was removed)
+- [ ] P106: Keep valueless scalar flags ahead of following positionals (P2, configSource.ts:969)
+- [ ] P107: Reject delimiters in edited transport hosts (P2, commands.ts:830)
+- [ ] P108: Exclude attached negations from modeled suffix evidence (P2, configSource.ts:249)
+- [ ] P109: Preserve valueless array flags before later positionals (P2, configSource.ts:943)
+- [ ] P110: Reject incompatible concurrent launch-method changes (P2, webview.ts:439)

--- a/docs/tasks/autodetect_mcp_source/verification.md
+++ b/docs/tasks/autodetect_mcp_source/verification.md
@@ -1,0 +1,84 @@
+# Verification Plan: Auto-detect and load .vscode/mcp.json as an editable configuration source
+
+## Purpose
+
+Verify that the panel detects an existing `.vscode/mcp.json` with a `servers.wcli0` entry, loads it into
+the form, and saves edits back to that file safely, while leaving the existing settings-driven editing and
+one-way export unchanged.
+
+## Pre-Implementation Verification
+
+Run from `vscode-extension/`.
+
+### Existing Tests Pass
+
+```bash
+npx tsc --noEmit -p ./
+node --require ./test/stubs/hook.cjs --test test/unit/*.test.cjs
+npx vscode-test
+```
+
+Expected: all pass (record the current unit + integration counts as the baseline).
+
+### Coverage Baseline (Before)
+
+| Module | Baseline Coverage | After Coverage | Delta |
+| ------ | ----------------- | -------------- | ----- |
+| configSource.ts | -- % | -- % | -- % |
+| argsBuilder.ts | -- % | -- % | -- % |
+| commands.ts | -- % | -- % | -- % |
+| webview.ts | -- % | -- % | -- % |
+
+## Post-Implementation Verification
+
+### Per-Phase Verification
+
+- Phase 1: `configSource.test.cjs` shows detection across present/absent/malformed/no-wcli0/no-workspace;
+  `parseServerArgs` handles `=`-form, repeated flags and negations; `parseMcpEntry` covers npx/node/custom
+  stdio plus http/sse URL parsing; the `buildLaunchSpec -> parseMcpEntry` round trip reproduces modeled
+  fields with unknown flags in `extraArgs`.
+- Phase 2: `webview.test.cjs` shows the source bar and banner render; a detected wcli0 source shows the
+  banner; switching to the file source posts `loadSource`; saving posts `saveToFile`; the home config is
+  rendered disabled.
+- Phase 3: `commands.test.cjs` shows `writeMcpJsonFromSettings` preserves other servers, refuses a
+  non-object root/`servers`, warns on comments, and never calls `config.update`; `webview.test.cjs` shows
+  `ready` posts detected sources, `loadSource` populates the form, `saveToFile` writes via the file
+  writer, the home config is rejected as a save target, and an external settings change does not clobber a
+  file source.
+- Phase 4: `mcpJson.test.js` shows detection and a save-back round trip preserving a second server.
+
+### Linter
+
+```bash
+npx tsc --noEmit -p ./
+npx markdownlint-cli2 "docs/tasks/autodetect_mcp_source/*.md"
+```
+
+Expected: 0 errors.
+
+### Regression Check
+
+```bash
+node --require ./test/stubs/hook.cjs --test test/unit/*.test.cjs
+npx vscode-test
+```
+
+Expected: all previously-passing tests still pass; new tests pass.
+
+## Final Acceptance Verification
+
+The feature can be accepted when all items are true:
+
+- [ ] Opening the panel with a `servers.wcli0` entry in `.vscode/mcp.json` shows the detection banner;
+  without it (or with no workspace) no banner shows and the settings source is active.
+- [ ] "Load & edit" populates every tab from the parsed entry and the source bar shows the file path and
+  `servers.wcli0` pointer.
+- [ ] `buildLaunchSpec(settings) -> parseMcpEntry -> settings` reproduces modeled fields; unmodeled flags
+  survive in `extraArgs`.
+- [ ] With the file source active, Save writes the edited entry back, preserves other `servers.*`, and
+  leaves `wcli0.*` settings untouched.
+- [ ] A malformed or absent `.vscode/mcp.json` does not break detection/the panel and is never overwritten.
+- [ ] `~/.win-cli-mcp/config.json` appears only as a read-only preview and cannot be a save target.
+- [ ] Switching source / loading a file with unsaved edits prompts before discarding.
+- [ ] Settings-scope editing and Export-tab behavior are unchanged with the settings source active.
+- [ ] Unit and integration suites pass; markdownlint passes; `tsc --noEmit` clean.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -28,6 +28,49 @@ you get per-user defaults plus per-project overrides for free — no hand-edited
   first persist the form's current edits to the selected scope, so the generated
   output always matches what you see (no separate "Save settings" click needed).
 
+### Editing an existing `.vscode/mcp.json`
+
+The configuration panel can edit more than VS Code settings. A **configuration
+source** switcher at the top of the panel makes explicit *what* the form is
+editing and *where* **Save** writes:
+
+- **VS Code Settings** (the default) — edits your `wcli0.*` settings at the
+  **User** or **Workspace** scope, exactly as before.
+- **`.vscode/mcp.json`** — edits the `servers.wcli0` entry of the workspace
+  `mcp.json` **file** directly.
+
+When the panel opens, it checks whether the workspace `.vscode/mcp.json` already
+defines a `wcli0` server. If it does, a banner offers a one-click **Load &
+edit**. Loading reverse-maps the entry into the form (launch method, shell,
+allowed directories, limits, transport, …); flags the form does not model are
+preserved verbatim so a save round-trips them. With the file source active,
+**Save to file** writes the edited entry back to `.vscode/mcp.json` — other
+servers in the file are preserved, a non-object or malformed file is refused
+rather than clobbered, a file containing comments is rewritten as plain JSON only
+after you confirm (the comments are removed), and **no `wcli0.*` setting is
+written**. This makes
+*load → edit → save* a first-class path alongside the existing
+*new → export* one.
+
+Loading favours preserving the entry over modelling it: an entry whose launcher
+the form cannot express exactly â€” including `npx <package>` written **without**
+`-y`, which keeps npx's install confirmation the `npx` launch method would
+suppress â€” is shown as a **custom** command so a save re-emits it unchanged,
+while the wcli0 flags after it stay editable. A note in the panel explains each
+such case. Fields the entry cannot store (per-shell config, profiles, and
+host/port edits for a URL like `unix:///tmp/server.sock` that has no host/port)
+are refused with an explanation rather than silently dropped on save. A file
+saved with VS Code's **UTF-8 with BOM** encoding is read normally, and its BOM
+is kept when the entry is written back.
+
+The server's implicit `~/.win-cli-mcp/config.json` is listed in the switcher as
+a **read-only preview** only; it is never an editable or save target. An entry
+that references a `--config` file (so its per-shell settings/profiles live in
+that file) can be edited for the parts the form models, but the referenced
+file's contents are not editable here — edit that file directly. Editing
+arbitrary picked files and the richer `config.json` format, plus a side-by-side
+settings/file view, are planned follow-ups.
+
 ## Configuration model
 
 The server is launched as either:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wcli0-vscode",
-  "version": "0.20260620.2",
+  "version": "0.20260621.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wcli0-vscode",
-      "version": "0.20260620.2",
+      "version": "0.20260621.15",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "wcli0-vscode",
   "displayName": "wcli0 — MCP Server",
   "description": "Configure and run the wcli0 MCP server with simple user- and workspace-level settings.",
-  "version": "0.20260620.2",
+  "version": "0.20260621.15",
   "publisher": "s2005",
   "license": "MIT",
   "engines": {

--- a/vscode-extension/src/argsBuilder.ts
+++ b/vscode-extension/src/argsBuilder.ts
@@ -86,8 +86,10 @@ export function resolvedConfigFilePath(s: Wcli0Settings): string | undefined {
 /**
  * A logging line limit the server requires as an integer in 1..10000. Used for
  * `maxReturnLines`, whose `validateLoggingConfig` check enforces `Number.isInteger`.
+ * Exported so the reverse parser can decide whether a loaded value fits the typed
+ * field or must round-trip verbatim through extraArgs (P59).
  */
-function isValidLogLimit(n: number): boolean {
+export function isValidLogLimit(n: number): boolean {
   return Number.isInteger(n) && n >= 1 && n <= 10000;
 }
 
@@ -95,9 +97,10 @@ function isValidLogLimit(n: number): boolean {
  * The server's `validateLoggingConfig` only enforces the 1..10000 range for
  * `maxOutputLines` (no integer requirement), so a fractional value like 1.5 is
  * accepted. Validate it on that looser constraint to avoid blocking a config the
- * server would run.
+ * server would run. Exported alongside {@link isValidLogLimit} for the parser's
+ * extraArgs round-trip decision (P59).
  */
-function isValidMaxOutputLines(n: number): boolean {
+export function isValidMaxOutputLines(n: number): boolean {
   return n >= 1 && n <= 10000;
 }
 
@@ -121,10 +124,28 @@ export function isServerInvalidLogPath(resolved: string): boolean {
 }
 
 /**
+ * Whether the token following a value-carrying option is consumed by yargs as that option's
+ * VALUE rather than being a new option. Any non-dash token is; so is a dash-prefixed token that
+ * looks like a negative number (verified against yargs-parser: `--commandTimeout -1` => -1,
+ * `--shell -1` => '-1', but `--shell -x` => '' plus a separate `-x` flag). Treating `-1` as a
+ * flag left it behind as an orphan positional when its option was stripped (P93). Mirrors
+ * `isOptionValue` in configSource so the strippers and the parser agree.
+ */
+function isOptionValueToken(next: string | undefined): boolean {
+  if (next === undefined) {
+    return false;
+  }
+  return !next.startsWith('-') || /^-(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]?\d+)?$/i.test(next);
+}
+
+/**
  * Append an option/value pair, using `--option=value` form when the value is
  * dash-prefixed. As separate argv entries, yargs would parse a value like `-e`
- * or `--exec` as a new option and drop it — and an emptied blocked-list option
- * makes the server replace its defaults with nothing, weakening security.
+ * or `--exec` as a new option and drop it — an emptied blocked-list option then
+ * makes the server replace its defaults with nothing (weakening security), and a
+ * scalar path such as a directory literally named `--unsafe` would be read as a
+ * separate safety flag instead of the path, changing the launch semantics (P73).
+ * Used for every value-bearing option whose value can start with a dash.
  */
 function pushOption(args: string[], flag: string, value: string): void {
   if (value.startsWith('-')) {
@@ -145,6 +166,17 @@ export interface BuildOptions {
   resolvePaths?: boolean;
 
   /**
+   * Only meaningful together with `resolvePaths: false`. When true, a plain relative
+   * path-like value (`--config`, `--allowedDir`, `--initialDir`, `--logDirectory`) is
+   * preserved verbatim instead of being anchored to a `${workspaceFolder}` token. Set
+   * when re-saving a loaded `.vscode/mcp.json` source, whose relative args were authored
+   * relative to the entry's own `cwd` and must round-trip unchanged so an unrelated edit
+   * does not retarget them (P27). Left false for a settings-driven export, where relative
+   * path settings are workspace-relative (matching the provider) and get the token.
+   */
+  preserveRelativePaths?: boolean;
+
+  /**
    * When set, the server is launched against this auto-managed config file
    * (`--config <path>`) and the global CLI flags are NOT emitted. Used when the
    * user configures shells individually (`wcli0.shells`), which can only be
@@ -152,6 +184,20 @@ export interface BuildOptions {
    * would conflict with the file's per-shell `enabled`/security settings.
    */
   managedConfigPath?: string;
+
+  /**
+   * When true, a hand-authored `--transport` token kept in `extraArgs` is NOT stripped from a
+   * stdio launch. Set only for a file-source round-trip ("Save to file"), where the entry's
+   * `type: stdio` is authoritative and the user's verbatim argv — including a stray
+   * `--transport http`/`--transport=sse` they wrote alongside `--http-*` options — must survive
+   * an unrelated save rather than being silently dropped (P-fileextratransport). The safety
+   * strip still applies to the provider and settings-export paths, which must never let an
+   * extraArgs `--transport http` turn a stdio registration into a network listener. It is
+   * still stripped here when a `--config` is emitted (the builder also pushes `--transport
+   * stdio`, and two `--transport` tokens yargs-merge into an array the server applies neither
+   * of).
+   */
+  preserveExtraTransport?: boolean;
 }
 
 /**
@@ -167,12 +213,16 @@ function stripTransportArgs(extraArgs: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < extraArgs.length; i++) {
     const a = extraArgs[i];
+    if (a === '--') {
+      out.push(...extraArgs.slice(i)); // positional region: never strip inside it (P97)
+      break;
+    }
     if (a === '--transport') {
       // Drop the flag, and its separate value token ONLY when that token is an
       // actual value rather than another option. yargs parses `--transport --unsafe`
       // as transport="" plus the still-applied `--unsafe`, so blindly consuming the
       // next token would also discard an unrelated following option (see P86).
-      if (i + 1 < extraArgs.length && !extraArgs[i + 1].startsWith('-')) {
+      if (isOptionValueToken(extraArgs[i + 1])) {
         i++;
       }
       continue;
@@ -215,13 +265,17 @@ function stripConfigArgs(extraArgs: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < extraArgs.length; i++) {
     const a = extraArgs[i];
+    if (a === '--') {
+      out.push(...extraArgs.slice(i)); // positional region: never strip inside it (P97)
+      break;
+    }
     // Space-separated forms (drop the flag and, when present, its separate value
     // token). `--c` is the long form yargs also accepts for the single-character `c`
     // alias. Consume the following token only when it is a real value, not another
     // option: yargs parses `--config --debug` as config="" plus the still-applied
     // `--debug`, so blindly consuming it would also discard an unrelated flag (P86).
     if (a === '--config' || a === '-c' || a === '--c') {
-      if (i + 1 < extraArgs.length && !extraArgs[i + 1].startsWith('-')) {
+      if (isOptionValueToken(extraArgs[i + 1])) {
         i++;
       }
       continue;
@@ -245,9 +299,54 @@ function stripConfigArgs(extraArgs: string[]): string[] {
     // real value rather than another option (P86/P88).
     if (a.length > 1 && a[0] === '-' && a[1] !== '-' && a.includes('c')) {
       const cIsLast = a[a.length - 1] === 'c';
-      if (cIsLast && i + 1 < extraArgs.length && !extraArgs[i + 1].startsWith('-')) {
+      if (cIsLast && isOptionValueToken(extraArgs[i + 1])) {
         i++;
       }
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Remove a value-carrying option (and its value) from a raw extraArgs list, matching any of
+ * the given long-flag spellings in `--flag value`, `--flag=value`, and bare `--flag` forms.
+ * Used to drop a log limit the parser diverted into extraArgs (a finite-but-out-of-range
+ * value round-trips verbatim there, P59) once the builder emits the SAME flag from the typed
+ * field: keeping both would make yargs parse the option as an array the server applies none
+ * of. Mirrors the next-token guard in {@link stripTransportArgs} so a following option is not
+ * swallowed as a value.
+ *
+ * The yargs negation of each scalar option (`--no-shell`, `--no-command-timeout`, ...) is
+ * stripped too: a loaded file may carry one in extraArgs (the parser does not model scalar
+ * negations), and emitting the positive flag from the typed field while it survives makes
+ * yargs parse the option as an array — `shell: ['cmd', false]`, `logDirectory: ['/tmp',
+ * false]` — that the server's scalar applyCli* helpers resolve to neither, so the edited value
+ * is ignored or crashes the server. A negation carries no value, so the token is dropped alone
+ * (P65). An UNSET field still round-trips its preserved negation: the strip is guarded by the
+ * same emission condition as the positive flag.
+ */
+function stripValueFlag(extraArgs: string[], names: string[]): string[] {
+  const exact = new Set(names);
+  const negated = new Set(names.map((n) => n.replace(/^--/, '--no-')));
+  const out: string[] = [];
+  for (let i = 0; i < extraArgs.length; i++) {
+    const a = extraArgs[i];
+    if (a === '--') {
+      out.push(...extraArgs.slice(i)); // positional region: never strip inside it (P97)
+      break;
+    }
+    if (exact.has(a)) {
+      if (isOptionValueToken(extraArgs[i + 1])) {
+        i++;
+      }
+      continue;
+    }
+    if (negated.has(a)) {
+      continue; // boolean negation of the same option — no value token to consume
+    }
+    if (names.some((n) => a.startsWith(`${n}=`))) {
       continue;
     }
     out.push(a);
@@ -288,15 +387,26 @@ function pathValue(value: string, opts: BuildOptions): string | undefined {
     if (!trimmed) {
       return undefined;
     }
-    // Convert a plain relative path to a ${workspaceFolder}-relative token so VS
-    // Code anchors it to the workspace, matching the resolved-path and config-file
-    // generators. A bare relative value would otherwise be C-rooted by the
-    // server's normalizeWindowsPath (e.g. "src" -> C:\src), denying the intended
-    // directory and possibly allowing an unrelated one. Values that already carry
-    // a token (or are absolute) are kept verbatim for VS Code to resolve.
     if (!isAbsolutePath(trimmed) && !hasUnresolvedVariables(trimmed)) {
+      // For a file-source round-trip, a relative path was authored relative to the
+      // entry's own cwd (the server resolves --config/--allowedDir/etc. against
+      // process.cwd()). Preserve it verbatim so re-saving an unrelated field does not
+      // retarget it: anchoring config.json to ${workspaceFolder} would launch a
+      // different file when cwd is not the workspace root, e.g. cwd
+      // ${workspaceFolder}/server must keep config.json -> .../server/config.json (P27).
+      if (opts.preserveRelativePaths) {
+        return trimmed.split(/[\\/]/).join('/');
+      }
+      // Settings export: convert a plain relative path to a ${workspaceFolder}-relative
+      // token so VS Code anchors it to the workspace, matching what the provider does
+      // (it resolves relative path settings against the workspace, not cwd). A bare
+      // relative value would otherwise be C-rooted by the server's normalizeWindowsPath
+      // (e.g. "src" -> C:\src), denying the intended directory and possibly allowing an
+      // unrelated one.
       return `\${workspaceFolder}/${trimmed.split(/[\\/]/).join('/')}`;
     }
+    // Values that already carry a token (or are absolute) are kept verbatim for VS
+    // Code to resolve.
     return trimmed;
   }
   return resolvedPath(value);
@@ -315,32 +425,53 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
 
   const configFile = pathValue(s.configFile, opts);
   if (configFile) {
-    args.push('--config', configFile);
+    pushOption(args, '--config', configFile);
   }
-  if (s.shell && s.shell !== 'all') {
-    args.push('--shell', s.shell);
+  const emitShell = Boolean(s.shell) && s.shell !== 'all';
+  if (emitShell) {
+    // Attached form for a dash-prefixed value, like every other scalar whose value can start
+    // with a dash (P73). A loaded entry can carry one the form's select cannot: yargs reads
+    // `--shell=--unsafe` as the shell name "--unsafe", but the two-token `--shell --unsafe` as an
+    // empty shell PLUS the active `unsafe` boolean -- so re-emitting it unattached turned a
+    // nonfunctional hand-authored launch into one with every safety restriction disabled (P84).
+    pushOption(args, '--shell', s.shell);
   }
   for (const dir of s.allowedDirectories) {
+    // An explicitly EMPTY entry is meaningful to the server: yargs supplies allowedDir as [''],
+    // and applyCliShellAndAllowedDirs turns restrictWorkingDirectory ON with that (empty) allowlist
+    // -- the entry denies every working directory. pathValue drops a blank value, so a no-op save
+    // removed --allowedDir entirely and the server fell back to the config/default allowed paths,
+    // widening what the authored entry permitted (P103). Round-trip it verbatim on a file-source
+    // save. The settings/provider paths keep dropping blanks (like the P57 suppression above, they
+    // are gated on preserveRelativePaths): there an empty line is editor noise, not an authored
+    // deny-all, and the form filters blanks out when collecting the textarea anyway.
+    if (opts.preserveRelativePaths && dir.trim() === '') {
+      pushOption(args, '--allowedDir', dir);
+      continue;
+    }
     const resolved = pathValue(dir, opts);
     if (resolved) {
-      args.push('--allowedDir', resolved);
+      pushOption(args, '--allowedDir', resolved);
     }
   }
   const initialDir = pathValue(s.initialDir, opts);
   if (initialDir) {
-    args.push('--initialDir', initialDir);
+    pushOption(args, '--initialDir', initialDir);
   }
   // The server ignores non-positive commandTimeout/maxCommandLength (uses its
   // default), so only emit positive values; invalid ones are surfaced by
   // validateLaunchSpec rather than silently falling back.
-  if (s.commandTimeout != null && s.commandTimeout > 0) {
+  const emitCommandTimeout = s.commandTimeout != null && s.commandTimeout > 0;
+  if (emitCommandTimeout) {
     args.push('--commandTimeout', String(s.commandTimeout));
   }
-  if (s.maxCommandLength != null && s.maxCommandLength > 0) {
+  const emitMaxCommandLength = s.maxCommandLength != null && s.maxCommandLength > 0;
+  if (emitMaxCommandLength) {
     args.push('--maxCommandLength', String(s.maxCommandLength));
   }
-  if (s.wslMountPoint.trim()) {
-    args.push('--wslMountPoint', s.wslMountPoint.trim());
+  const emitWslMountPoint = s.wslMountPoint.trim().length > 0;
+  if (emitWslMountPoint) {
+    pushOption(args, '--wslMountPoint', s.wslMountPoint.trim());
   }
   for (const cmd of s.blockedCommands) {
     pushOption(args, '--blockedCommand', cmd);
@@ -351,9 +482,13 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   for (const op of s.blockedOperators) {
     pushOption(args, '--blockedOperator', op);
   }
-  // Only emit log limits the server accepts; an out-of-range value makes
-  // validateLoggingConfig throw on startup (surfaced by validateLaunchSpec).
-  if (s.maxOutputLines != null && isValidMaxOutputLines(s.maxOutputLines)) {
+  // Only emit log limits the server accepts as a config-file value; an out-of-range value
+  // makes validateLoggingConfig throw on startup (surfaced by validateLaunchSpec). A loaded
+  // file-source value the server still accepts as a CLI flag (any > 0, applied by
+  // applyCliLogging without re-validation) is preserved verbatim via extraArgs by the parser
+  // (P59), so it round-trips even though the typed field cannot hold it.
+  const emitMaxOutputLines = s.maxOutputLines != null && isValidMaxOutputLines(s.maxOutputLines);
+  if (emitMaxOutputLines) {
     args.push('--maxOutputLines', String(s.maxOutputLines));
   }
   if (s.enableTruncation === 'enabled') {
@@ -366,18 +501,27 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   } else if (s.enableLogResources === 'disabled') {
     args.push('--no-enableLogResources');
   }
-  if (s.maxReturnLines != null && isValidLogLimit(s.maxReturnLines)) {
+  const emitMaxReturnLines = s.maxReturnLines != null && isValidLogLimit(s.maxReturnLines);
+  if (emitMaxReturnLines) {
     args.push('--maxReturnLines', String(s.maxReturnLines));
   }
   const logDirectory = pathValue(s.logDirectory, opts);
   if (logDirectory) {
-    args.push('--logDirectory', logDirectory);
+    pushOption(args, '--logDirectory', logDirectory);
   }
   // --allowAllDirs disables the working-directory restriction before initialDir
   // is applied, and is meaningless once paths are configured. Only emit it when
   // nothing else constrains the working directory.
+  //
+  // EXCEPT for a file-source round-trip (preserveRelativePaths): a hand-authored
+  // --allowAllDirs the form shows as set must survive an unrelated save. Dropping it flips
+  // the "Allow all directories" tri-select on the post-write reparse, and combined with
+  // --initialDir it silently re-tightens the server: loadConfig applies --allowAllDirs
+  // (clearing restrictWorkingDirectory) BEFORE the CLI --initialDir is merged, so without the
+  // flag the entry confines the server to initialDir instead of staying unrestricted. The
+  // provider/settings-export paths keep the suppression (P57).
   const dirsConfigured = s.allowedDirectories.some((d) => d.trim()) || s.initialDir.trim().length > 0;
-  if (s.allowAllDirs && !dirsConfigured) {
+  if (s.allowAllDirs && (opts.preserveRelativePaths || !dirsConfigured)) {
     args.push('--allowAllDirs');
   }
   if (s.safetyMode === 'yolo') {
@@ -395,6 +539,9 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   // stdio launch: a provider/mcp.json stdio registration must never let an
   // extraArgs value such as `--transport http` turn the process into a network
   // listener the client never connects to.
+  // The transport host/port/origin scalar flags this build actually emitted, recorded so a
+  // diverted/preserved copy of the SAME flag can be stripped from extraArgs below (P61).
+  const emittedTransportScalarFlags: string[] = [];
   let stripExtraTransport = false;
   if (s.transportMode === 'stdio') {
     // When a config file is referenced it may select http/sse; emit an explicit
@@ -404,8 +551,17 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
     // below so it cannot start a network listener.
     if (configFile) {
       args.push('--transport', 'stdio');
+      // A --transport stdio is now emitted, so a conflicting extraArgs --transport must be
+      // stripped even for a file-source round-trip — two tokens would yargs-merge into an
+      // array the server resolves to neither, silently keeping the referenced config's mode.
+      stripExtraTransport = true;
+    } else {
+      // No --transport is emitted. The provider/settings-export paths still strip a stray
+      // extraArgs --transport so a stdio registration cannot become a network listener; a
+      // file-source round-trip instead preserves the user's authored token verbatim
+      // (P-fileextratransport).
+      stripExtraTransport = !opts.preserveExtraTransport;
     }
-    stripExtraTransport = true;
   } else {
     args.push('--transport', s.transportMode);
     stripExtraTransport = true;
@@ -415,14 +571,17 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
       s.transportMode === 'http' ? '--http-allowed-origins' : '--sse-allowed-origins';
     if (s.transportHost.trim()) {
       args.push(hostFlag, s.transportHost.trim());
+      emittedTransportScalarFlags.push(hostFlag);
     }
     // Only emit a port the server will accept; an invalid one is surfaced by
     // validateLaunchSpec instead (otherwise the server silently uses its default).
     if (isValidPort(s.transportPort)) {
       args.push(portFlag, String(s.transportPort));
+      emittedTransportScalarFlags.push(portFlag);
     }
     if (s.transportAllowedOrigins.length > 0) {
       args.push(originFlag, s.transportAllowedOrigins.join(','));
+      emittedTransportScalarFlags.push(originFlag);
     }
   }
 
@@ -436,6 +595,42 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   }
   if (configFile) {
     extras = stripConfigArgs(extras);
+  }
+  // When the builder emits a modeled SCALAR value flag from a typed field, drop any
+  // same-named flag the parser diverted into extraArgs for round-trip: emitting both yields a
+  // duplicate option yargs merges into an array the server's applyCli* helpers resolve to
+  // neither (e.g. a loaded `--commandTimeout bad` or `--logDirectory --debug` the parser kept
+  // verbatim, then the user sets that field in the form — the form value must win, otherwise
+  // the edited value is ignored or crashes the server). Each strip is guarded by the SAME
+  // condition as the emission so an UNSET field still round-trips its preserved (malformed)
+  // value (P34/P59/P61). Only the kebab/camel spellings the parser produces need stripping.
+  // Array options (--allowedDir / --blocked*) are exempt: the server merges repeated values.
+  if (emitShell) {
+    extras = stripValueFlag(extras, ['--shell']);
+  }
+  if (initialDir) {
+    extras = stripValueFlag(extras, ['--initialDir', '--initial-dir']);
+  }
+  if (emitCommandTimeout) {
+    extras = stripValueFlag(extras, ['--commandTimeout', '--command-timeout']);
+  }
+  if (emitMaxCommandLength) {
+    extras = stripValueFlag(extras, ['--maxCommandLength', '--max-command-length']);
+  }
+  if (emitWslMountPoint) {
+    extras = stripValueFlag(extras, ['--wslMountPoint', '--wsl-mount-point']);
+  }
+  if (emitMaxOutputLines) {
+    extras = stripValueFlag(extras, ['--maxOutputLines', '--max-output-lines']);
+  }
+  if (emitMaxReturnLines) {
+    extras = stripValueFlag(extras, ['--maxReturnLines', '--max-return-lines']);
+  }
+  if (logDirectory) {
+    extras = stripValueFlag(extras, ['--logDirectory', '--log-directory']);
+  }
+  for (const flag of emittedTransportScalarFlags) {
+    extras = stripValueFlag(extras, [flag]);
   }
   for (const extra of extras) {
     args.push(extra);

--- a/vscode-extension/src/argsBuilder.ts
+++ b/vscode-extension/src/argsBuilder.ts
@@ -354,6 +354,39 @@ function stripValueFlag(extraArgs: string[], names: string[]): string[] {
   return out;
 }
 
+// The bare boolean flags this builder emits, all of which it emits ONLY for an enabled setting
+// (a disabled one is emitted as the `--no-*` spelling). yargs consumes a following bare
+// `true`/`false` token as a declared boolean's VALUE -- verified against the installed yargs:
+// `--enableTruncation false` yields false and NO positional, while `--enableTruncation=true false`
+// yields true plus the positional. So one of these standing directly in front of a boolean-like
+// positional preserved in extraArgs would both flip the setting and delete the positional (P114).
+const BARE_BOOLEAN_FLAGS = new Set<string>([
+  '--allowAllDirs',
+  '--debug',
+  '--enableLogResources',
+  '--enableTruncation',
+  '--unsafe',
+  '--yolo',
+]);
+
+/**
+ * Rewrite the generated token at `at` into its attached `--flag=true` form when it is a bare
+ * boolean flag and `next` -- the first extraArgs token that will follow it -- is a bare
+ * `true`/`false` yargs would swallow as its value (P114). The attached form is self-terminating and
+ * means exactly what the bare form means here, since the builder emits the bare spelling only for
+ * an ENABLED setting. This is the boolean counterpart of the parser's P106/P109 rewrite and of the
+ * P112 array hoist; no OTHER generated token is at risk, because every value this builder emits is
+ * preceded by its own flag, so a bare token can only ever come from extraArgs.
+ */
+function guardBooleanBeforePositional(args: string[], at: number, next: string | undefined): void {
+  if (at < 0 || (next !== 'true' && next !== 'false')) {
+    return;
+  }
+  if (BARE_BOOLEAN_FLAGS.has(args[at])) {
+    args[at] = `${args[at]}=true`;
+  }
+}
+
 /**
  * Build the minimal arg list for an auto-managed-config launch: point the server
  * at the generated config file and force stdio (a provider-launched process must
@@ -371,7 +404,10 @@ function buildManagedServerArgs(s: Wcli0Settings, managedConfigPath: string): st
   // start a network listener instead of speaking stdio (see stripTransportArgs); a
   // second --config would make yargs parse args.config as an array and the server fall
   // back to a different/default config, ignoring the managed file (see stripConfigArgs).
-  for (const extra of stripConfigArgs(stripTransportArgs(s.extraArgs))) {
+  const extras = stripConfigArgs(stripTransportArgs(s.extraArgs));
+  // A leading `true`/`false` in extraArgs would be consumed by a trailing `--debug` (P114).
+  guardBooleanBeforePositional(args, args.length - 1, extras[0]);
+  for (const extra of extras) {
     args.push(extra);
   }
   return args;
@@ -656,6 +692,16 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   let leadingPositionals = 0;
   while (leadingPositionals < extras.length && isOptionValueToken(extras[leadingPositionals])) {
     leadingPositionals++;
+  }
+  if (leadingPositionals > 0) {
+    // That leading run lands directly behind whichever generated token ends up in front of it:
+    // the last NON-array arg when the hoist below fires, otherwise the last generated arg. A bare
+    // boolean flag there swallows a `true`/`false` positional, so it is emitted attached (P114).
+    const lastGenerated =
+      greedyArrayAt.size > 0
+        ? args.reduce((last, _token, i) => (greedyArrayAt.has(i) ? last : i), -1)
+        : args.length - 1;
+    guardBooleanBeforePositional(args, lastGenerated, extras[0]);
   }
   if (leadingPositionals > 0 && greedyArrayAt.size > 0) {
     return [

--- a/vscode-extension/src/argsBuilder.ts
+++ b/vscode-extension/src/argsBuilder.ts
@@ -422,6 +422,17 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
     return buildManagedServerArgs(s, opts.managedConfigPath);
   }
   const args: string[] = [];
+  // Indices in `args` occupied by a yargs ARRAY option (--allowedDir / --blocked*), recorded so
+  // they can be re-emitted after a leading positional preserved in extraArgs (see the hoist at
+  // the end of this function, P112).
+  const greedyArrayAt = new Set<number>();
+  const pushArrayOption = (flag: string, value: string): void => {
+    const before = args.length;
+    pushOption(args, flag, value);
+    for (let i = before; i < args.length; i++) {
+      greedyArrayAt.add(i);
+    }
+  };
 
   const configFile = pathValue(s.configFile, opts);
   if (configFile) {
@@ -446,12 +457,12 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
     // are gated on preserveRelativePaths): there an empty line is editor noise, not an authored
     // deny-all, and the form filters blanks out when collecting the textarea anyway.
     if (opts.preserveRelativePaths && dir.trim() === '') {
-      pushOption(args, '--allowedDir', dir);
+      pushArrayOption('--allowedDir', dir);
       continue;
     }
     const resolved = pathValue(dir, opts);
     if (resolved) {
-      pushOption(args, '--allowedDir', resolved);
+      pushArrayOption('--allowedDir', resolved);
     }
   }
   const initialDir = pathValue(s.initialDir, opts);
@@ -474,13 +485,13 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
     pushOption(args, '--wslMountPoint', s.wslMountPoint.trim());
   }
   for (const cmd of s.blockedCommands) {
-    pushOption(args, '--blockedCommand', cmd);
+    pushArrayOption('--blockedCommand', cmd);
   }
   for (const arg of s.blockedArguments) {
-    pushOption(args, '--blockedArgument', arg);
+    pushArrayOption('--blockedArgument', arg);
   }
   for (const op of s.blockedOperators) {
-    pushOption(args, '--blockedOperator', op);
+    pushArrayOption('--blockedOperator', op);
   }
   // Only emit log limits the server accepts as a config-file value; an out-of-range value
   // makes validateLoggingConfig throw on startup (surfaced by validateLaunchSpec). A loaded
@@ -631,6 +642,28 @@ export function buildServerArgs(s: Wcli0Settings, opts: BuildOptions = {}): stri
   }
   for (const flag of emittedTransportScalarFlags) {
     extras = stripValueFlag(extras, [flag]);
+  }
+  // yargs declares --allowedDir/--blockedCommand/--blockedArgument/--blockedOperator as ARRAY
+  // options, which keep consuming tokens until the next `-`-prefixed one. extraArgs is appended
+  // AFTER the generated flags, so a bare POSITIONAL preserved at the head of extraArgs lands
+  // directly behind those array flags and is swallowed as another value: yargs reads
+  // `wcli0 marker --allowedDir C:/trusted` as the positional `marker` plus ONE allowed directory,
+  // but rebuilding it as `--allowedDir C:/trusted marker` yields TWO -- so an unrelated save
+  // silently widened the server's permitted working directories (and the same shape can empty a
+  // blocked list). Re-emit the array flags after that leading run instead, which reproduces the
+  // authored order. Only the leading run is at risk: any later positional already has a
+  // `-`-prefixed token in front of it, which is exactly where yargs stops consuming array values.
+  let leadingPositionals = 0;
+  while (leadingPositionals < extras.length && isOptionValueToken(extras[leadingPositionals])) {
+    leadingPositionals++;
+  }
+  if (leadingPositionals > 0 && greedyArrayAt.size > 0) {
+    return [
+      ...args.filter((_, i) => !greedyArrayAt.has(i)),
+      ...extras.slice(0, leadingPositionals),
+      ...args.filter((_, i) => greedyArrayAt.has(i)),
+      ...extras.slice(leadingPositionals),
+    ];
   }
   for (const extra of extras) {
     args.push(extra);

--- a/vscode-extension/src/commands.ts
+++ b/vscode-extension/src/commands.ts
@@ -271,6 +271,31 @@ function preservedFileUrl(
 }
 
 /**
+ * Why a transport host cannot be interpolated into a URL authority, or undefined when it can. The
+ * host field is pasted straight between `http://` and `:port`, so a value carrying an authority
+ * delimiter silently produces a different endpoint: `gateway.example/api` becomes
+ * `http://gateway.example/api:9444/mcp`, which reparses as host `gateway.example` with no explicit
+ * port -- the accepted edit is lost and the path is malformed (P107). An embedded port is rejected
+ * for the same reason (`example.com:8080` would yield `...:8080:9444`); an IPv6 literal is not, as
+ * it is bracketed by {@link fileSourceUrlHost} and carries two or more colons.
+ */
+function unusableTransportHost(host: string): string | undefined {
+  const trimmed = (host ?? '').trim();
+  if (!trimmed) {
+    return undefined; // empty falls back to loopback when the URL is rebuilt
+  }
+  const bare =
+    trimmed.startsWith('[') && trimmed.endsWith(']') ? trimmed.slice(1, -1) : trimmed;
+  if (/[/?#@]/.test(bare) || /\s/.test(bare)) {
+    return 'a path, query, fragment, userinfo or whitespace character';
+  }
+  if (bare.includes(':') && (bare.match(/:/g) ?? []).length < 2) {
+    return 'a port (set the port in the port field instead)';
+  }
+  return undefined;
+}
+
+/**
  * The host to write into a REBUILT file-source http/sse URL (when {@link preservedFileUrl}
  * declines to round-trip the verbatim URL because the host or port was edited). A file
  * source's `transportHost` came from a user-authored CONNECT URL, so it must round-trip
@@ -694,6 +719,19 @@ export async function writeMcpJsonFromSettings(
         );
         return false;
       }
+    }
+    // Refuse a host the URL cannot carry, but only when the URL will actually be REBUILT from the
+    // host/port fields -- a preserved verbatim URL never interpolates them (P107).
+    const willRebuild = !(fileSource
+      ? preservedFileUrl(settings, urlBase)
+      : preservedTransportUrl(settings));
+    const badHost = willRebuild ? unusableTransportHost(settings.transportHost) : undefined;
+    if (badHost) {
+      void vscode.window.showErrorMessage(
+        `wcli0: transport.host "${settings.transportHost}" contains ${badHost}, so it cannot be ` +
+          'used as the host of the server URL. Enter only a hostname or IP address.',
+      );
+      return false;
     }
     const preserved = fileSource
       ? preservedFileUrl(settings, urlBase)

--- a/vscode-extension/src/commands.ts
+++ b/vscode-extension/src/commands.ts
@@ -9,16 +9,21 @@ import {
   validateLaunchSpec,
 } from './argsBuilder';
 import { buildConfigFile } from './configFile';
+import { parseHttpUrl, parseMcpEntry } from './configSource';
 import {
   ConfigScope,
+  defaultSettings,
   hasPerShellConfig,
   hasProfilesConfig,
+  hasRawPerShellConfig,
+  hasUnresolvedExtensionVariables,
   hasUnresolvedVariables,
   primaryWorkspaceFolder,
   readSettings,
   readSettingsForScope,
   resolveVariables,
   SHELL_NAMES,
+  TransportMode,
   Wcli0Settings,
 } from './settings';
 import {
@@ -171,23 +176,424 @@ export async function generateConfigFile(formScopeArg?: unknown): Promise<void> 
 export async function writeWorkspaceMcpJson(
   formScopeArg?: unknown,
   configFileLoadable: (resolvedPath: string) => boolean = configFileIsLoadable,
-): Promise<void> {
+): Promise<boolean> {
   const folder = primaryWorkspaceFolder();
   if (!folder) {
     void vscode.window.showErrorMessage('wcli0: open a workspace folder first.');
-    return;
+    return false;
   }
   const settings = readExportSettings(asScope(formScopeArg), folder.uri);
+  return writeMcpJsonFromSettings(settings, folder, { configFileLoadable });
+}
 
+/**
+ * Write the wcli0 server entry into `<folder>/.vscode/mcp.json` from an explicit
+ * settings object, preserving any other servers and refusing to clobber a malformed
+ * or comment-bearing file (see the merge logic below). Shared by the settings-driven
+ * `writeWorkspaceMcpJson` export and the file-source "Save to file" path, which
+ * supplies settings built from the form rather than read from a scope — so saving a
+ * file source never writes any `wcli0.*` setting.
+ */
+/**
+ * The verbatim http/sse URL to write for an entry, when a loaded file source's
+ * URL should be preserved rather than rebuilt from host/port. Returns the original
+ * URL only while it still parses to the host/port currently shown in the form — so
+ * a custom scheme/path or default-port URL round-trips unchanged, but editing the
+ * host/port falls back to the canonical reconstruction (P5). Undefined for
+ * settings-sourced reads, which never carry `transportUrl`.
+ */
+function preservedTransportUrl(settings: Wcli0Settings): string | undefined {
+  const url = settings.transportUrl?.trim();
+  if (!url) {
+    return undefined;
+  }
+  const parsed = parseHttpUrl(url);
+  if (!parsed || parsed.host !== settings.transportHost) {
+    return undefined;
+  }
+  // A settings read uses transportPort 0 as the "default port" sentinel for a URL that omits
+  // its port; parseHttpUrl reports that omitted port as `undefined`, so map it to 0 before
+  // comparing. An explicit port must still match transportPort exactly (P5).
+  const urlPort = parsed.port ?? 0;
+  return urlPort === settings.transportPort ? url : undefined;
+}
+
+/**
+ * The verbatim http/sse URL to write when saving a loaded file source, or undefined to
+ * rebuild it from host/port. Preserves the loaded entry's URL whenever the user has not
+ * changed the transport mode or the host/port the URL decomposes to — so a custom
+ * scheme/path (P5), a default-port URL (P8), or a socket/named-pipe URL the host/port
+ * fields cannot model (P10) round-trips unchanged. Decided against the loaded entry's raw
+ * URL rather than `settings.transportUrl` so the host/port editing rules match exactly
+ * what {@link parseMcpEntry} chose to model for that URL.
+ */
+function preservedFileUrl(
+  settings: Wcli0Settings,
+  base: Record<string, unknown>,
+): string | undefined {
+  const rawUrl = typeof base.url === 'string' ? base.url.trim() : '';
+  if (!rawUrl) {
+    return undefined;
+  }
+  // Compare against the lowercased type: parseMcpEntry models an entry written as
+  // `HTTP`/`SSE` as http/sse, so settings.transportMode is already lowercase. Comparing the
+  // raw type would treat a no-op save of an uppercase entry as a mode switch and rebuild the
+  // URL to the canonical form, losing the custom/default-port URL shape the parser preserved
+  // (P48).
+  const baseType = typeof base.type === 'string' ? base.type.toLowerCase() : 'stdio';
+  if (settings.transportMode !== baseType) {
+    // The user switched the transport mode; rebuild the URL for the new mode.
+    return undefined;
+  }
+  const parsed = parseHttpUrl(rawUrl);
+  if (!parsed) {
+    // Socket/named-pipe URL: the host/port fields are inert for it, so preserve verbatim.
+    return rawUrl;
+  }
+  if (parsed.port === undefined) {
+    // Default-port URL (no explicit port): parseMcpEntry models only the host and leaves the
+    // port field at the form default. Preserve the verbatim URL only while the host is unchanged
+    // AND the user has not entered a port; a host OR port edit falls back to canonical
+    // reconstruction. Without the port check a port-only edit was silently dropped — the save
+    // wrote the original URL back unchanged and the next reparse lost the edit (P67). The
+    // default-port marker is `defaultSettings().transportPort`, exactly the value parseMcpEntry
+    // leaves when the URL omits its port, so an untouched save still round-trips verbatim (P8).
+    const portUntouched = settings.transportPort === defaultSettings().transportPort;
+    return parsed.host === settings.transportHost && portUntouched ? rawUrl : undefined;
+  }
+  // Fully decomposable (an explicit port, including an unusable `:0` the form replaced with
+  // its default): preserve only while host AND port are untouched. A `:0` URL therefore never
+  // round-trips verbatim — its port can never equal the default the form holds — so saving
+  // rebuilds the canonical URL instead of writing back the invalid port (P5/P-port0).
+  return parsed.host === settings.transportHost && parsed.port === settings.transportPort
+    ? rawUrl
+    : undefined;
+}
+
+/**
+ * The host to write into a REBUILT file-source http/sse URL (when {@link preservedFileUrl}
+ * declines to round-trip the verbatim URL because the host or port was edited). A file
+ * source's `transportHost` came from a user-authored CONNECT URL, so it must round-trip
+ * verbatim — unlike {@link clientHost}, which maps a server BIND host (`0.0.0.0`, `::`) to a
+ * connectable loopback address for the settings-driven export. Applying that bind->connect
+ * mapping here would silently rewrite an untouched wildcard host (`0.0.0.0`->`127.0.0.1`,
+ * `[::]`->`[::1]`) on a port-only edit (P60). Only the syntactic bracketing of a bare IPv6
+ * literal is kept so the rebuilt authority stays valid; an empty host falls back to loopback.
+ */
+function fileSourceUrlHost(host: string): string {
+  const h = (host ?? '').trim() || '127.0.0.1';
+  // Bracket a bare IPv6 literal (contains ':' and isn't already bracketed); leave wildcard
+  // binds, bracketed literals, and plain hostnames/IPv4 exactly as authored.
+  if (h.includes(':') && !h.startsWith('[')) {
+    return `[${h}]`;
+  }
+  return h;
+}
+
+// The wcli0-entry keys the form regenerates per transport mode (replaced from the form on
+// a file save). Other VS Code-supported keys present on the entry are left untouched
+// (see mergeEntryOntoBase).
+const STDIO_OWNED_KEYS = ['type', 'command', 'args', 'cwd', 'env'];
+const HTTP_OWNED_KEYS = ['type', 'url'];
+
+// The FULL set of transport-specific keys VS Code recognizes for each mode, including the
+// unmodeled ones the merge otherwise preserves. When the user switches transport mode, the
+// OTHER mode's whole set is removed so stale fields do not leak across — e.g. an HTTP entry's
+// `headers`/`oauth` must not survive into a stdio entry, nor stdio's `envFile`/`dev`/
+// `sandboxEnabled` into an HTTP entry (P19).
+const STDIO_FIELD_KEYS = [...STDIO_OWNED_KEYS, 'envFile', 'dev', 'sandboxEnabled'];
+const HTTP_FIELD_KEYS = [...HTTP_OWNED_KEYS, 'headers', 'oauth'];
+
+/**
+ * Merge the freshly generated wcli0 fields onto the loaded `.vscode/mcp.json` entry,
+ * preserving any VS Code-supported fields the form does not model — HTTP `headers`/`oauth`
+ * (P7), stdio `envFile`/`dev`/`sandboxEnabled` (P12), and so on — rather than reconstructing
+ * the entry from scratch. Keys the form owns for the CURRENT transport mode are replaced from
+ * `generated`; the OTHER transport mode's ENTIRE field set (modeled and unmodeled) is removed
+ * so a stdio<->http switch leaves no stale transport-specific fields behind (P19).
+ */
+function mergeEntryOntoBase(
+  base: Record<string, unknown>,
+  generated: Record<string, unknown>,
+  mode: TransportMode,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base };
+  const otherModeKeys = mode === 'stdio' ? HTTP_FIELD_KEYS : STDIO_FIELD_KEYS;
+  const owned = mode === 'stdio' ? STDIO_OWNED_KEYS : HTTP_OWNED_KEYS;
+  for (const key of [...otherModeKeys, ...owned]) {
+    delete merged[key];
+  }
+  return Object.assign(merged, generated);
+}
+
+// The `${...}` variable forms VS Code actually substitutes when it launches an mcp.json
+// server: the namespaced `${env:NAME}` / `${input:NAME}` / `${command:NAME}` / `${config:NAME}`
+// forms, the extension-owned `${workspaceFolder(:name)}` / `${userHome}`, and the other named
+// built-ins. A BARE `${NAME}` (e.g. `${PATH}`) is deliberately NOT here — VS Code does not
+// expand it — so a value relying on one must still face local path validation (P-varsyntax).
+const VSCODE_VARIABLE_TOKEN = new RegExp(
+  [
+    '\\$\\{(?:env|input|command|config):[^}]+\\}',
+    '\\$\\{workspaceFolder(?::[^}]+)?\\}',
+    '\\$\\{(?:workspaceFolderBasename|userHome|pathSeparator|cwd|execPath|lineNumber|selectedText|defaultBuildTask|fileWorkspaceFolder|relativeFileDirname|relativeFile|fileBasenameNoExtension|fileBasename|fileDirname|fileExtname|file)\\}',
+    '\\$\\{/\\}',
+  ].join('|'),
+  'g',
+);
+
+/**
+ * Whether a launch-field value is a VS Code launch-time variable path (e.g. `${input:cfg}`,
+ * `${command:pickConfig}`, `${env:HOME}/cfg.json`) that VS Code resolves when it launches
+ * the server. The extension owns only `${workspaceFolder}` / `${userHome}`; any OTHER
+ * RECOGNIZED VS Code `${...}` left after resolving those is VS Code's to expand, so a
+ * file-source save must not block on it being locally unresolvable/unreadable (P13/P18).
+ * A value whose leftover token is NOT a known VS Code form — a typo or a bare shell
+ * variable like `${PATH}/cfg.json` that VS Code will never substitute — is treated as a
+ * real local path so the normal validation still rejects the broken path (P-varsyntax).
+ */
+function isVscodeVariablePath(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const resolved = resolveVariables(trimmed);
+  if (!hasUnresolvedVariables(resolved) || hasUnresolvedExtensionVariables(resolved)) {
+    // Nothing left for VS Code to expand, or an extension-owned token we failed to resolve
+    // (no matching workspace folder) — in the latter case the value really is broken.
+    return false;
+  }
+  // Every remaining `${...}` must be a form VS Code substitutes; if anything is left after
+  // stripping the recognized ones, it is a bare/unknown token VS Code will not expand.
+  return !hasUnresolvedVariables(resolved.replace(VSCODE_VARIABLE_TOKEN, ''));
+}
+
+// Validation-only stand-in for a required launch field (node script / custom command) whose
+// value is a VS Code variable: an absolute path passes the anchorability checks while the real
+// `${input:...}`/`${env:...}` value is emitted into the entry verbatim (buildLaunchSpec keeps
+// it under resolvePaths:false).
+const VSCODE_VARIABLE_PLACEHOLDER = '/__wcli0_vscode_variable__';
+
+/**
+ * Return a copy of `settings` with every launch field that holds a VS Code launch-time
+ * variable neutralized for validation only. VS Code resolves these at launch and the entry
+ * round-trips them verbatim, so the extension's local anchorability/loadability checks must
+ * not reject an otherwise no-op file-source save (P18). Optional path fields are blanked
+ * (skipped by the checks); required fields are replaced with an absolute placeholder; and
+ * variable allowed-directories are dropped.
+ */
+function neutralizeVscodeVariableLaunchFields(settings: Wcli0Settings): Wcli0Settings {
+  const blankIfVar = (v: string) => (isVscodeVariablePath(v) ? '' : v);
+  return {
+    ...settings,
+    configFile: blankIfVar(settings.configFile),
+    cwd: blankIfVar(settings.cwd),
+    initialDir: blankIfVar(settings.initialDir),
+    logDirectory: blankIfVar(settings.logDirectory),
+    allowedDirectories: settings.allowedDirectories.filter((d) => !isVscodeVariablePath(d)),
+    nodeScriptPath: isVscodeVariablePath(settings.nodeScriptPath)
+      ? VSCODE_VARIABLE_PLACEHOLDER
+      : settings.nodeScriptPath,
+    customCommand: isVscodeVariablePath(settings.customCommand)
+      ? VSCODE_VARIABLE_PLACEHOLDER
+      : settings.customCommand,
+  };
+}
+
+/**
+ * The absolute path a file-source entry's `--config` resolves to for the loadability check.
+ * Mirrors the server's launch-time resolution for a committed entry: an absolute path (or a
+ * `${workspaceFolder}`-anchored one) is used as-is, while a plain RELATIVE path is resolved
+ * against the entry's own launch cwd — where the server runs — rather than the workspace
+ * root (P-cwdconfig). Returns undefined when no config is set or it still holds an unresolved
+ * variable (VS Code resolves those at launch; they are neutralized before this is reached).
+ */
+function fileSourceConfigPath(
+  s: Wcli0Settings,
+  folder: vscode.WorkspaceFolder,
+): string | undefined {
+  const raw = s.configFile.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const resolved = resolveVariables(raw);
+  if (hasUnresolvedVariables(resolved)) {
+    // A VS Code launch variable (`${input:cfg}`, …) VS Code resolves at launch — unknowable
+    // and unreadable locally, so there is nothing to check.
+    return undefined;
+  }
+  if (isAbsolutePath(resolved)) {
+    return resolved;
+  }
+  // Relative: the server resolves it against the entry's launch cwd. But if the cwd ITSELF is
+  // a VS Code variable (e.g. `${input:cwd}`) resolved at launch, we cannot know where that is,
+  // so anchoring to the workspace root would validate the wrong file (or wrongly reject an
+  // unchanged entry). Skip the check in that case (P-varcwd).
+  const cwd = s.cwd.trim();
+  if (cwd && hasUnresolvedVariables(resolveVariables(cwd))) {
+    return undefined;
+  }
+  return vscode.Uri.joinPath(launchCwdUri(folder, s), ...resolved.split(/[\\/]/).filter(Boolean))
+    .fsPath;
+}
+
+/** Options for {@link writeMcpJsonFromSettings}. */
+export interface WriteMcpJsonOptions {
+  /**
+   * Injected config-file loadability check (tests use the in-memory filesystem; defaults
+   * to the real on-disk check).
+   */
+  configFileLoadable?: (resolvedPath: string) => boolean;
+  /**
+   * The loaded `.vscode/mcp.json` `servers.wcli0` entry when saving a file source. When
+   * present, the generated fields are merged onto it (preserving unmodeled VS Code fields),
+   * the raw `env` and `url` are round-tripped, and a VS Code-variable `--config` path is not
+   * blocked. Absent for the settings-driven export, which builds a fresh entry.
+   */
+  baseEntry?: Record<string, unknown>;
+  /**
+   * `JSON.stringify` of the entry the caller's `settings` were overlaid on (`'null'` when the
+   * caller found no entry on disk). The save takes its OWN full-file snapshot, so a concurrent
+   * write landing between the caller's read and that snapshot would pair modeled fields derived
+   * from the older entry with a newer merge base and silently overwrite the change. Supplying
+   * this makes the save refuse that race instead (P95). Omitted by the settings-driven export,
+   * whose settings come from VS Code settings rather than from the file.
+   */
+  expectedEntryJson?: string;
+}
+
+export async function writeMcpJsonFromSettings(
+  settings: Wcli0Settings,
+  folder: vscode.WorkspaceFolder,
+  opts: WriteMcpJsonOptions = {},
+): Promise<boolean> {
+  const configFileLoadable = opts.configFileLoadable ?? configFileIsLoadable;
+  const baseEntry = opts.baseEntry;
+  const fileSource = !!baseEntry;
+  // A file source's per-shell settings (wcli0.shells) and environment profiles
+  // (wcli0.profiles) cannot be expressed in a .vscode/mcp.json entry at all — neither a
+  // stdio entry (which carries only CLI flags) nor an http/sse entry (which carries only a
+  // URL) round-trips them, and this save only writes the entry. Any such values in the form
+  // are therefore unsaved edits the post-write reparse would silently drop while still
+  // reporting success. Refuse for BOTH transport modes so the loss is explicit; previously
+  // only the stdio branch guarded this, so http/sse file edits on the Shells/Profiles tabs
+  // disappeared with a misleading "Saved" (P29/P-httpshells). Use the RAW helpers (ignoring
+  // the ignoreInheritedShells/Profiles mask): the mask is a settings-only opt-out and does
+  // not make the edits storable in the entry, so masked-but-edited shells/profiles must still
+  // be refused (P-maskedshells). The settings-driven export is handled per-mode below: there
+  // shells/profiles persist in wcli0.* settings and the provider builds its own managed
+  // config, so they get a sync warning, not a hard block.
+  //
+  // For profiles, gate on ANY non-empty profiles object, not only launch-MEANINGFUL ones
+  // (hasRawProfilesConfig): the Profiles editor accepts any JSON object, so a non-emittable
+  // profile such as {"p":{"description":"x","env":{}}} is still an unsaved edit the entry
+  // cannot store and the reparse drops while reporting "Saved" (P-emptyprofile). Emptiness
+  // is the right gate because a clean file load never populates profiles (parseMcpEntry leaves
+  // them {}), so this only fires on a real edit, never on an untouched save.
+  const hasFileProfileEdit = Object.keys(settings.profiles ?? {}).length > 0;
+  if (fileSource && (hasRawPerShellConfig(settings) || hasFileProfileEdit)) {
+    void vscode.window.showErrorMessage(
+      'wcli0: per-shell settings (wcli0.shells) and environment profiles (wcli0.profiles) cannot ' +
+        'be written to a .vscode/mcp.json entry, so they cannot be saved from this form. They live ' +
+        "in the server's config file; edit it directly (and reference it via --config for stdio), " +
+        'then reload the source.',
+    );
+    return false;
+  }
+  // The inherited-config masks (ignoreInheritedShells / ignoreInheritedProfiles) are
+  // settings-only opt-outs that no .vscode/mcp.json entry can store. The form disables their
+  // controls on a file source, but guard the host too: a non-default mask reaching this save is
+  // an unsaved edit the post-write reparse would silently drop while reporting "Saved", so
+  // refuse it explicitly (P-maskfile).
+  if (fileSource && (settings.ignoreInheritedShells || settings.ignoreInheritedProfiles)) {
+    void vscode.window.showErrorMessage(
+      'wcli0: the "ignore inherited per-shell config / profiles" options are VS Code settings ' +
+        'and cannot be written to a .vscode/mcp.json entry, so they cannot be saved from this ' +
+        'form. Switch to VS Code Settings to change them.',
+    );
+    return false;
+  }
+  // For a file source, take ONE full-file snapshot up front and use it as the basis for every
+  // on-disk-dependent decision below: URL preservation (P41), the env round-trip (P23), the
+  // uneditable-argv carry-forward (P40), the merge base (P46), AND the OTHER servers carried into
+  // the written file. Reading the WHOLE file once — not just servers.wcli0, and not a second time
+  // at the write step — closes the window in which a concurrent delete/recreate of
+  // .vscode/mcp.json during a warning modal would drop the file's other servers: the merge base
+  // and the surrounding-servers container now come from the same snapshot (P69). Reading it
+  // before validation also lets the http/sse URL-preservation check use the current entry rather
+  // than the stale load snapshot (P41). The malformed-root / non-object-`servers` guards run here
+  // too, so an invalid file is refused before any modal. Falls back to the loaded baseEntry when
+  // nothing usable is on disk.
+  const mcpUri = vscode.Uri.joinPath(folder.uri, '.vscode', 'mcp.json');
+  const fileSnapshot = fileSource ? await readExistingMcpJson(mcpUri) : undefined;
+  if (fileSource && !fileSnapshot) {
+    return false; // unreadable / invalid file — readExistingMcpJson already reported why
+  }
+  const onDiskServers =
+    fileSnapshot && isPlainObject(fileSnapshot.existing.servers)
+      ? (fileSnapshot.existing.servers as Record<string, unknown>)
+      : undefined;
+  const onDiskEntry =
+    onDiskServers && isPlainObject(onDiskServers.wcli0)
+      ? (onDiskServers.wcli0 as Record<string, unknown>)
+      : undefined;
+  // Refuse when the entry changed between the caller's read (which produced `settings`) and the
+  // snapshot above: the modeled fields would be from the older entry while the merge base and the
+  // carried-forward argv come from the newer one, so a concurrent edit would be silently
+  // overwritten by a stale value the user never saw (P95). Both reads agreeing — including both
+  // finding no entry — proceeds normally, so the deleted-entry recreate path (P23) is unaffected.
+  if (fileSource && opts.expectedEntryJson !== undefined) {
+    if (JSON.stringify(onDiskEntry ?? null) !== opts.expectedEntryJson) {
+      void vscode.window.showErrorMessage(
+        'wcli0: .vscode/mcp.json changed while saving, so your edits were not applied to the ' +
+          'current entry. Nothing was written — reload the source and try again.',
+      );
+      return false;
+    }
+  }
+  const urlBase = (onDiskEntry ?? baseEntry) as Record<string, unknown>;
+  // An entry whose `type` the form cannot model (a future/custom transport such as
+  // "websocket") is parsed as stdio for its editable fields, but saving would let
+  // mergeEntryOntoBase overwrite that original `type` with "stdio" (and strip the other
+  // transport's URL-like fields) after an unrelated edit — silently normalizing a transport
+  // the user deliberately chose. Refuse rather than corrupt it; the parse note already directs
+  // the user to edit .vscode/mcp.json directly to change the type (P-unknowntype). Check the
+  // CURRENT on-disk entry (the actual merge base) so a type changed after load is honored.
+  const rawBaseType = fileSource && typeof urlBase.type === 'string' ? urlBase.type : '';
+  const baseType = rawBaseType ? rawBaseType.toLowerCase() : 'stdio';
+  if (fileSource && baseType !== 'stdio' && baseType !== 'http' && baseType !== 'sse') {
+    void vscode.window.showErrorMessage(
+      `wcli0: the entry's transport type "${rawBaseType}" is not stdio/http/sse and cannot be ` +
+        'saved from this form (saving would normalize it to stdio). Edit .vscode/mcp.json ' +
+        'directly to change the transport type.',
+    );
+    return false;
+  }
   // Validate only what the generated entry actually uses. A stdio entry needs a
   // working launch command; an http/sse entry only contains a URL, so local
   // launch settings (method, allowed dirs) are irrelevant and only the port
   // matters — otherwise a valid external endpoint couldn't be written.
   if (settings.transportMode === 'stdio') {
+    // Launch fields holding a VS Code launch-time variable (`${input:...}`, `${env:...}`,
+    // `${command:...}` in --config, cwd, node script, custom command, ...) are resolved by VS
+    // Code at launch, not by us, so they cannot be checked on disk and must not block a
+    // file-source save (P13/P18). Validate with those neutralized; the verbatim argv is still
+    // emitted into the entry below (buildLaunchSpec keeps the unresolved tokens).
+    const validateSettings = fileSource
+      ? neutralizeVscodeVariableLaunchFields(settings)
+      : settings;
     // A referenced wcli0.configFile becomes the entry's `--config`; validate it can
     // actually be loaded so the exported entry does not silently fall back to an
-    // implicit config the server discovers instead (P85).
-    const cfgPath = resolvedConfigFilePath(settings);
+    // implicit config the server discovers instead (P85). For a file source a relative
+    // --config is resolved by the server against the ENTRY's own cwd (process.cwd()), not
+    // the workspace root, so check loadability there — otherwise a no-op save is wrongly
+    // refused when only <cwd>/config.json exists, or wrongly accepted because an unrelated
+    // <workspace>/config.json exists while the real cwd-relative file is missing (P-cwdconfig).
+    // Use the ORIGINAL settings (not the variable-neutralized copy) so fileSourceConfigPath
+    // can see whether the entry's cwd is a VS Code variable and skip the check accordingly
+    // (P-varcwd). A variable --config is still reported as undefined either way.
+    const cfgPath = fileSource
+      ? fileSourceConfigPath(settings, folder)
+      : resolvedConfigFilePath(validateSettings);
     const cfgLoadable = !cfgPath || configFileLoadable(cfgPath);
     const hasLoadableConfigFile = !!cfgPath && cfgLoadable;
     // Per-shell settings (wcli0.shells) and environment profiles (wcli0.profiles)
@@ -205,14 +611,14 @@ export async function writeWorkspaceMcpJson(
           'represented in .vscode/mcp.json. Generate a config file (wcli0: Generate Config File) and ' +
           'reference it via wcli0.configFile, or clear wcli0.shells / wcli0.profiles before exporting.',
       );
-      return;
+      return false;
     }
-    const blocking = validateLaunchSpec(settings, false, false, cfgLoadable).filter(
+    const blocking = validateLaunchSpec(validateSettings, false, false, cfgLoadable).filter(
       (p) => p.blocking,
     );
     if (blocking.length > 0) {
       void vscode.window.showErrorMessage(`wcli0: ${blocking.map((p) => p.message).join(' ')}`);
-      return;
+      return false;
     }
     // When shells/profiles are configured the entry relies entirely on the referenced
     // configFile to carry them, but the export cannot confirm that file is in sync with
@@ -230,7 +636,7 @@ export async function writeWorkspaceMcpJson(
         'Write anyway',
       );
       if (pick !== 'Write anyway') {
-        return;
+        return false;
       }
     }
     // A stdio entry with no explicit wcli0.configFile carries plain CLI flags but no
@@ -253,30 +659,131 @@ export async function writeWorkspaceMcpJson(
           'Write anyway',
         );
         if (pick !== 'Write anyway') {
-          return;
+          return false;
         }
       }
     }
-  } else if (!isValidPort(settings.transportPort)) {
-    void vscode.window.showErrorMessage(
-      `wcli0: transport.port (${settings.transportPort}) must be an integer between 1 and 65535.`,
-    );
-    return;
+  } else {
+    // A loaded file source decides URL preservation against the CURRENT on-disk entry so the
+    // rules match what parseMcpEntry modeled (default-port/socket URLs included, P8/P10) AND
+    // a concurrent edit to an unmodeled URL part survives (P41); the settings-driven export
+    // uses the host/port round-trip check (P5).
+    // An opaque http/sse URL -- one parseHttpUrl cannot decompose, such as a socket or
+    // named-pipe form (`unix:///tmp/server.sock#/mcp`) -- is preserved verbatim by
+    // preservedFileUrl, because the host/port fields are inert for it: parseMcpEntry models
+    // neither and leaves both at the form defaults. The controls stay editable though, so a
+    // host or port change was accepted as a network-savable edit, the original URL was written
+    // back unchanged, and the post-write reparse discarded the edit behind a "Saved" message.
+    // Refuse it explicitly instead, matching the parse note that directs the user to edit
+    // .vscode/mcp.json for such a URL (P81). Only while the mode is unchanged: switching the
+    // transport mode rebuilds the URL from host/port, where the edit does take effect.
+    if (fileSource) {
+      const rawOpaqueUrl = typeof urlBase.url === 'string' ? urlBase.url.trim() : '';
+      const formDefaults = defaultSettings();
+      if (
+        rawOpaqueUrl &&
+        settings.transportMode === baseType &&
+        !parseHttpUrl(rawOpaqueUrl) &&
+        (settings.transportHost !== formDefaults.transportHost ||
+          settings.transportPort !== formDefaults.transportPort)
+      ) {
+        void vscode.window.showErrorMessage(
+          `wcli0: the entry URL "${rawOpaqueUrl}" cannot be represented by the host and port ` +
+            'fields, so it is preserved as-is and host/port edits cannot be saved for it. Revert ' +
+            'them, or edit .vscode/mcp.json directly to change the URL.',
+        );
+        return false;
+      }
+    }
+    const preserved = fileSource
+      ? preservedFileUrl(settings, urlBase)
+      : preservedTransportUrl(settings);
+    if (!preserved && !isValidPort(settings.transportPort)) {
+      // Only validate the port when the URL will be reconstructed from host/port. A
+      // preserved verbatim URL (e.g. one relying on a default port) carries its own
+      // authority and need not pass the standalone port check (P5).
+      void vscode.window.showErrorMessage(
+        `wcli0: transport.port (${settings.transportPort}) must be an integer between 1 and 65535.`,
+      );
+      return false;
+    }
   }
 
+  // The regenerated, form-owned `args` array is built from the loaded snapshot, and the merge
+  // replaces `args` wholesale — so EVERY argv-derived field the form does not edit must be
+  // re-derived from the CURRENT on-disk entry (read once up front) and spliced back, or a flag
+  // another process added to servers.wcli0.args is dropped (P-staleargs/P40). Besides the
+  // escape-hatch `extraArgs`, this covers `customArgs`, the blocked lists, `--maxReturnLines`,
+  // and the transport allowed-origins — none of which have a form control. Modeled fields
+  // still follow the form, as for every loaded field.
+  let buildSettings = settings;
+  if (fileSource && settings.transportMode === 'stdio') {
+    const onDisk = parseMcpEntry(onDiskEntry ?? baseEntry!).settings;
+    // Only carry forward when the on-disk entry is itself stdio, so a mode switch does not
+    // import an http entry's (empty) argv fields.
+    if (onDisk.transportMode === 'stdio') {
+      buildSettings = {
+        ...settings,
+        customArgs: onDisk.customArgs,
+        blockedCommands: onDisk.blockedCommands,
+        blockedArguments: onDisk.blockedArguments,
+        blockedOperators: onDisk.blockedOperators,
+        maxReturnLines: onDisk.maxReturnLines,
+        transportAllowedOrigins: onDisk.transportAllowedOrigins,
+        // --wslMountPoint is parsed and re-emitted but has no form control, so it is carried
+        // forward from the current on-disk entry like the other uneditable argv fields —
+        // otherwise an unrelated save rebuilds args from the stale loaded value and drops a
+        // --wslMountPoint another process added/changed after the panel loaded (P-wslmount).
+        wslMountPoint: onDisk.wslMountPoint,
+        extraArgs: onDisk.extraArgs,
+      };
+    } else {
+      buildSettings = { ...settings, extraArgs: onDisk.extraArgs };
+    }
+  }
   // Preserve portable ${workspaceFolder} tokens rather than resolving them: a
   // committed mcp.json is shared across machines and VS Code resolves these
-  // variables itself, so baking in absolute paths would break for teammates.
-  const spec = buildLaunchSpec(settings, { resolvePaths: false });
+  // variables itself, so baking in absolute paths would break for teammates. For a
+  // file source, also preserve plain relative path args verbatim (preserveRelativePaths):
+  // they were authored relative to the entry's own cwd, so anchoring them to
+  // ${workspaceFolder} on an unrelated save would retarget the referenced file (P27).
+  const spec = buildLaunchSpec(buildSettings, {
+    resolvePaths: false,
+    preserveRelativePaths: fileSource,
+    // A file-source save round-trips the entry's verbatim argv, so a hand-authored
+    // --transport kept in extraArgs (P30) must not be stripped from the stdio launch and
+    // leave its companion --http-* options orphaned (P-fileextratransport). The provider and
+    // settings-export paths still strip it for safety.
+    preserveExtraTransport: fileSource,
+  });
 
   let entry: Record<string, unknown>;
+  // The form-owned fields, kept separately so a file-source save can merge them onto the
+  // CURRENT on-disk entry (read below) rather than only the snapshot loaded into the panel (P20).
+  let generatedForMerge: Record<string, unknown> | undefined;
   if (settings.transportMode === 'stdio') {
     // Include cwd only when launch.cwd is explicitly set. NOTE: omitting it does
     // not avoid the workspace — VS Code defaults a committed stdio entry's cwd to
     // the workspace folder, so the server may still auto-load <workspace>/config.json.
     // There is no portable "safe" cwd for a shared mcp.json (an absolute temp path
     // would not be portable); set wcli0.launch.cwd or wcli0.configFile to control it.
-    let env = spec.env;
+    //
+    // env is not form-editable. For a file source, round-trip the loaded entry's raw env
+    // verbatim (including non-string values VS Code allows, e.g. numbers/null) rather than
+    // the string-filtered settings env, so an unrelated save does not silently drop them
+    // (P9). For the settings-driven export, use the env built from settings.
+    let env: Record<string, unknown> = spec.env;
+    if (fileSource) {
+      // Round-trip the CURRENT on-disk entry's raw env, not the snapshot loaded into the
+      // panel: another process may have added/changed servers.wcli0.env after the panel
+      // opened, and the on-disk merge below treats env as a form-owned stdio key (it would
+      // otherwise delete the on-disk value and apply this stale one), silently dropping
+      // those vars without even the env prompt. Fall back to the loaded baseEntry when no
+      // entry is on disk (P23, matching the merge base re-derivation below for P20). Reuses
+      // the single on-disk read taken above for extraArgs.
+      const rawEnv = (onDiskEntry ?? baseEntry!).env;
+      env = isPlainObject(rawEnv) ? rawEnv : {};
+    }
     if (Object.keys(env).length > 0) {
       // env is serialized into the (commonly committed) mcp.json and may hold
       // secrets inherited from User settings — require an explicit choice.
@@ -287,72 +794,83 @@ export async function writeWorkspaceMcpJson(
         'Omit environment',
       );
       if (pick === undefined) {
-        return; // cancelled — don't write
+        return false; // cancelled — don't write
       }
       if (pick === 'Omit environment') {
         env = {};
       }
     }
-    entry = {
+    const generated: Record<string, unknown> = {
       type: 'stdio',
       command: spec.command,
       args: spec.args,
       ...(spec.cwd ? { cwd: spec.cwd } : {}),
       ...(Object.keys(env).length ? { env } : {}),
     };
+    // For a file source, merge onto the loaded entry so unmodeled VS Code stdio fields
+    // (envFile, dev, sandboxEnabled, ...) survive an unrelated edit (P12). The merge base is
+    // re-derived from the current on-disk entry at the write step (P20).
+    generatedForMerge = generated;
+    entry = fileSource ? mergeEntryOntoBase(baseEntry!, generated, 'stdio') : generated;
   } else {
-    entry = {
-      type: settings.transportMode === 'http' ? 'http' : 'sse',
-      // Normalize wildcard/IPv6 bind hosts into a connectable client URL.
-      url: `http://${clientHost(settings.transportHost)}:${settings.transportPort}${
+    // Prefer the CURRENT on-disk entry's verbatim URL when host/port are unchanged so a
+    // custom scheme/path or default-port URL is not silently downgraded (P5/P8/P10) and a
+    // concurrent edit to an unmodeled URL part survives (P41). Otherwise rebuild from the
+    // host/port: a settings export normalizes a wildcard/IPv6 BIND host into a connectable
+    // client URL (clientHost), but a file source's host came from a user-authored CONNECT
+    // URL and must round-trip verbatim, so a port-only edit keeps the untouched host instead
+    // of rewriting `0.0.0.0`->`127.0.0.1` / `[::]`->`[::1]` (fileSourceUrlHost, P60).
+    const rebuiltHost = fileSource
+      ? fileSourceUrlHost(settings.transportHost)
+      : clientHost(settings.transportHost);
+    const url =
+      (fileSource
+        ? preservedFileUrl(settings, urlBase)
+        : preservedTransportUrl(settings)) ??
+      `http://${rebuiltHost}:${settings.transportPort}${
         settings.transportMode === 'http' ? '/mcp' : '/sse'
-      }`,
+      }`;
+    // A file entry with no usable url (`{"type":"http"}`, `url: ""`, a non-string url) has
+    // nothing for preservedFileUrl to keep, so the canonical fallback above would write
+    // http://127.0.0.1:9444/mcp on an otherwise no-op save -- turning an invalid or deliberately
+    // incomplete entry into a live local endpoint the user never chose. Keep the url key exactly
+    // as it was found (absent stays absent, an empty or non-string value round-trips) while the
+    // transport mode, host and port are all untouched; a real host/port edit is a deliberate "set
+    // the endpoint" and still writes the rebuilt URL (P88).
+    const rawFileUrl = fileSource && typeof urlBase.url === 'string' ? urlBase.url.trim() : '';
+    const urlDefaults = defaultSettings();
+    const keepMissingUrl =
+      fileSource &&
+      !rawFileUrl &&
+      settings.transportMode === baseType &&
+      settings.transportHost === urlDefaults.transportHost &&
+      settings.transportPort === urlDefaults.transportPort;
+    const generated: Record<string, unknown> = {
+      type: settings.transportMode === 'http' ? 'http' : 'sse',
     };
+    if (!keepMissingUrl) {
+      generated.url = url;
+    } else if ('url' in urlBase) {
+      generated.url = urlBase.url; // verbatim, including an empty string or non-string value
+    }
+    // For a file source, merge onto the loaded entry so unmodeled VS Code http/sse fields
+    // (headers, oauth, ...) survive an unrelated edit (P7). The merge base is re-derived from
+    // the current on-disk entry at the write step (P20).
+    generatedForMerge = generated;
+    entry = fileSource
+      ? mergeEntryOntoBase(baseEntry!, generated, settings.transportMode)
+      : generated;
   }
 
-  const mcpUri = vscode.Uri.joinPath(folder.uri, '.vscode', 'mcp.json');
-  let existing: Record<string, unknown> = {};
-  let raw: Uint8Array | undefined;
-  try {
-    raw = await vscode.workspace.fs.readFile(mcpUri);
-  } catch (err) {
-    if (!isFileNotFound(err)) {
-      // A real read error (permissions, transient FS) — don't risk clobbering.
-      void vscode.window.showErrorMessage(
-        `wcli0: could not read ${mcpUri.fsPath} (${(err as Error).message}). Not writing.`,
-      );
-      return;
-    }
-    // Not found — start fresh.
+  // Reuse the single up-front snapshot for a file source (P46/P69); the settings-driven export
+  // took no up-front snapshot, so it reads the file fresh here. Both go through the same helper,
+  // which has already applied the malformed-root / non-object-`servers` guards.
+  const writeSnapshot = fileSource ? fileSnapshot! : await readExistingMcpJson(mcpUri);
+  if (!writeSnapshot) {
+    return false; // settings-export read failed / invalid — readExistingMcpJson already reported
   }
-  if (raw) {
-    try {
-      // VS Code registers mcp.json as JSON-with-comments, so tolerate comments
-      // and trailing commas rather than refusing to merge into a valid JSONC file.
-      existing = parseJsonc(Buffer.from(raw).toString('utf8')) as Record<string, unknown>;
-    } catch (err) {
-      // The file exists but is not valid JSON/JSONC — refuse rather than clobber it.
-      void vscode.window.showErrorMessage(
-        `wcli0: ${mcpUri.fsPath} is not valid JSON (${(err as Error).message}). Fix it before writing.`,
-      );
-      return;
-    }
-  }
-  // A syntactically valid file can still have a non-object root or `servers`
-  // (e.g. `null`, or `"servers": []`); merging into those would throw or
-  // silently drop the entry, so refuse rather than corrupt the file.
-  if (!isPlainObject(existing)) {
-    void vscode.window.showErrorMessage(
-      `wcli0: ${mcpUri.fsPath} root is not a JSON object. Fix it before writing.`,
-    );
-    return;
-  }
-  if (existing.servers !== undefined && !isPlainObject(existing.servers)) {
-    void vscode.window.showErrorMessage(
-      `wcli0: "servers" in ${mcpUri.fsPath} is not a JSON object. Fix it before writing.`,
-    );
-    return;
-  }
+  const existing = writeSnapshot.existing;
+  const raw = writeSnapshot.raw;
   // Re-serializing with JSON.stringify drops any comments/formatting the file
   // had. Warn before discarding them rather than silently reformatting.
   if (raw && containsJsoncComments(Buffer.from(raw).toString('utf8'))) {
@@ -362,21 +880,62 @@ export async function writeWorkspaceMcpJson(
       'Write anyway',
     );
     if (pick !== 'Write anyway') {
-      return;
+      return false;
     }
   }
 
   const servers = (existing.servers as Record<string, unknown>) ?? {};
+  // For a file source, merge the form-owned fields onto the SAME on-disk snapshot that
+  // supplied the env/argv/url preservation data — the single read taken up front
+  // (onDiskEntry) — rather than re-reading servers.wcli0 here. The up-front read already
+  // captures an external edit made after the panel loaded (e.g. new headers/envFile/oauth),
+  // so it still satisfies P20; using a SECOND, later read for the merge base would pair a
+  // fresh base with the stale generated env/args built from the up-front read, producing an
+  // incoherent mix that drops externally added env or flags (P46). Falls back to the loaded
+  // baseEntry when no entry was on disk.
+  if (fileSource && generatedForMerge) {
+    const mergeBase = (onDiskEntry ?? baseEntry!) as Record<string, unknown>;
+    entry = mergeEntryOntoBase(mergeBase, generatedForMerge, settings.transportMode);
+  }
   servers.wcli0 = entry;
   existing.servers = servers;
 
+  // The snapshot everything above was built from was taken BEFORE the awaited modal prompts (the
+  // environment prompt, the JSONC-comment warning). If another editor wrote .vscode/mcp.json while
+  // one of those was open, serializing that snapshot now would silently discard the edit -- including
+  // changes to servers this form never touches. Re-read immediately before writing and refuse when
+  // the bytes no longer match, so a concurrent write is reported instead of overwritten (P101).
+  let currentRaw: Uint8Array | undefined;
+  try {
+    currentRaw = await vscode.workspace.fs.readFile(mcpUri);
+  } catch (err) {
+    if (!isFileNotFound(err)) {
+      void vscode.window.showErrorMessage(
+        `wcli0: could not re-read ${mcpUri.fsPath} (${(err as Error).message}). Not writing.`,
+      );
+      return false;
+    }
+  }
+  if (!sameFileBytes(currentRaw, raw)) {
+    void vscode.window.showErrorMessage(
+      `wcli0: ${mcpUri.fsPath} changed while saving, so nothing was written. Reload the source ` +
+        'and apply your edits again.',
+    );
+    return false;
+  }
+
   await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(folder.uri, '.vscode'));
+  // Re-attach a UTF-8 BOM when the file we read had one. parseJsonc strips it so a
+  // "UTF-8 with BOM" file is readable at all (P86), but dropping it on write would silently
+  // re-encode a file the user (or their editor's encoding setting) deliberately saved that way.
+  const hadBom = !!raw && raw.length >= 3 && raw[0] === 0xef && raw[1] === 0xbb && raw[2] === 0xbf;
   await vscode.workspace.fs.writeFile(
     mcpUri,
-    Buffer.from(JSON.stringify(existing, null, 2) + '\n', 'utf8'),
+    Buffer.from((hadBom ? BOM : '') + JSON.stringify(existing, null, 2) + '\n', 'utf8'),
   );
   const doc = await vscode.workspace.openTextDocument(mcpUri);
   await vscode.window.showTextDocument(doc);
+  return true;
 }
 
 /** Show the resolved launch command line and offer to copy it. */
@@ -564,11 +1123,17 @@ export async function refreshServerDefinition(provider: Wcli0McpProvider): Promi
  * genuinely malformed input so callers can refuse to overwrite it.
  */
 export function parseJsonc(text: string): unknown {
+  // Strip a leading UTF-8 BOM. VS Code can save .vscode/mcp.json as "UTF-8 with BOM" and reads
+  // such a file back happily, but Buffer.toString('utf8') keeps the U+FEFF and JSON.parse throws
+  // on it -- which made every caller (detection, the entry load, the save's merge read) treat a
+  // perfectly good file as absent or malformed. Stripping it here covers all of them at once
+  // (P86); the writer re-attaches the BOM so the file's encoding survives a save.
+  const source = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
   let out = '';
   let inString = false;
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    const next = text[i + 1];
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    const next = source[i + 1];
     if (inString) {
       out += ch;
       if (ch === '\\') {
@@ -586,7 +1151,7 @@ export function parseJsonc(text: string): unknown {
       continue;
     }
     if (ch === '/' && next === '/') {
-      while (i < text.length && text[i] !== '\n') {
+      while (i < source.length && source[i] !== '\n') {
         i++;
       }
       out += '\n';
@@ -594,10 +1159,10 @@ export function parseJsonc(text: string): unknown {
     }
     if (ch === '/' && next === '*') {
       i += 2;
-      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
         i++;
       }
-      if (i >= text.length) {
+      if (i >= source.length) {
         // EOF before the closing */ — malformed; don't silently accept the
         // truncated remainder and overwrite the user's file.
         throw new SyntaxError('Unterminated block comment in JSONC input');
@@ -617,6 +1182,9 @@ export function parseJsonc(text: string): unknown {
   }
   return JSON.parse(out);
 }
+
+/** The UTF-8 byte-order mark, as the single character it decodes to (U+FEFF). */
+const BOM = '\ufeff';
 
 /** Whether the text contains a `//` or block comment outside any string. */
 function containsJsoncComments(text: string): boolean {
@@ -703,6 +1271,73 @@ async function implicitConfigIn(dir: vscode.Uri): Promise<string | undefined> {
     // Not present — no committed override vector.
     return undefined;
   }
+}
+
+/**
+ * Read and parse `.vscode/mcp.json` into the object the wcli0 entry is merged into, applying the
+ * malformed-root / non-object-`servers` guards. Returns `{ raw, existing }` on success (with
+ * `raw` undefined and `existing` an empty object when the file does not exist yet), or `undefined`
+ * when the file cannot be used — a real read error, or invalid JSON/root/`servers` — after showing
+ * the user why. A file-source save takes this snapshot ONCE up front and reuses it for the merge
+ * base, the surrounding servers, and the comment-removal check, so a concurrent delete/recreate
+ * between two separate reads cannot drop the file's other servers (P69).
+ */
+/**
+ * Whether two optional file snapshots hold identical bytes; two absent files count as identical.
+ * Used for the pre-write re-read below (P101).
+ */
+function sameFileBytes(a: Uint8Array | undefined, b: Uint8Array | undefined): boolean {
+  if (a === undefined || b === undefined) {
+    return a === undefined && b === undefined;
+  }
+  return a.length === b.length && Buffer.compare(Buffer.from(a), Buffer.from(b)) === 0;
+}
+
+async function readExistingMcpJson(
+  mcpUri: vscode.Uri,
+): Promise<{ raw?: Uint8Array; existing: Record<string, unknown> } | undefined> {
+  let raw: Uint8Array;
+  try {
+    raw = await vscode.workspace.fs.readFile(mcpUri);
+  } catch (err) {
+    if (!isFileNotFound(err)) {
+      // A real read error (permissions, transient FS) — don't risk clobbering.
+      void vscode.window.showErrorMessage(
+        `wcli0: could not read ${mcpUri.fsPath} (${(err as Error).message}). Not writing.`,
+      );
+      return undefined;
+    }
+    // Not found — start fresh.
+    return { raw: undefined, existing: {} };
+  }
+  let existing: Record<string, unknown>;
+  try {
+    // VS Code registers mcp.json as JSON-with-comments, so tolerate comments
+    // and trailing commas rather than refusing to merge into a valid JSONC file.
+    existing = parseJsonc(Buffer.from(raw).toString('utf8')) as Record<string, unknown>;
+  } catch (err) {
+    // The file exists but is not valid JSON/JSONC — refuse rather than clobber it.
+    void vscode.window.showErrorMessage(
+      `wcli0: ${mcpUri.fsPath} is not valid JSON (${(err as Error).message}). Fix it before writing.`,
+    );
+    return undefined;
+  }
+  // A syntactically valid file can still have a non-object root or `servers`
+  // (e.g. `null`, or `"servers": []`); merging into those would throw or
+  // silently drop the entry, so refuse rather than corrupt the file.
+  if (!isPlainObject(existing)) {
+    void vscode.window.showErrorMessage(
+      `wcli0: ${mcpUri.fsPath} root is not a JSON object. Fix it before writing.`,
+    );
+    return undefined;
+  }
+  if (existing.servers !== undefined && !isPlainObject(existing.servers)) {
+    void vscode.window.showErrorMessage(
+      `wcli0: "servers" in ${mcpUri.fsPath} is not a JSON object. Fix it before writing.`,
+    );
+    return undefined;
+  }
+  return { raw, existing };
 }
 
 /** Whether a workspace.fs read error means the file is simply absent. */

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -1,0 +1,1277 @@
+import * as vscode from 'vscode';
+import { isValidLogLimit, isValidMaxOutputLines } from './argsBuilder';
+import { parseJsonc } from './commands';
+import { defaultSettings, SHELL_NAMES, TransportMode, TriState, Wcli0Settings } from './settings';
+
+/**
+ * The kinds of configuration source the form can edit, one at a time. `settings`
+ * is the existing VS Code settings editing (the default); `mcpJson` is the
+ * workspace `.vscode/mcp.json` file's `servers.wcli0` entry. The model is kept
+ * deliberately small so later tasks (arbitrary file browse, `config.json`) can add
+ * kinds without reworking it.
+ */
+export type ConfigSourceKind = 'settings' | 'mcpJson';
+
+/** A selectable configuration source surfaced in the source switcher. */
+export interface ConfigSource {
+  kind: ConfigSourceKind;
+  /** Display label, e.g. "VS Code Settings" or ".vscode/mcp.json". */
+  label: string;
+  /** Absolute path of the backing file (file sources only). */
+  fsPath?: string;
+  /** JSON pointer of the edited entry, e.g. `servers.wcli0` (file sources only). */
+  pointer?: string;
+  /**
+   * A read-only preview entry (e.g. the implicit `~/.win-cli-mcp/config.json`):
+   * listed for awareness but never loadable or a save target.
+   */
+  readOnly?: boolean;
+  /** Whether a detected file actually contains a wcli0 entry to load. */
+  hasWcli0?: boolean;
+}
+
+/** Result of probing the workspace `.vscode/mcp.json` for a wcli0 entry. */
+export interface McpJsonDetection {
+  uri: vscode.Uri;
+  fsPath: string;
+  /** Whether the file exists and parses as JSON/JSONC with an object root. */
+  exists: boolean;
+  /** Whether a `servers.wcli0` entry is present. */
+  hasWcli0: boolean;
+}
+
+/** The `.vscode/mcp.json` Uri for a workspace folder. */
+export function mcpJsonUri(folder: vscode.WorkspaceFolder): vscode.Uri {
+  return vscode.Uri.joinPath(folder.uri, '.vscode', 'mcp.json');
+}
+
+/**
+ * Probe `<folder>/.vscode/mcp.json` for a `servers.wcli0` entry. Tolerates JSONC
+ * (the format VS Code registers for mcp.json) via {@link parseJsonc}, and never
+ * throws: a missing, unreadable, or malformed file reports `exists`/`hasWcli0`
+ * false so detection can run eagerly on panel open without breaking it.
+ */
+export async function detectWorkspaceMcpJson(
+  folder: vscode.WorkspaceFolder,
+): Promise<McpJsonDetection> {
+  const uri = mcpJsonUri(folder);
+  const base: McpJsonDetection = { uri, fsPath: uri.fsPath, exists: false, hasWcli0: false };
+  let raw: Uint8Array;
+  try {
+    raw = await vscode.workspace.fs.readFile(uri);
+  } catch {
+    // Not found / unreadable — no committed entry to detect.
+    return base;
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseJsonc(Buffer.from(raw).toString('utf8'));
+  } catch {
+    // Present but malformed — surface as existing-but-no-entry rather than throwing.
+    return { ...base, exists: true };
+  }
+  if (!isPlainObject(parsed)) {
+    return { ...base, exists: true };
+  }
+  const servers = parsed.servers;
+  const hasWcli0 = isPlainObject(servers) && isPlainObject(servers.wcli0);
+  return { ...base, exists: true, hasWcli0 };
+}
+
+/** Read and return the `servers.wcli0` entry from a workspace `.vscode/mcp.json`. */
+export async function readWcli0Entry(
+  folder: vscode.WorkspaceFolder,
+): Promise<Record<string, unknown> | undefined> {
+  const uri = mcpJsonUri(folder);
+  let raw: Uint8Array;
+  try {
+    raw = await vscode.workspace.fs.readFile(uri);
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseJsonc(Buffer.from(raw).toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.servers)) {
+    return undefined;
+  }
+  const entry = parsed.servers.wcli0;
+  return isPlainObject(entry) ? entry : undefined;
+}
+
+/** The result of reverse-mapping an mcp.json entry into the form's settings. */
+export interface ParsedEntry {
+  settings: Wcli0Settings;
+  /** Non-blocking notes about parts of the entry the form cannot fully model. */
+  notes: string[];
+}
+
+/** A recognized value-bearing CLI option and how it maps onto settings. */
+type OptionKind = 'string' | 'number' | 'array' | 'csv';
+interface OptionSpec {
+  key: keyof Wcli0Settings;
+  kind: OptionKind;
+}
+
+// Recognized `--option value` / `--option=value` flags, keyed by flag name. Mirror
+// of the forward emission in argsBuilder.buildServerArgs. Transport host/port use the
+// http/sse-specific flag names the forward builder emits. The `config` option's `c`
+// alias (`-c`, `--c`) is included so a hand-written entry that uses the short form is
+// modeled like `--config` instead of dumped to extraArgs (matching the forward
+// builder's stripConfigArgs, which recognizes the same alias forms — P32).
+//
+// The server defines its multi-word options in camelCase, but yargs camel-case
+// expansion ALSO accepts the kebab-case spelling, so a hand-written entry may use
+// `--max-command-length` etc.; the kebab-case aliases below are modeled identically to
+// their camelCase forms so such a value is recognized rather than hidden in extraArgs and
+// then re-emitted in both spellings on save (which yargs parses as an array — P47).
+const VALUE_OPTIONS: Record<string, OptionSpec> = {
+  '--config': { key: 'configFile', kind: 'string' },
+  '-c': { key: 'configFile', kind: 'string' },
+  '--c': { key: 'configFile', kind: 'string' },
+  '--shell': { key: 'shell', kind: 'string' },
+  '--allowedDir': { key: 'allowedDirectories', kind: 'array' },
+  '--allowed-dir': { key: 'allowedDirectories', kind: 'array' },
+  '--initialDir': { key: 'initialDir', kind: 'string' },
+  '--initial-dir': { key: 'initialDir', kind: 'string' },
+  '--commandTimeout': { key: 'commandTimeout', kind: 'number' },
+  '--command-timeout': { key: 'commandTimeout', kind: 'number' },
+  '--maxCommandLength': { key: 'maxCommandLength', kind: 'number' },
+  '--max-command-length': { key: 'maxCommandLength', kind: 'number' },
+  '--wslMountPoint': { key: 'wslMountPoint', kind: 'string' },
+  '--wsl-mount-point': { key: 'wslMountPoint', kind: 'string' },
+  '--blockedCommand': { key: 'blockedCommands', kind: 'array' },
+  '--blocked-command': { key: 'blockedCommands', kind: 'array' },
+  '--blockedArgument': { key: 'blockedArguments', kind: 'array' },
+  '--blocked-argument': { key: 'blockedArguments', kind: 'array' },
+  '--blockedOperator': { key: 'blockedOperators', kind: 'array' },
+  '--blocked-operator': { key: 'blockedOperators', kind: 'array' },
+  '--maxOutputLines': { key: 'maxOutputLines', kind: 'number' },
+  '--max-output-lines': { key: 'maxOutputLines', kind: 'number' },
+  '--maxReturnLines': { key: 'maxReturnLines', kind: 'number' },
+  '--max-return-lines': { key: 'maxReturnLines', kind: 'number' },
+  '--logDirectory': { key: 'logDirectory', kind: 'string' },
+  '--log-directory': { key: 'logDirectory', kind: 'string' },
+  '--transport': { key: 'transportMode', kind: 'string' },
+  '--http-host': { key: 'transportHost', kind: 'string' },
+  '--sse-host': { key: 'transportHost', kind: 'string' },
+  '--http-port': { key: 'transportPort', kind: 'number' },
+  '--sse-port': { key: 'transportPort', kind: 'number' },
+  '--http-allowed-origins': { key: 'transportAllowedOrigins', kind: 'csv' },
+  '--sse-allowed-origins': { key: 'transportAllowedOrigins', kind: 'csv' },
+};
+
+// Boolean / tri-state / safety flags the forward builder emits with no value. Shared by
+// parseServerArgs (which models them) and isRecognizedServerFlag (the suffix detector).
+// The kebab-case spellings are yargs camel-case-expansion aliases of the camelCase
+// options, accepted just like their camelCase forms (P47).
+const BOOLEAN_FLAGS = new Set<string>([
+  '--allowAllDirs',
+  '--allow-all-dirs',
+  '--no-allowAllDirs',
+  '--no-allow-all-dirs',
+  '--debug',
+  '--no-debug',
+  '--yolo',
+  '--no-yolo',
+  '--unsafe',
+  '--no-unsafe',
+  '--enableTruncation',
+  '--no-enableTruncation',
+  '--enable-truncation',
+  '--no-enable-truncation',
+  '--enableLogResources',
+  '--no-enableLogResources',
+  '--enable-log-resources',
+  '--no-enable-log-resources',
+]);
+
+// The value-option flags that select/override transport. For a stdio entry the
+// authoritative `type` field — not a flag in the args — sets transportMode, so these
+// must NOT be consumed when parsing a stdio entry's args; otherwise a stray
+// `--transport http` (or `--http-port`) in a stdio entry flips the type and deletes the
+// launcher on save (P30).
+const TRANSPORT_FLAGS = new Set<string>([
+  '--transport',
+  '--http-host',
+  '--sse-host',
+  '--http-port',
+  '--sse-port',
+  '--http-allowed-origins',
+  '--sse-allowed-origins',
+]);
+
+/** Options for {@link parseServerArgs}. */
+export interface ParseServerArgsOptions {
+  /**
+   * When true, transport flags (`--transport`, `--http-*`, `--sse-*`) are NOT consumed
+   * and instead fall through to `extraArgs` verbatim. Set when parsing a stdio entry,
+   * whose `type` is authoritative and must not be overridden by a transport flag in its
+   * args (P30).
+   */
+  stdio?: boolean;
+}
+
+/**
+ * Whether a flag token is one the form models as a wcli0 server flag — a recognized value-option,
+ * a recognized boolean/tri-state, or an attached `--opt=value` form of either. Used by the suffix
+ * detector to know when the modeled-flags portion of the run has begun, so unknown `--flag value`
+ * pairs AFTER it are treated as extraArgs rather than launcher positionals (P42).
+ *
+ * When `stdio` is true the transport flags (`--transport`, `--http-*`, `--sse-*`) do NOT count as
+ * modeled: a stdio entry's authoritative `type` sets the transport and those flags fall through to
+ * extraArgs verbatim (P30), so they must not "prove" a wcli0 server suffix that would otherwise be
+ * split out and reorder a wrapper's own options on save (P77).
+ *
+ * An attached boolean assignment (`--debug=true`, `--enableTruncation=false`, `--debug=0`) is
+ * recognized just like its bare spelling, so a wrapper suffix carrying only such a flag is still
+ * detected and the flag stays editable instead of being stranded in customArgs (P76). EVERY
+ * attached value counts, not only the literal true/false spellings, matching the attached-boolean
+ * modeling in {@link parseServerArgs}: yargs coerces any other value to false, so
+ * `wrapper target --enableTruncation=0` really does disable truncation and the form must show it
+ * rather than the server default (P94).
+ */
+function isRecognizedServerFlag(token: string, stdio = false): boolean {
+  const isModeledValueOption = (flag: string): boolean =>
+    flag in VALUE_OPTIONS && !(stdio && TRANSPORT_FLAGS.has(flag));
+  if (isModeledValueOption(token) || BOOLEAN_FLAGS.has(token)) {
+    return true;
+  }
+  const eq = token.indexOf('=');
+  if (eq > 0 && token.startsWith('-')) {
+    const flag = token.slice(0, eq);
+    if (isModeledValueOption(flag)) {
+      return true;
+    }
+    return BOOLEAN_FLAGS.has(flag);
+  }
+  return false;
+}
+
+/**
+ * Whether the token following a value option is consumed by yargs as that option's VALUE. Any
+ * non-dash token is; so is a dash-prefixed token that looks like a negative number, which yargs
+ * does NOT treat as a new option (verified against yargs-parser: `--commandTimeout -1` => -1 and
+ * `--shell -1` => '-1', while `--shell -x` => '' plus a separate `-x` flag). Reading `-1` as a
+ * flag hid a repeated option with a negative value from the duplicate pre-scan, so the pair was
+ * modeled last-wins and the save changed the launch (P93). Mirrors argsBuilder's strippers.
+ *
+ * The accepted shapes are exactly the ones the installed parser consumes: an optional integer part
+ * and at most one fractional part (`-1`, `-1.5`, `-.5`, `-0`, `-01`). Scientific notation and a
+ * trailing dot are NOT consumed — yargs reads `--shell -1e2` as an empty shell plus the short
+ * options `1` and `e` — so accepting them modeled a value the server never sees and let a save
+ * rewrite the entry as `--shell=-1e2`, disabling every known shell (P102).
+ */
+function isOptionValueToken(next: string | undefined): boolean {
+  return (
+    next !== undefined && (!next.startsWith('-') || /^-(?:\d+(?:\.\d+)?|\.\d+)$/.test(next))
+  );
+}
+
+/**
+ * Whether `tokens` parse cleanly as a run of wcli0 server flags — the shape the forward
+ * builder emits as the suffix after a launcher's own args. Every token must be a flag
+ * (a recognized value-option consuming the next token as its value, an attached
+ * `--opt=value`, a recognized boolean/tri-state, or any other `--flag` that round-trips
+ * as an extraArg); a bare non-flag token that is not the value of a recognized
+ * value-option is an "orphan" and disqualifies the run. Used to find where the wcli0
+ * flags begin so launcher options that collide with wcli0 flag names stay in the launcher
+ * portion (see {@link serverFlagSuffixStart}).
+ *
+ * When `requireModeled` is true the run must contain at least one MODELED wcli0 flag to
+ * qualify: an unknown-only run such as `--verbose` is then NOT a server-flag suffix and is
+ * left in the launcher portion. This guards a non-wcli0 wrapper whose own trailing option
+ * follows a positional (`wrapper target --verbose`) — without evidence of a modeled flag the
+ * suffix is the wrapper's, not wcli0's, so moving it into extraArgs would reorder it after the
+ * generated server flags on save (`target --shell cmd --verbose`) and change the invocation
+ * (P56). For the wcli0 binary itself (the index-0 case) `requireModeled` stays false: its args
+ * really are wcli0's, so an unknown-only run is a legitimate extraArg.
+ */
+function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = false): boolean {
+  let seenModeled = false;
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === '--') {
+      return false; // options separator — positionals follow, not a pure server-flag run
+    }
+    if (!t.startsWith('-')) {
+      return false; // orphan bare token — not a flag and not consumed as a value
+    }
+    const eq = t.indexOf('=');
+    if (eq > 0) {
+      // Attached `--opt=value` / `-c=value` (recognized modeled or an extraArg) — self-contained.
+      if (isRecognizedServerFlag(t, stdio)) {
+        seenModeled = true;
+      }
+      continue;
+    }
+    if (t in VALUE_OPTIONS) {
+      if (i + 1 >= tokens.length) {
+        return false; // a value-option with no value cannot be a clean server flag
+      }
+      // A stdio entry's transport flags consume their value structurally but are NOT modeled
+      // evidence (they fall through to extraArgs verbatim, P30); counting them would let a
+      // transport-only suffix masquerade as wcli0's and reorder a wrapper's options on save (P77).
+      if (!(stdio && TRANSPORT_FLAGS.has(t))) {
+        seenModeled = true;
+      }
+      i++; // consume the value
+      // An array option is GREEDY in yargs (greedy-arrays defaults to true), so every further
+      // value token belongs to it too and is not an orphan that disqualifies the run (P99).
+      if (VALUE_OPTIONS[t].kind === 'array') {
+        while (isOptionValueToken(tokens[i + 1])) {
+          i++;
+        }
+      }
+      continue;
+    }
+    if (BOOLEAN_FLAGS.has(t)) {
+      seenModeled = true; // a recognized boolean/tri-state modeled flag
+      continue;
+    }
+    // Any other bare `--flag` round-trips as an extraArg. Once the modeled portion has
+    // begun, it may carry a space-separated value; consume that value so a run of
+    // `--unknown value` pairs in the suffix stays pure (P42, generalizing the P24 trailing
+    // rule to any number of pairs). Before any modeled flag the following bare token is a
+    // launcher positional and must NOT be consumed — it disqualifies the run via the orphan
+    // check above, keeping wrapper options/positionals in the launcher portion (P15/P17).
+    if (
+      seenModeled &&
+      i + 1 < tokens.length &&
+      !tokens[i + 1].startsWith('-') &&
+      tokens[i + 1] !== '--'
+    ) {
+      i++; // consume this extraArg's value
+    }
+  }
+  // A pure flag run qualifies unconditionally, except when the caller demands evidence of a
+  // modeled wcli0 flag (a wrapper scan): an unknown-only run is then not a server-flag suffix
+  // and stays in the launcher portion (P56).
+  return requireModeled ? seenModeled : true;
+}
+
+/**
+ * The index where the wcli0 server-flag suffix begins in a launcher's full arg list. The
+ * forward builder emits `[...launcherArgs, ...serverFlags]`, so the server flags are a
+ * contiguous suffix: return the smallest index whose remaining tokens form a pure
+ * server-flag run starting with a flag. Everything before it is the launcher's own args.
+ * Defaults to `args.length` (no server flags). Scanning for the longest such suffix keeps
+ * launcher options whose names collide with wcli0 flags (a wrapper's `--config`, node's
+ * `--inspect`) in the launcher portion (P15).
+ *
+ * `allowIndexZero` is true only when the command IS the wcli0 binary, so an index-0 run
+ * really is server flags. For a non-wcli0 (wrapper) command an index-0 flag run is
+ * ambiguous — `mywrapper --transport fast` is the wrapper's own option, not a wcli0 flag
+ * (P-wrapperflags) — so scanning starts at index 1: the leading token stays in the
+ * launcher portion and the scan still finds a LATER modeled-flag suffix, e.g. the
+ * `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
+ *
+ * A wrapper scan additionally requires the suffix to contain a modeled wcli0 flag
+ * (`requireModeled`), so an unknown-only run such as the wrapper's own `--verbose` in
+ * `wrapper target --verbose` is NOT mistaken for a server-flag suffix and stays in the
+ * launcher portion (P56). The wcli0 binary itself (allowIndexZero) does not require this: its
+ * args are genuinely wcli0's, including unknown-only extraArgs.
+ *
+ * The scan stops at a `--` options separator, because yargs treats everything after one as
+ * positionals, so no server-flag suffix can begin there (P75). The single exception is a
+ * pass-through separator that is PROVEN to be one: a wrapper whose separator is followed by the
+ * wcli0 binary itself (`npx --package=wcli0 -- wcli0 --shell cmd`, P17). There the scan resumes
+ * after that binary token, since the flags following it really are wcli0's. For any other
+ * separator -- `node --inspect dist/index.js -- --debug`, a wrapper passing positionals to some
+ * other program -- the remainder stays with the launcher, so a positional `--debug` is not modeled
+ * as an active flag and a newly saved `--shell cmd` is not appended after a separator where the
+ * server would never read it (P83). `stdio` is forwarded to the run check so a stdio entry's
+ * transport flags do not count as modeled evidence (P77).
+ */
+function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = false): number {
+  for (let i = allowIndexZero ? 0 : 1; i < args.length; i++) {
+    if (args[i] === '--') {
+      // An options separator: yargs treats every following token as a positional, so no
+      // server-flag suffix can begin at or after it (P75). Stop -- unless this is a wrapper
+      // separator with the wcli0 binary itself behind it, the one shape that PROVES a
+      // pass-through (`npx --package=wcli0 -- wcli0 --shell cmd`, P17): there the scan resumes
+      // after that binary token, whose own flags are genuinely wcli0's. Anything else (a generic
+      // `node --inspect dist/index.js -- --debug`, a wrapper handing positionals to another
+      // program) keeps its remainder in the launcher portion, so a positional is never modeled as
+      // an active flag and a saved flag is never appended behind a separator the server ignores
+      // (P83). A second `--` after the wrapped binary is that binary's own separator and stops
+      // the scan, exactly as it does for a direct wcli0 launch.
+      if (allowIndexZero) {
+        break;
+      }
+      const wrappedBinaryAt = args.findIndex((t, j) => j > i && isWcli0Command(t));
+      if (wrappedBinaryAt === -1) {
+        break;
+      }
+      i = wrappedBinaryAt; // resume scanning at the token AFTER the wrapped wcli0 binary
+      continue;
+    }
+    if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), !allowIndexZero, stdio)) {
+      return i;
+    }
+  }
+  return args.length;
+}
+
+/**
+ * Whether a custom launch `command` is the wcli0 binary itself (so its args are wcli0
+ * server flags rather than a wrapper's own options). Matched by basename, tolerating a
+ * directory prefix and a `.js`/`.cjs`/`.mjs`/`.cmd`/`.bat`/`.exe` suffix. Used to decide
+ * whether a server-flag run starting at arg index 0 can be trusted (P-wrapperflags).
+ */
+function isWcli0Command(command: string): boolean {
+  const base = command.trim().replace(/\\/g, '/').split('/').pop() ?? '';
+  return /^wcli0(\.(js|cjs|mjs|cmd|bat|exe))?$/i.test(base);
+}
+
+/**
+ * The config-file string yargs derives from a single-dash bundle's remainder after the `c`
+ * alias (the part after `c` in `-c<remainder>`), or `undefined` when yargs would NOT read it
+ * as the config string. Verified against yargs-parser: it attaches the remainder as the value
+ * only when the remainder is fully numeric (`-c123`, `-c-5`, `-c5.5`) or when its first
+ * character is a non-word, non-dot character with at least one more character following
+ * (`-c/etc/x.json`, `-c~/x.json`, `-c\\srv\share`). A word-character start (`-cfoo`, `-cX`,
+ * even `-cC:/x.json`) makes yargs split the remainder into separate short boolean flags so
+ * `config` is empty; a leading `.` triggers dot-notation object parsing (`-c.foo` =>
+ * `config={foo:true}`); and a lone non-word char (`-c/`) is also read as a boolean. In every
+ * such case `config` is NOT the literal remainder, so the bundle must round-trip verbatim
+ * rather than fabricate a config path (P62).
+ */
+function yargsBundleConfigValue(remainder: string): string | undefined {
+  if (/^-?\d+(\.\d*)?(e-?\d+)?$/.test(remainder)) {
+    return remainder;
+  }
+  if (remainder.length >= 2 && /\W/.test(remainder[0]) && remainder[0] !== '.') {
+    return remainder;
+  }
+  return undefined;
+}
+
+/**
+ * Reverse of {@link buildServerArgs}: parse a wcli0 flag list back into the subset
+ * of settings the form models, plus the leftover (unrecognized) flags. Accepts both
+ * `--opt value` and `--opt=value` forms and the boolean/tri-state/safety flags the
+ * forward builder emits. Anything unrecognized is preserved verbatim in `extraArgs`
+ * so a save round-trips it rather than silently dropping it.
+ */
+export function parseServerArgs(
+  args: string[],
+  opts: ParseServerArgsOptions = {},
+): {
+  settings: Partial<Wcli0Settings>;
+  extraArgs: string[];
+} {
+  const out: Partial<Wcli0Settings> = {};
+  const extraArgs: string[] = [];
+  const arrays: Partial<Record<keyof Wcli0Settings, string[]>> = {};
+
+  // Look up a value-option, honoring the stdio exclusion: a stdio entry's authoritative
+  // `type` sets transportMode, so a transport flag in its args is NOT modeled and falls
+  // through to extraArgs verbatim (P30).
+  const optionFor = (flag: string): OptionSpec | undefined => {
+    const spec = VALUE_OPTIONS[flag];
+    if (spec && opts.stdio && TRANSPORT_FLAGS.has(flag)) {
+      return undefined;
+    }
+    return spec;
+  };
+
+  const pushArray = (key: keyof Wcli0Settings, value: string) => {
+    const list = (arrays[key] ??= []);
+    list.push(value);
+  };
+  const applyValue = (spec: OptionSpec, value: string) => {
+    switch (spec.kind) {
+      case 'array':
+        pushArray(spec.key, value);
+        break;
+      case 'csv':
+        (out as Record<string, unknown>)[spec.key] = value
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      case 'number': {
+        const n = Number(value);
+        (out as Record<string, unknown>)[spec.key] = Number.isFinite(n) ? n : value;
+        break;
+      }
+      default:
+        (out as Record<string, unknown>)[spec.key] = value;
+    }
+  };
+  // Whether a numeric option's value should be preserved verbatim in extraArgs rather than
+  // modeled into the typed field. An unparseable value would poison the typed field and then
+  // block every save (P34). A log limit (maxReturnLines / maxOutputLines) the typed field
+  // cannot faithfully re-emit — finite but outside the config-file bound the forward builder
+  // and validateLaunchSpec enforce (1..10000, integer for maxReturnLines) — is also diverted:
+  // the server still applies any such CLI value > 0 via applyCliLogging (no re-validation), so
+  // a hand-authored `--maxReturnLines 50000` or `--maxOutputLines 0` must round-trip rather
+  // than strand the save (maxReturnLines has no form control, so it is otherwise unfixable). A
+  // non-positive commandTimeout / maxCommandLength is diverted too: the server simply ignores
+  // such a value and runs on its default (applyCliShellAndAllowedDirs never lowers the limit
+  // for it), but the form's number input rejects a negative and validateLaunchSpec blocks any
+  // value <= 0, so modeling a hand-authored `--commandTimeout 0` / `--maxCommandLength=-1`
+  // would strand every save. Preserving it lets an unrelated edit round-trip the entry (P64).
+  // A value the field CAN hold is modeled normally so the form stays editable (P59).
+  const divertNumber = (spec: OptionSpec, raw: string): boolean => {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) {
+      return true;
+    }
+    if (spec.key === 'maxReturnLines') {
+      return !isValidLogLimit(n);
+    }
+    if (spec.key === 'maxOutputLines') {
+      return !isValidMaxOutputLines(n);
+    }
+    if (spec.key === 'commandTimeout' || spec.key === 'maxCommandLength') {
+      return n <= 0;
+    }
+    return false;
+  };
+
+  // Whether a `--shell` value must be preserved verbatim instead of modeled. The form's shell
+  // control is a fixed <select>, so the ONLY values it can hold are the five real shell names
+  // (SHELL_NAMES) plus its own `all` sentinel. Anything else is unrepresentable:
+  //   - `all` is an OMISSION sentinel here — buildServerArgs emits no `--shell` for it — but the
+  //     server's `--shell all` is a shell NAME, loading only a module called "all" that does not
+  //     exist, so the entry has NO usable shells. Modeling it as the sentinel let a no-op save
+  //     drop the flag and re-enable every default shell (P96).
+  //   - any other name (`fish`, `zsh`, `ALL`) cannot be selected at all: assigning it leaves the
+  //     select on its empty/Inherit value, the form counts as changed, and a save drops `--shell`
+  //     — again turning an entry the server matched to no shell into one running the defaults
+  //     (P100).
+  // Both are preserved verbatim instead, so the entry round-trips and the save changes nothing.
+  const divertShellValue = (spec: OptionSpec, raw: string): boolean =>
+    spec.key === 'shell' && !(SHELL_NAMES as readonly string[]).includes(raw);
+
+  // Whether an option is a single-value (scalar) field rather than an accumulating array. yargs
+  // parses a REPEATED scalar option as an array (`--config a --config b` => ['a','b'], `--shell cmd
+  // --shell bash` => ['cmd','bash']), which a single-value form field cannot represent and which
+  // the server often treats very differently from the last value. Array-kind options legitimately
+  // repeat, so they are exempt from the duplicate handling below.
+  const isScalarOption = (spec: OptionSpec): boolean => spec.kind !== 'array';
+
+  // The scalar option keys that appear more than once in this arg list. A duplicated scalar is NOT
+  // modeled last-wins (which would silently collapse `--config a --config b` to `b` on a no-op
+  // save); instead every occurrence is preserved verbatim in extraArgs so the hand-authored entry
+  // round-trips unchanged (P78). The count follows the modeling paths in the loop below — it honors
+  // the stdio transport exclusion (optionFor), the `-c` config bundle, and stops at the `--`
+  // separator (P74) — but deliberately counts a SYNTACTICALLY present occurrence even when its
+  // value would be diverted from the typed field (an unparseable or out-of-range number, P34/P59).
+  // yargs still turns such a repeat into an array (verified: `--commandTimeout bad
+  // --commandTimeout 5` => ['bad', 5], which applyCliSecurityOverrides ignores because it is not a
+  // number), so counting only the representable occurrence modeled the entry as a plain
+  // `--commandTimeout 5` and let the builder strip the preserved malformed copy — changing a
+  // launch that ran on the default timeout into one that applies 5 (P90).
+  const duplicatedScalarKeys = ((): Set<keyof Wcli0Settings> => {
+    const counts = new Map<keyof Wcli0Settings, number>();
+    const bump = (key: keyof Wcli0Settings) => counts.set(key, (counts.get(key) ?? 0) + 1);
+    for (let i = 0; i < args.length; i++) {
+      const token = args[i];
+      if (token === '--') {
+        break; // options separator: the remainder is positional and is never parsed (P74)
+      }
+      const eq = token.indexOf('=');
+      if (eq > 0 && token.startsWith('-')) {
+        const spec = optionFor(token.slice(0, eq));
+        if (spec && isScalarOption(spec)) {
+          bump(spec.key); // counted even when divertNumber would keep the value out of the field
+        }
+        continue;
+      }
+      // `-c` short bundle carrying the config alias (mirrors the bundle path in the loop below).
+      if (token.length > 1 && token[0] === '-' && token[1] !== '-' && token.includes('c')) {
+        const attached = token.slice(token.indexOf('c') + 1);
+        if (attached) {
+          if (yargsBundleConfigValue(attached) !== undefined) {
+            bump('configFile');
+          }
+        } else {
+          // `c` is the bundle's last character: yargs defines config from the next token, or as
+          // an empty string when none follows -- either way the key is present (P98).
+          bump('configFile');
+        }
+        continue;
+      }
+      const spec = optionFor(token);
+      if (spec && isScalarOption(spec)) {
+        // Counted on PRESENCE for a string/csv option, because yargs defines the key even with no
+        // value (verified: `--shell --debug --shell bash` => shell: ['', 'bash'], which is not a
+        // usable shell name). Requiring a value token hid that occurrence, so only `bash` was
+        // modeled, the preserved `--shell` was stripped when the field was emitted, and a no-op
+        // save rewrote an entry with NO usable shell into one running commands through Bash (P98).
+        // A NUMBER option is different: yargs DROPS a valueless one entirely (`--commandTimeout
+        // --commandTimeout 5` => 5, no array), so counting it would preserve a pair the server
+        // resolves to a single value and leave the form showing no timeout (P102). Values the
+        // typed field cannot hold are still counted (P90).
+        if (spec.kind !== 'number' || isOptionValueToken(args[i + 1])) {
+          bump(spec.key);
+        }
+      }
+    }
+    const dups = new Set<keyof Wcli0Settings>();
+    for (const [key, n] of counts) {
+      if (n >= 2) {
+        dups.add(key);
+      }
+    }
+    return dups;
+  })();
+
+  // yargs declares allowAllDirs/debug/yolo/unsafe/enableTruncation/enableLogResources as
+  // `type:'boolean'` (src/index.ts), and a boolean option consumes a following bare
+  // `true`/`false` token as its value (verified against yargs: `--debug false` => debug=false;
+  // any OTHER following token is left as a positional and the flag reads true). Model that
+  // explicit value rather than recording every bare flag as true and stranding the `false` in
+  // extraArgs, which would make the form show the opposite of what the server runs and let the
+  // preserved value defeat a later edit (P68). The negated `--no-*` spellings already mean false
+  // and do not consume a following token, so they are matched verbatim below.
+  const boolValueFollows = (i: number): boolean =>
+    args[i + 1] === 'true' || args[i + 1] === 'false';
+  const boolValueAt = (i: number): boolean => args[i + 1] !== 'false';
+
+  // A hand-authored entry that sets BOTH --yolo and --unsafe is rejected by the server, which
+  // declares them mutually exclusive (.conflicts('unsafe','yolo') in src/index.ts). yargs' check
+  // fails whenever both keys are DEFINED, regardless of their boolean value — and yargs-parser
+  // defines the key for every spelling: `--yolo`, `--yolo true/false`, `--no-yolo`, and the
+  // attached `--yolo=true/false`. So pairing --unsafe with ANY yolo spelling (even `--yolo false`
+  // or `--no-yolo`) is rejected, not just the both-positive case (verified against yargs). Detect
+  // the conflict whenever both families are present in any form; the loop then preserves every
+  // safety-family token verbatim in extraArgs and leaves safetyMode at its default. Collapsing the
+  // pair to one mode would let a no-op save rewrite a previously-failing entry into a valid launch
+  // the user never chose (P70/P71).
+  // Scan only the tokens BEFORE the `--` options separator. yargs treats everything after it as
+  // positional, so a safety flag there never defines its key and cannot conflict: it runs
+  // `['--unsafe', '--', '--yolo']` in unsafe mode. Scanning the whole array reported a phantom
+  // conflict, which stranded `--unsafe` in extraArgs and left the form showing the default safe
+  // mode while the server actually ran unsafe -- and picking another mode from that misreported
+  // form could then emit a REAL --yolo/--unsafe conflict the server rejects (P79). Mirrors the
+  // parse loop and the duplicate-scalar pre-scan, which both stop at the separator (P74/P78).
+  const separatorAt = args.indexOf('--');
+  const optionArgs = separatorAt === -1 ? args : args.slice(0, separatorAt);
+  const yoloPresent = optionArgs.some(
+    (t) => t === '--yolo' || t === '--no-yolo' || t.startsWith('--yolo='),
+  );
+  const unsafePresent = optionArgs.some(
+    (t) => t === '--unsafe' || t === '--no-unsafe' || t.startsWith('--unsafe='),
+  );
+  const safetyConflict = yoloPresent && unsafePresent;
+
+  // Model a yargs attached boolean assignment (`--debug=true`, `--enableTruncation=false`, the
+  // safety flags, ...) the same way the bare spellings below are modeled, so the form reflects
+  // the real setting and a later edit is not defeated by a stale attached value surviving in
+  // extraArgs (yargs parses `--debug --debug=false` as debug=false, last-wins) (P72). `on` follows
+  // yargs' own coercion for a declared boolean -- exactly the string `true` is true, EVERY other
+  // attached value (`0`, `1`, `yes`, `FALSE`) is false (P87). Returns false when the flag is not a
+  // known boolean (the caller then preserves it verbatim) -- including a safety flag under a
+  // conflict, which must round-trip unchanged to keep the server-rejected state intact (P71).
+  const applyAttachedBoolean = (flag: string, on: boolean): boolean => {
+    switch (flag) {
+      case '--allowAllDirs':
+      case '--allow-all-dirs':
+        out.allowAllDirs = on;
+        return true;
+      case '--debug':
+        out.debug = on;
+        return true;
+      case '--enableTruncation':
+      case '--enable-truncation':
+        out.enableTruncation = (on ? 'enabled' : 'disabled') as TriState;
+        return true;
+      case '--enableLogResources':
+      case '--enable-log-resources':
+        out.enableLogResources = (on ? 'enabled' : 'disabled') as TriState;
+        return true;
+      case '--yolo':
+      case '--unsafe': {
+        if (safetyConflict) {
+          return false; // preserve verbatim — the conflicting entry is server-rejected (P71)
+        }
+        // Last-wins, exactly as yargs resolves a repeated boolean (verified: `--unsafe
+        // --unsafe=false` => unsafe:false, `--unsafe=false --unsafe` => unsafe:true). A later
+        // FALSE must therefore clear a mode an earlier occurrence set, or a no-op save would
+        // rewrite `--unsafe --unsafe=false` as a bare `--unsafe` and disable every protection
+        // the entry actually kept (P89).
+        const mode = flag === '--yolo' ? 'yolo' : 'unsafe';
+        if (on) {
+          out.safetyMode = mode;
+        } else if (out.safetyMode === mode) {
+          out.safetyMode = 'safe';
+        }
+        return true;
+      }
+      default:
+        return false;
+    }
+  };
+
+  // Model the REMAINING values of a greedy array option. yargs' `greedy-arrays` defaults to true
+  // (documented in yargs-parser's README), so an array option swallows every following value token,
+  // not just the first: verified against the installed parser, `--blockedCommand rm del --debug`
+  // => ['rm', 'del'] and `--blockedCommand=rm del` => ['rm', 'del']. Modeling only the first value
+  // left the rest in extraArgs, and re-emitting them after the modeled pair turned them into
+  // positionals the server never applies — an unrelated save silently shrank a blocklist or an
+  // allowed-directory list (P99). Only `array` kinds are greedy; the server declares exactly those
+  // four options with `array: true` (src/index.ts), and its csv options take a single token.
+  const consumeGreedyArrayValues = (spec: OptionSpec, from: number): number => {
+    if (spec.kind !== 'array') {
+      return from;
+    }
+    let at = from;
+    while (isOptionValueToken(args[at + 1])) {
+      applyValue(spec, args[at + 1]);
+      at++;
+    }
+    return at;
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i];
+    // The `--` options separator: yargs treats every following token as a positional, not an
+    // option (`node script.js -- --shell cmd` leaves `--shell`/`cmd` positional, NOT shell=cmd).
+    // Preserve the separator and the remainder verbatim and stop parsing so a no-op save does not
+    // re-emit those positionals as active wcli0 flags and change the launch behavior (P74).
+    if (token === '--') {
+      for (let j = i; j < args.length; j++) {
+        extraArgs.push(args[j]);
+      }
+      break;
+    }
+    // Boolean / tri-state / safety flags. Each positive spelling accepts both the camelCase
+    // form and its yargs kebab-case alias (P47), and consumes a following explicit
+    // `true`/`false` value the way yargs does (P68).
+    if (token === '--allowAllDirs' || token === '--allow-all-dirs') {
+      out.allowAllDirs = boolValueAt(i);
+      if (boolValueFollows(i)) {
+        i++;
+      }
+      continue;
+    }
+    // yargs accepts a negated boolean (`--no-X`) for every boolean option the server declares
+    // (allowAllDirs / debug / yolo / unsafe — see src/index.ts). Consume and model these here
+    // rather than letting them fall through to extraArgs: a preserved `--no-debug` survives a
+    // save and yargs then parses `--debug --no-debug` as debug=false, silently discarding the
+    // user's form edit (P63).
+    if (token === '--no-allowAllDirs' || token === '--no-allow-all-dirs') {
+      out.allowAllDirs = false;
+      continue;
+    }
+    if (token === '--debug') {
+      out.debug = boolValueAt(i);
+      if (boolValueFollows(i)) {
+        i++;
+      }
+      continue;
+    }
+    if (token === '--no-debug') {
+      out.debug = false;
+      continue;
+    }
+    // --yolo / --unsafe select the safety mode. Under a conflict (both safety keys defined in any
+    // form — see safetyConflict) the server rejects the entry, so the flag is preserved verbatim
+    // in extraArgs rather than collapsed to one mode that silently turns the rejected entry into a
+    // valid launch (P70/P71); the following true/false (if any) falls through to extraArgs on the
+    // next iteration, keeping the original tokens intact. With no conflict an explicit `--yolo
+    // false` / `--unsafe false` is not a positive (it leaves the default mode) and consumes its
+    // value.
+    if (token === '--yolo' || token === '--unsafe') {
+      if (safetyConflict) {
+        extraArgs.push(token);
+        continue;
+      }
+      const on = boolValueAt(i);
+      if (boolValueFollows(i)) {
+        i++;
+      }
+      // Last-wins like yargs (`--unsafe --unsafe false` => unsafe:false): an explicit false
+      // clears a mode an earlier occurrence of the SAME family set, mirroring the `--no-*`
+      // spellings below. Without this a repeated flag ending in false was modeled as the
+      // positive mode and a no-op save dropped the false, disabling the protections (P89).
+      const mode = token === '--yolo' ? 'yolo' : 'unsafe';
+      if (on) {
+        out.safetyMode = mode;
+      } else if (out.safetyMode === mode) {
+        out.safetyMode = 'safe';
+      }
+      continue;
+    }
+    // Under a safety conflict (both yolo and unsafe keys defined) the entry is server-rejected, so
+    // a negation must round-trip verbatim alongside the positive flags rather than be modeled or
+    // dropped — otherwise a no-op save of `--no-yolo --unsafe` collapses to a valid `--unsafe`
+    // launch (P71).
+    if (safetyConflict && (token === '--no-yolo' || token === '--no-unsafe')) {
+      extraArgs.push(token);
+      continue;
+    }
+    // A negated safety flag clears only the matching mode. With no conflict only one family is
+    // present, so a `--no-yolo` simply mirrors yargs' last-wins (`--yolo --no-yolo` => safe)
+    // without clobbering an unrelated selection. With no positive seen, safetyMode stays default.
+    if (token === '--no-yolo' && out.safetyMode === 'yolo') {
+      out.safetyMode = 'safe';
+      continue;
+    }
+    if (token === '--no-unsafe' && out.safetyMode === 'unsafe') {
+      out.safetyMode = 'safe';
+      continue;
+    }
+    if (token === '--no-yolo' || token === '--no-unsafe') {
+      continue;
+    }
+    if (token === '--enableTruncation' || token === '--enable-truncation') {
+      out.enableTruncation = (boolValueAt(i) ? 'enabled' : 'disabled') as TriState;
+      if (boolValueFollows(i)) {
+        i++;
+      }
+      continue;
+    }
+    if (token === '--no-enableTruncation' || token === '--no-enable-truncation') {
+      out.enableTruncation = 'disabled' as TriState;
+      continue;
+    }
+    if (token === '--enableLogResources' || token === '--enable-log-resources') {
+      out.enableLogResources = (boolValueAt(i) ? 'enabled' : 'disabled') as TriState;
+      if (boolValueFollows(i)) {
+        i++;
+      }
+      continue;
+    }
+    if (token === '--no-enableLogResources' || token === '--no-enable-log-resources') {
+      out.enableLogResources = 'disabled' as TriState;
+      continue;
+    }
+    // Attached `--opt=value` / `-c=value` form (any single-or-double dash flag with `=`).
+    const eq = token.indexOf('=');
+    if (eq > 0 && token.startsWith('-')) {
+      const flag = token.slice(0, eq);
+      const value = token.slice(eq + 1);
+      // A yargs attached boolean assignment (`--debug=true`, `--enableTruncation=false`,
+      // `--debug=0`, ...): model it so the form reflects the real setting and a later edit is
+      // not defeated by a stale value preserved in extraArgs (P72). EVERY attached value is
+      // modeled, not just the literal true/false spellings, because yargs-parser coerces the
+      // attached string of a declared boolean with `val === 'true'` (processValue) -- so
+      // `--debug=0`, `--debug=1` and `--debug=yes` all mean FALSE. Preserving those in extraArgs
+      // let a later "enable Debug" emit `--debug` followed by the preserved `--debug=0`, which
+      // yargs resolves last-wins back to false and silently defeats the edit (P87).
+      // applyAttachedBoolean returns false for a non-boolean flag (and for a safety flag under a
+      // conflict), which then falls through and is preserved verbatim below.
+      if (applyAttachedBoolean(flag, value === 'true')) {
+        continue;
+      }
+      const spec = optionFor(flag);
+      if (spec) {
+        const v = value;
+        if (divertShellValue(spec, v)) {
+          // A shell name the form's select cannot hold (`all`, `fish`, ...) — preserve it (P96/P100).
+          extraArgs.push(token);
+          continue;
+        }
+        if (spec.kind === 'number' && divertNumber(spec, v)) {
+          // A numeric value the typed field cannot faithfully hold: an unparseable value
+          // (P34) or an out-of-range log limit (P59). Preserve it verbatim so it round-trips
+          // instead of poisoning the field and blocking every save.
+          extraArgs.push(token);
+          continue;
+        }
+        if (isScalarOption(spec) && duplicatedScalarKeys.has(spec.key)) {
+          // A scalar option repeated in the entry: yargs makes it an array, so preserve every
+          // occurrence verbatim rather than collapsing to a last-wins value the field can't
+          // represent (P78).
+          extraArgs.push(token);
+          continue;
+        }
+        applyValue(spec, v);
+        i = consumeGreedyArrayValues(spec, i);
+        continue;
+      }
+      extraArgs.push(token);
+      continue;
+    }
+    // Short-option bundle carrying the `c` config alias without `=` (yargs reads the `c`
+    // alias anywhere in a single-dash bundle as --config): `-c/other.json`, `-cX`,
+    // `-xc/other.json`, `-dc /other.json`. Mirror argsBuilder.stripConfigArgs so a bundled
+    // config pin is modeled as configFile instead of being hidden in extraArgs, where the
+    // Config file field and loadability checks would miss it (P45). The `--config`/`--c`
+    // long forms and every `=` form are handled by the value-option paths above/below.
+    if (token.length > 1 && token[0] === '-' && token[1] !== '-' && token.includes('c')) {
+      const attached = token.slice(token.indexOf('c') + 1);
+      if (attached) {
+        const config = yargsBundleConfigValue(attached);
+        if (config !== undefined) {
+          if (duplicatedScalarKeys.has('configFile')) {
+            extraArgs.push(token); // repeated --config: preserve verbatim, never last-wins (P78)
+          } else {
+            out.configFile = config; // value attached to the bundle, e.g. `-c/other.json`
+          }
+          continue;
+        }
+        // yargs would NOT read this remainder as the config string (`-cfoo` parses as the
+        // separate short flags `-c -f -o -o`, leaving config empty; `-c.foo` as a
+        // dot-notation object). Modeling it as configFile would fabricate a path the server
+        // never used and let a no-op save emit a spurious `--config <value>`. Preserve the
+        // token verbatim so it round-trips instead (P62).
+        extraArgs.push(token);
+        continue;
+      }
+      if (isOptionValueToken(args[i + 1])) {
+        if (duplicatedScalarKeys.has('configFile')) {
+          // repeated --config: preserve the bundle verbatim; its value falls through next (P78).
+          extraArgs.push(token);
+          continue;
+        }
+        out.configFile = args[i + 1]; // `c` is the bundle's last char; the next token is its value
+        i++;
+        continue;
+      }
+      // `c` is the bundle's last char with no following value (the next token is another
+      // flag, or there is none): yargs would read config as empty. Preserve the token
+      // verbatim so it round-trips rather than fabricating a value (mirrors P44/P86).
+      extraArgs.push(token);
+      continue;
+    }
+    // Space-separated `--opt value` form. Consume the next token as the value ONLY when it
+    // is a real value, not another option: yargs parses e.g. `--blockedCommand --debug` as
+    // an empty `blockedCommand` plus a still-applied `--debug`, so swallowing the flag would
+    // drop it and rewrite the option with a bogus value on save (P44, mirroring
+    // stripConfigArgs). A value-option whose next token is a flag is preserved verbatim in
+    // extraArgs and the flag is parsed on the next iteration.
+    const spec = optionFor(token);
+    if (spec && isOptionValueToken(args[i + 1])) {
+      if (divertShellValue(spec, args[i + 1])) {
+        // A shell name the form's select cannot hold — `all` is its omission sentinel (P96), any
+        // other name is not offered at all (P100). Preserve the flag here and let its value fall
+        // through to extraArgs on the next iteration.
+        extraArgs.push(token);
+        continue;
+      }
+      if (spec.kind === 'number' && divertNumber(spec, args[i + 1])) {
+        // A numeric value the typed field cannot faithfully hold (unparseable, P34; or an
+        // out-of-range log limit, P59): don't consume it. The flag is preserved here, and the
+        // following value token falls through to extraArgs on the next iteration.
+        extraArgs.push(token);
+        continue;
+      }
+      if (isScalarOption(spec) && duplicatedScalarKeys.has(spec.key)) {
+        // A repeated scalar option: preserve the flag verbatim; its value token is not consumed
+        // here and falls through to extraArgs on the next iteration, so both round-trip (P78).
+        extraArgs.push(token);
+        continue;
+      }
+      applyValue(spec, args[i + 1]);
+      i++;
+      i = consumeGreedyArrayValues(spec, i);
+      continue;
+    }
+    extraArgs.push(token);
+  }
+
+  for (const [key, list] of Object.entries(arrays)) {
+    (out as Record<string, unknown>)[key] = list;
+  }
+  return { settings: out, extraArgs };
+}
+
+/** Whether a value is a plain JSON object (not null, not an array). */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Coerce an unknown value to a trimmed string, or '' when not a string. */
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** Coerce an unknown value to a string-keyed string map (for env). */
+function asStringMap(value: unknown): Record<string, string> {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === 'string') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Reverse-map a `.vscode/mcp.json` `servers.wcli0` entry into a complete
+ * {@link Wcli0Settings} the form can render, plus notes for parts that cannot be
+ * fully represented. The entry is the inverse of what {@link buildLaunchSpec} emits:
+ * `type` -> transport mode; for stdio the `command`/`args` give the launch method
+ * and server flags; `cwd`/`env` give the launch directory and environment. For
+ * http/sse the `url` gives host/port. Unmodeled flags survive in `extraArgs`.
+ */
+export function parseMcpEntry(entry: Record<string, unknown>): ParsedEntry {
+  const s = defaultSettings();
+  const notes: string[] = [];
+  // Match `type` case-insensitively so an entry written as `HTTP`/`Sse` is modeled as
+  // http/sse rather than silently coerced to stdio (P31).
+  const rawType = asString(entry.type);
+  const type = rawType ? rawType.toLowerCase() : 'stdio';
+
+  if (type === 'http' || type === 'sse') {
+    s.transportMode = type as TransportMode;
+    // Trim exactly as preservedFileUrl does before it decides whether to keep the URL verbatim.
+    // Parsing the untrimmed value here made `" http://gateway.example:8443/mcp"` undecomposable,
+    // so the form showed the default host/port while the save path (which trims) decomposed it,
+    // saw a mismatch against those defaults, and rewrote the endpoint to the canonical default on
+    // an otherwise no-op save (P91).
+    const url = asString(entry.url).trim();
+    // Always retain the verbatim URL so a save round-trips it unchanged, even when the
+    // host/port fields cannot fully represent it: a custom scheme/path (P5), a URL with
+    // no explicit port (P8), or a socket/named-pipe URL (P10).
+    if (url) {
+      s.transportUrl = url;
+    }
+    const canonicalPath = type === 'http' ? 'mcp' : 'sse';
+    const parsed = parseHttpUrl(url);
+    if (parsed && parsed.port !== undefined && parsed.port >= 1 && parsed.port <= 65535) {
+      // Fully modeled: an explicit host AND usable port the form's fields can edit.
+      s.transportHost = parsed.host;
+      s.transportPort = parsed.port;
+      if (!isCanonicalTransportUrl(url, type, parsed)) {
+        notes.push(
+          `The ${type} URL "${url}" uses a custom scheme or path. It is preserved as-is ` +
+            'when you save, but editing the host or port here rewrites it to the ' +
+            `http://host:port/${canonicalPath} form.`,
+        );
+      }
+    } else if (parsed && parsed.port === undefined) {
+      // Decomposes to a host but no explicit port (a default-port URL such as
+      // https://host/path). Show the host, but keep the form's default port so the
+      // number field stays valid (min=1) rather than rendering an invalid 0 (P8); the
+      // verbatim URL above round-trips, and a host edit rebuilds the canonical form.
+      s.transportHost = parsed.host;
+      notes.push(
+        `The ${type} URL "${url}" does not specify a port (it uses the scheme default). ` +
+          'It is preserved as-is when you save; editing the host or port rewrites it to the ' +
+          `http://host:port/${canonicalPath} form.`,
+      );
+    } else if (parsed) {
+      // An explicitly-written but unusable port: a number outside 1..65535 (`:0`, or one above
+      // 65535 such as `:70000`), or a non-numeric/malformed one (`:abc`, `:-1`, reported as NaN
+      // by parseHttpUrl, P66). The port field cannot hold any of these (it is constrained to
+      // 1..65535), so show the host and keep the form's default port. Unlike a default-port URL
+      // the verbatim URL is NOT preserved on save (preservedFileUrl requires the port to be
+      // unchanged, and an out-of-range or NaN value can never match the default), so saving
+      // rebuilds the canonical http://host:port form from the port field rather than loading an
+      // invalid port that strands the form's number input and blocks unrelated saves
+      // (P-port0/P-portmax/P66).
+      s.transportHost = parsed.host;
+      const portText = Number.isNaN(parsed.port)
+        ? 'has a non-numeric port, which is not a usable port'
+        : `specifies port ${parsed.port}, which is not a usable port`;
+      notes.push(
+        `The ${type} URL "${url}" ${portText} ` +
+          '(it must be an integer between 1 and 65535). Saving rewrites it to the ' +
+          `http://host:port/${canonicalPath} form using the port field below.`,
+      );
+    } else if (url) {
+      // Cannot be decomposed into host/port at all (a socket or named-pipe URL such as
+      // unix:///tmp/server.sock#/mcp). Keep the form's defaults and preserve the URL
+      // verbatim so an unrelated save does not rewrite it to http://host:port (P10).
+      notes.push(
+        `The ${type} URL "${url}" cannot be represented by the host and port fields. ` +
+          'It is preserved as-is when you save; edit .vscode/mcp.json directly to change it.',
+      );
+    } else {
+      // No usable url at all: `{"type":"http"}`, `url: ""`, or a non-string url. There is
+      // nothing to model and nothing to preserve verbatim, so a save keeps the entry's url key
+      // exactly as it was found rather than manufacturing the canonical default endpoint (P88).
+      notes.push(
+        `The ${type} entry has no usable url. It is kept as-is when you save; set the host and ` +
+          'port below to write one, or edit .vscode/mcp.json directly.',
+      );
+    }
+    return { settings: s, notes };
+  }
+
+  // stdio: command + args carry the launch method and server flags.
+  s.transportMode = 'stdio';
+  const command = asString(entry.command);
+  // Coerce each arg like node's spawn would (String()) rather than dropping non-strings
+  // to '', so a numeric arg such as 9229 round-trips as "9229" instead of being corrupted
+  // to an empty string (P33).
+  const args = Array.isArray(entry.args)
+    ? entry.args.map((a) => (typeof a === 'string' ? a : String(a)))
+    : [];
+  let serverArgs: string[];
+  // The npx/node fast paths only apply when the launcher has no options before the
+  // package/script — `npx -y <pkg>` or `node <script>`. An entry like
+  // `npx --package=x -- wcli0 ...` (P17) or `node --inspect dist/index.js ...` (P14)
+  // carries launcher options the form cannot model as a package/script, so it falls
+  // through to custom parsing, where the launcher args round-trip verbatim.
+  // The npx fast path additionally requires the forward builder's own `-y`: buildLaunchSpec
+  // always emits `npx -y <pkg>`, so modeling a hand-authored `npx wcli0@1.2.3` would let an
+  // UNRELATED save add `-y` and silently turn npx's installation confirmation into an automatic
+  // accept (npm documents that npx prompts before installing a missing package and that `-y`
+  // suppresses that prompt). Without `-y` the entry falls through to custom parsing instead,
+  // where `npx` and its package token round-trip verbatim and the server flags after them are
+  // still modeled (P82).
+  // It also needs a real package token. `npx -y` (or `npx -y ""`) authored no package, but
+  // buildLaunchSpec substitutes an empty packageSpec with `wcli0@latest`, so modeling it would let
+  // an unrelated save turn an incomplete invocation into an automatic install-and-run of wcli0
+  // (npx itself requires a package or an explicit call). Such an entry is a custom launch, where
+  // its tokens round-trip untouched (P85).
+  const isPlainNpx =
+    command === 'npx' &&
+    args[0] === '-y' &&
+    args[1] !== undefined &&
+    args[1].trim() !== '' &&
+    !args[1].startsWith('-');
+  const isPlainNode = command === 'node' && args[0] !== undefined && !args[0].startsWith('-');
+  if (isPlainNpx) {
+    s.launchMethod = 'npx';
+    // Forward emits ['-y', packageSpec, ...flags].
+    s.packageSpec = args[1] ?? '';
+    serverArgs = args.slice(2);
+  } else if (isPlainNode) {
+    s.launchMethod = 'node';
+    s.nodeScriptPath = args[0] ?? '';
+    serverArgs = args.slice(1);
+  } else {
+    s.launchMethod = 'custom';
+    s.customCommand = command;
+    // Leading tokens are the custom command's own args; the wcli0 server flags are the
+    // contiguous suffix the forward builder appends (`[...customArgs, ...serverFlags]`).
+    // Split at the START of the longest pure server-flag suffix, not the first dashed
+    // token, so a launcher option that collides with a wcli0 flag name (a wrapper's own
+    // `--config`/`--transport`, node's `--inspect`, uvx's `--from`) stays in customArgs
+    // and a load/save round-trip preserves the command order (P15).
+    //
+    // Only trust an index-0 boundary when the command IS the wcli0 binary (its args really
+    // are server flags). For a wrapper command an index-0 flag run is ambiguous —
+    // `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so the scan
+    // skips index 0 and keeps looking for a later modeled-flag suffix, so the `--shell` in
+    // `wrapper --no-cache --shell bash` is still recovered instead of stranded in customArgs
+    // (P-wrapperflags / P43).
+    // This branch only ever parses a stdio entry (http/sse return earlier), so pass stdio=true:
+    // a transport flag in the args must not "prove" a server-flag suffix that reorders a wrapper's
+    // own options on save, since stdio leaves transport flags in extraArgs verbatim (P77).
+    const start = serverFlagSuffixStart(args, isWcli0Command(command), true);
+    s.customArgs = args.slice(0, start);
+    serverArgs = args.slice(start);
+  }
+
+  // Parse the server flags as stdio: a transport flag (`--transport`, `--http-*`, `--sse-*`)
+  // in a stdio entry's args must NOT override the authoritative `type` — it falls through
+  // to extraArgs verbatim instead of flipping transportMode and deleting the launcher on
+  // save (P30).
+  const { settings: parsed, extraArgs } = parseServerArgs(serverArgs, { stdio: true });
+  Object.assign(s, parsed);
+  s.extraArgs = extraArgs;
+  s.cwd = asString(entry.cwd);
+  s.env = asStringMap(entry.env);
+
+  if (rawType && type !== 'stdio' && type !== 'http' && type !== 'sse') {
+    // An entry whose `type` the form cannot model (e.g. "websocket", or a future
+    // transport). It is parsed as stdio for the editable fields, but the original type is
+    // not one the form offers; surface it so the user knows a save will normalize it (P31).
+    notes.push(
+      `The entry type "${rawType}" is not stdio/http/sse and cannot be fully modeled here. ` +
+        'Edit .vscode/mcp.json directly to change the transport type.',
+    );
+  }
+  if (
+    command === 'npx' &&
+    args[0] !== undefined &&
+    args[0] !== '-y' &&
+    args[0].trim() !== '' &&
+    !args[0].startsWith('-')
+  ) {
+    // A plain `npx <pkg>` entry: modeled as a custom command rather than the npx launch method,
+    // because the npx launch method always emits `-y` and would suppress npx's installation
+    // confirmation the entry deliberately left in place (P82).
+    notes.push(
+      'This entry runs npx WITHOUT -y, so npx asks before installing the package. It is shown ' +
+        'as a custom command to preserve that; saving via the npx launch method would add -y ' +
+        'and accept the installation automatically.',
+    );
+  }
+  if (s.configFile.trim()) {
+    notes.push(
+      'This entry references a config file via --config. Per-shell settings and ' +
+        'environment profiles inside that file are not editable here; edit the referenced ' +
+        'config file directly.',
+    );
+  }
+  return { settings: s, notes };
+}
+
+/**
+ * Parse host/port out of an http/sse URL; returns undefined when unparseable. An OMITTED
+ * port is reported as `port: undefined` (the URL relies on the scheme default), distinct
+ * from an explicitly-written port — including an unusable `:0`, reported as `port: 0`. The
+ * two must not be conflated: a `:0` URL is a real explicit port, not a default-port URL, so
+ * it must not be preserved verbatim in a way that ignores a port-field edit (P-port0). An
+ * explicit but NON-NUMERIC port (`:abc`, `:-1`) is reported as `port: NaN` — also distinct
+ * from an omitted port — so the caller rebuilds the canonical URL from the port field rather
+ * than treating the malformed URL as a default-port one that a port edit cannot fix (P66).
+ */
+export function parseHttpUrl(url: string): { host: string; port: number | undefined } | undefined {
+  if (!url) {
+    return undefined;
+  }
+  // An authority holding a VS Code substitution token (`http://${input:host}:8080/mcp`,
+  // `http://host:${input:port}/mcp`) cannot be decomposed: the colon INSIDE `${...}` is not the
+  // host/port delimiter, and the real host/port are unknown until VS Code resolves the variable at
+  // launch. Splitting it anyway produced host `${input` with a malformed port, and the save then
+  // rebuilt the URL as `http://${input:9444/mcp`, destroying both the variable and the endpoint.
+  // Report it as undecomposable so it is preserved verbatim like a socket URL (P10) and host/port
+  // edits are refused rather than applied to it (P81/P92).
+  const authorityStart = /^[a-z]+:\/\//i.exec(url);
+  if (authorityStart) {
+    const authority = url.slice(authorityStart[0].length).split(/[/?#]/)[0];
+    if (authority.includes('${')) {
+      return undefined;
+    }
+  }
+  // Match `scheme://[userinfo@]host[:port]/...`, where host may be a bracketed IPv6
+  // literal. The optional `userinfo@` is skipped so credentials (`user:pass@host:port`)
+  // do not get mistaken for the host and an explicit port behind them is still read (P21).
+  // The port group captures everything between `:` and the path/query/fragment so an explicit
+  // non-numeric port is seen (and rejected below) rather than left out of the match — which
+  // would make the URL look like it omitted its port entirely (P66).
+  const m = /^[a-z]+:\/\/(?:[^@/]*@)?(\[[^\]]+\]|[^:/]+)(?::([^/?#]*))?/i.exec(url);
+  if (!m) {
+    return undefined;
+  }
+  const host = m[1];
+  // No `:` after the host -> omitted port (scheme default). An explicit digit-only port -> its
+  // number (range-checked by the caller). An explicit but malformed port (`:abc`, `:-1`, or an
+  // empty `:`) -> NaN, flagged as an unusable explicit port the port field must rebuild.
+  let port: number | undefined;
+  if (m[2] === undefined) {
+    port = undefined;
+  } else if (/^\d+$/.test(m[2])) {
+    port = Number(m[2]);
+  } else {
+    port = NaN;
+  }
+  return { host, port };
+}
+
+/**
+ * Whether `url` is exactly the shape the forward builder emits for an http/sse
+ * entry: `http://<host>:<port>/<mcp|sse>` with an explicit port and no userinfo,
+ * query, or fragment. A canonical URL round-trips losslessly through host/port, so
+ * it needs no preservation note; anything else does (P5).
+ */
+function isCanonicalTransportUrl(
+  url: string,
+  type: 'http' | 'sse',
+  parsed: { host: string; port: number | undefined },
+): boolean {
+  const path = type === 'http' ? '/mcp' : '/sse';
+  return (
+    parsed.port !== undefined &&
+    parsed.port > 0 &&
+    url === `http://${parsed.host}:${parsed.port}${path}`
+  );
+}

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -233,6 +233,12 @@ export interface ParseServerArgsOptions {
  * modeling in {@link parseServerArgs}: yargs coerces any other value to false, so
  * `wrapper target --enableTruncation=0` really does disable truncation and the form must show it
  * rather than the server default (P94).
+ *
+ * A NEGATED spelling with an attached value is excluded: yargs applies `--name=value` before
+ * boolean negation, so `--no-debug=false` defines an unrelated `no-debug` key rather than setting
+ * `debug` (verified against yargs-parser). parseServerArgs preserves such a token verbatim, so
+ * counting it as modeled evidence would split a wrapper's own trailing token into the server
+ * suffix and let a later edit reorder the wrapper's invocation (P108).
  */
 function isRecognizedServerFlag(token: string, stdio = false): boolean {
   const isModeledValueOption = (flag: string): boolean =>
@@ -246,7 +252,7 @@ function isRecognizedServerFlag(token: string, stdio = false): boolean {
     if (isModeledValueOption(flag)) {
       return true;
     }
-    return BOOLEAN_FLAGS.has(flag);
+    return BOOLEAN_FLAGS.has(flag) && !flag.startsWith('--no-');
   }
   return false;
 }
@@ -460,6 +466,16 @@ export function parseServerArgs(
 } {
   const out: Partial<Wcli0Settings> = {};
   const extraArgs: string[] = [];
+  // Indices in extraArgs of a recognized value option preserved with NO value token after it. The
+  // builder re-emits extraArgs AFTER the modeled flags, so such a flag can end up next to a token
+  // the entry kept apart from it and swallow it as its value; makeExtrasReorderSafe() below
+  // rewrites those cases (P106/P109). Recorded here because only the parse knows the token had no
+  // value: once the tokens sit side by side in extraArgs that fact is no longer visible.
+  const valuelessOptionAt = new Set<number>();
+  const preserveValueless = (token: string): void => {
+    valuelessOptionAt.add(extraArgs.length);
+    extraArgs.push(token);
+  };
   const arrays: Partial<Record<keyof Wcli0Settings, string[]>> = {};
 
   // Look up a value-option, honoring the stdio exclusion: a stdio entry's authoritative
@@ -923,8 +939,9 @@ export function parseServerArgs(
       }
       // `c` is the bundle's last char with no following value (the next token is another
       // flag, or there is none): yargs would read config as empty. Preserve the token
-      // verbatim so it round-trips rather than fabricating a value (mirrors P44/P86).
-      extraArgs.push(token);
+      // verbatim so it round-trips rather than fabricating a value (mirrors P44/P86). Recorded as
+      // valueless so the reorder guard below can make it safe if a positional follows (P106).
+      preserveValueless(token);
       continue;
     }
     // Space-separated `--opt value` form. Consume the next token as the value ONLY when it
@@ -960,13 +977,91 @@ export function parseServerArgs(
       i = consumeGreedyArrayValues(spec, i);
       continue;
     }
+    if (VALUE_OPTIONS[token] && !isOptionValueToken(args[i + 1])) {
+      // A recognized value option with no value after it (`--shell --debug ...`). Preserved as
+      // today, but recorded so the reorder guard below can re-emit it safely. Looked up in
+      // VALUE_OPTIONS directly rather than through optionFor(), so a stdio entry's transport flags
+      // (which P30 deliberately leaves unmodeled) get the same treatment.
+      preserveValueless(token);
+      continue;
+    }
     extraArgs.push(token);
   }
 
   for (const [key, list] of Object.entries(arrays)) {
     (out as Record<string, unknown>)[key] = list;
   }
-  return { settings: out, extraArgs };
+  return { settings: out, extraArgs: makeExtrasReorderSafe(extraArgs, valuelessOptionAt) };
+}
+
+/**
+ * Re-emit preserved args so they survive the builder's reordering. `buildServerArgs` appends
+ * extraArgs AFTER the flags it generates from the typed fields, so two tokens the entry kept apart
+ * can become neighbours. That is only dangerous in one shape: a recognized value option preserved
+ * with NO value (`valuelessAt`) followed later by a real POSITIONAL, which the re-emitted order
+ * would feed to it as its value. yargs reads `node dist/index.js --shell --debug cmd` as shell='',
+ * debug=true and a positional `cmd`, but the rebuilt `--debug --shell cmd` makes `cmd` the shell
+ * (P106); the same reordering turns `--allowedDir --debug C:/work` into an allowed directory, which
+ * additionally switches restrictWorkingDirectory ON and injection protection OFF (P109).
+ *
+ * Each kind is re-emitted in the form that cannot capture a following token, verified against the
+ * installed yargs-parser:
+ *   - string/csv: `--flag=` parses exactly like the valueless flag ('') and consumes nothing.
+ *   - number: a valueless number option defines NO key, while `--flag=` would define 0 — the token
+ *     is inert, so it is dropped rather than rewritten.
+ *   - array: a valueless array option yields [] (ignored by the server's `length > 0` check), while
+ *     `--flag=` would yield [''] — the deny-all of P103 — so the inert token is dropped too.
+ *
+ * When no positional follows, everything round-trips byte-for-byte as before: a valueless flag next
+ * to another flag (`--blockedCommand --debug`, P44) or to its own repeated occurrence (P78/P98) is
+ * already safe in any order.
+ */
+function makeExtrasReorderSafe(extras: string[], valuelessAt: Set<number>): string[] {
+  // Tokens after a `--` separator stay positional wherever they end up, so they neither create the
+  // hazard nor suffer from it (P74).
+  const separator = extras.indexOf('--');
+  const end = separator === -1 ? extras.length : separator;
+  const consumed = new Set<number>();
+  for (let i = 0; i < end; i++) {
+    if (VALUE_OPTIONS[extras[i]] && !valuelessAt.has(i) && isOptionValueToken(extras[i + 1])) {
+      consumed.add(i + 1); // this token is that option's value, not a positional
+    }
+  }
+  let positionalAt = -1;
+  for (let i = 0; i < end; i++) {
+    if (!extras[i].startsWith('-') && !consumed.has(i)) {
+      positionalAt = i;
+      break;
+    }
+  }
+  if (positionalAt === -1) {
+    return extras;
+  }
+  const out: string[] = [];
+  for (let i = 0; i < extras.length; i++) {
+    const token = extras[i];
+    if (i >= positionalAt || !valuelessAt.has(i)) {
+      out.push(token);
+      continue;
+    }
+    if (token.startsWith('--')) {
+      const spec = VALUE_OPTIONS[token];
+      if (spec && (spec.kind === 'string' || spec.kind === 'csv')) {
+        out.push(`${token}=`);
+      }
+      continue; // number / array: the valueless token is inert, so it is dropped
+    }
+    // A single-dash token carrying the `c` config alias (`-c`, or a bundle such as `-dc`). Its own
+    // attached form is unusable -- yargs swallows the next token for `-c=` -- so emit any other
+    // bundled letters as their own token and the alias in its long attached form. Verified:
+    // `-dc --debug x` and `-d --config= --debug x` both give config='', d=true, x positional.
+    const others = token.slice(1).replace(/c/g, '');
+    if (others) {
+      out.push(`-${others}`);
+    }
+    out.push('--config=');
+  }
+  return out;
 }
 
 /** Whether a value is a plain JSON object (not null, not an array). */

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -362,18 +362,15 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * launcher options whose names collide with wcli0 flags (a wrapper's `--config`, node's
  * `--inspect`) in the launcher portion (P15).
  *
- * `allowIndexZero` is true only when the command IS the wcli0 binary, so an index-0 run
- * really is server flags. For a non-wcli0 (wrapper) command an index-0 flag run is
- * ambiguous — `mywrapper --transport fast` is the wrapper's own option, not a wcli0 flag
- * (P-wrapperflags) — so scanning starts at index 1: the leading token stays in the
- * launcher portion and the scan still finds a LATER modeled-flag suffix, e.g. the
- * `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
+ * Only ever used for a WRAPPER command; a direct wcli0 launch parses its whole arg list instead
+ * (P105). An index-0 flag run is ambiguous for a wrapper — `mywrapper --transport fast` is the
+ * wrapper's own option, not a wcli0 flag (P-wrapperflags) — so scanning starts at index 1: the
+ * leading token stays in the launcher portion and the scan still finds a LATER modeled-flag
+ * suffix, e.g. the `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
  *
- * A wrapper scan additionally requires the suffix to contain a modeled wcli0 flag
- * (`requireModeled`), so an unknown-only run such as the wrapper's own `--verbose` in
- * `wrapper target --verbose` is NOT mistaken for a server-flag suffix and stays in the
- * launcher portion (P56). The wcli0 binary itself (allowIndexZero) does not require this: its
- * args are genuinely wcli0's, including unknown-only extraArgs.
+ * The suffix must also contain a modeled wcli0 flag (`requireModeled` in the run check), so an
+ * unknown-only run such as the wrapper's own `--verbose` in `wrapper target --verbose` is NOT
+ * mistaken for a server-flag suffix and stays in the launcher portion (P56).
  *
  * The scan stops at a `--` options separator, because yargs treats everything after one as
  * positionals, so no server-flag suffix can begin there (P75). The single exception is a
@@ -386,8 +383,8 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * server would never read it (P83). `stdio` is forwarded to the run check so a stdio entry's
  * transport flags do not count as modeled evidence (P77).
  */
-function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = false): number {
-  for (let i = allowIndexZero ? 0 : 1; i < args.length; i++) {
+function serverFlagSuffixStart(args: string[], stdio = false): number {
+  for (let i = 1; i < args.length; i++) {
     if (args[i] === '--') {
       // An options separator: yargs treats every following token as a positional, so no
       // server-flag suffix can begin at or after it (P75). Stop -- unless this is a wrapper
@@ -398,10 +395,7 @@ function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = 
       // program) keeps its remainder in the launcher portion, so a positional is never modeled as
       // an active flag and a saved flag is never appended behind a separator the server ignores
       // (P83). A second `--` after the wrapped binary is that binary's own separator and stops
-      // the scan, exactly as it does for a direct wcli0 launch.
-      if (allowIndexZero) {
-        break;
-      }
+      // the scan, exactly as parseServerArgs stops at it for a direct wcli0 launch.
       const wrappedBinaryAt = args.findIndex((t, j) => j > i && isWcli0Command(t));
       if (wrappedBinaryAt === -1) {
         break;
@@ -409,7 +403,7 @@ function serverFlagSuffixStart(args: string[], allowIndexZero: boolean, stdio = 
       i = wrappedBinaryAt; // resume scanning at the token AFTER the wrapped wcli0 binary
       continue;
     }
-    if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), !allowIndexZero, stdio)) {
+    if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), true, stdio)) {
       return i;
     }
   }
@@ -1145,16 +1139,23 @@ export function parseMcpEntry(entry: Record<string, unknown>): ParsedEntry {
     // `--config`/`--transport`, node's `--inspect`, uvx's `--from`) stays in customArgs
     // and a load/save round-trip preserves the command order (P15).
     //
-    // Only trust an index-0 boundary when the command IS the wcli0 binary (its args really
-    // are server flags). For a wrapper command an index-0 flag run is ambiguous —
-    // `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so the scan
-    // skips index 0 and keeps looking for a later modeled-flag suffix, so the `--shell` in
-    // `wrapper --no-cache --shell bash` is still recovered instead of stranded in customArgs
-    // (P-wrapperflags / P43).
+    // When the command IS the wcli0 binary there is nothing to split: every arg is the server's
+    // own, so the WHOLE list is parsed as one server argument list. Scanning it for a suffix could
+    // cut it in the wrong place — for `wcli0 --allowAllDirs marker --no-allowAllDirs` the index-0
+    // run failed the purity check on the positional `marker`, so the scan picked the trailing
+    // negation as the suffix, left the ENABLING flag in customArgs and modeled allowAllDirs=false;
+    // a no-op save then emitted `--allowAllDirs marker` and flipped the server from restricted to
+    // UNRESTRICTED directories (P105). parseServerArgs handles the `--` separator itself, keeping
+    // it and its positionals verbatim in extraArgs (P74), so the round-trip stays exact.
+    //
+    // For a wrapper command the split is still needed and still starts at index 1: an index-0 flag
+    // run is ambiguous — `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so
+    // the scan keeps looking for a later modeled-flag suffix, recovering the `--shell` in
+    // `wrapper --no-cache --shell bash` instead of stranding it (P-wrapperflags / P43).
     // This branch only ever parses a stdio entry (http/sse return earlier), so pass stdio=true:
     // a transport flag in the args must not "prove" a server-flag suffix that reorders a wrapper's
     // own options on save, since stdio leaves transport flags in extraArgs verbatim (P77).
-    const start = serverFlagSuffixStart(args, isWcli0Command(command), true);
+    const start = isWcli0Command(command) ? 0 : serverFlagSuffixStart(args, true);
     s.customArgs = args.slice(0, start);
     serverArgs = args.slice(start);
   }

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -615,11 +615,20 @@ export function parseServerArgs(
         // usable shell name). Requiring a value token hid that occurrence, so only `bash` was
         // modeled, the preserved `--shell` was stripped when the field was emitted, and a no-op
         // save rewrote an entry with NO usable shell into one running commands through Bash (P98).
-        // A NUMBER option is different: yargs DROPS a valueless one entirely (`--commandTimeout
-        // --commandTimeout 5` => 5, no array), so counting it would preserve a pair the server
-        // resolves to a single value and leave the form showing no timeout (P102). Values the
-        // typed field cannot hold are still counted (P90).
-        if (spec.kind !== 'number' || isOptionValueToken(args[i + 1])) {
+        // A NUMBER option is different: yargs DROPS a valueless one only while the key is still
+        // UNDEFINED (`--commandTimeout --commandTimeout 5` => 5, no array), so counting that
+        // leading occurrence would preserve a pair the server resolves to a single value and
+        // leave the form showing no timeout (P102). Once an earlier occurrence has defined the
+        // key, a valueless repeat is appended as null and yargs yields an ARRAY (verified:
+        // `--maxCommandLength 1000000 --maxCommandLength` => [1000000, null]), which
+        // applyCliSecurityOverrides ignores because it is not a number -- the entry runs on the
+        // server's safer default. Counting only the occurrence that carries a value modeled
+        // 1000000, and the builder then stripped the preserved valueless token, so an unrelated
+        // save activated the much weaker command-length limit the entry never applied (P111).
+        // Values the typed field cannot hold are still counted (P90).
+        const numberDefinesKey =
+          isOptionValueToken(args[i + 1]) || (counts.get(spec.key) ?? 0) > 0;
+        if (spec.kind !== 'number' || numberDefinesKey) {
           bump(spec.key);
         }
       }

--- a/vscode-extension/src/configSource.ts
+++ b/vscode-extension/src/configSource.ts
@@ -164,6 +164,31 @@ const VALUE_OPTIONS: Record<string, OptionSpec> = {
   '--sse-allowed-origins': { key: 'transportAllowedOrigins', kind: 'csv' },
 };
 
+// Server options that TAKE a value but the form does NOT model (no field maps to them), so they
+// round-trip verbatim in extraArgs. yargs still consumes the following token as their value, so the
+// valueless bookkeeping and the reorder guard below must know about them just like the modeled
+// ones: `--init-config --debug path` leaves init-config empty and `path` positional, so the server
+// runs normally, but the rebuilt `--debug --init-config path` makes `path` the option value and the
+// server then writes a default config there and EXITS (src/index.ts) -- after a save that changed
+// something else entirely (P113). `--initConfig` is the yargs camel-case spelling of the server's
+// `init-config` option and is accepted identically (verified against the installed yargs).
+const UNMODELED_VALUE_OPTIONS = new Set<string>(['--init-config', '--initConfig']);
+
+/**
+ * The value kind of a flag that consumes a following token: the modeled options from
+ * {@link VALUE_OPTIONS}, plus the server options the form only preserves
+ * ({@link UNMODELED_VALUE_OPTIONS}, all string-typed). Returns undefined for anything else. Used
+ * wherever the code must reason about every value-consuming option the SERVER declares rather than
+ * only the ones with a field behind them (P113).
+ */
+function valueOptionKind(flag: string): OptionKind | undefined {
+  const spec = VALUE_OPTIONS[flag];
+  if (spec) {
+    return spec.kind;
+  }
+  return UNMODELED_VALUE_OPTIONS.has(flag) ? 'string' : undefined;
+}
+
 // Boolean / tri-state / safety flags the forward builder emits with no value. Shared by
 // parseServerArgs (which models them) and isRecognizedServerFlag (the suffix detector).
 // The kebab-case spellings are yargs camel-case-expansion aliases of the camelCase
@@ -370,7 +395,7 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  *
  * Only ever used for a WRAPPER command; a direct wcli0 launch parses its whole arg list instead
  * (P105). An index-0 flag run is ambiguous for a wrapper — `mywrapper --transport fast` is the
- * wrapper's own option, not a wcli0 flag (P-wrapperflags) — so scanning starts at index 1: the
+ * wrapper's own option, not a wcli0 flag (P-wrapperflags) — so no suffix can start at index 0: that
  * leading token stays in the launcher portion and the scan still finds a LATER modeled-flag
  * suffix, e.g. the `--shell` in `wrapper --no-cache --shell bash`, instead of stranding it (P43).
  *
@@ -379,7 +404,10 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * mistaken for a server-flag suffix and stays in the launcher portion (P56).
  *
  * The scan stops at a `--` options separator, because yargs treats everything after one as
- * positionals, so no server-flag suffix can begin there (P75). The single exception is a
+ * positionals, so no server-flag suffix can begin there (P75). Index 0 is visited for this reason
+ * alone: a separator THERE follows the same rules, so `node -- wrapper.js --debug` keeps the
+ * wrapper's own `--debug` in customArgs instead of showing it as wcli0's Debug setting and
+ * dropping it from the launcher when that setting is turned off (P115). The single exception is a
  * pass-through separator that is PROVEN to be one: a wrapper whose separator is followed by the
  * wcli0 binary itself (`npx --package=wcli0 -- wcli0 --shell cmd`, P17). There the scan resumes
  * after that binary token, since the flags following it really are wcli0's. For any other
@@ -390,7 +418,7 @@ function isPureServerFlagRun(tokens: string[], requireModeled = false, stdio = f
  * transport flags do not count as modeled evidence (P77).
  */
 function serverFlagSuffixStart(args: string[], stdio = false): number {
-  for (let i = 1; i < args.length; i++) {
+  for (let i = 0; i < args.length; i++) {
     if (args[i] === '--') {
       // An options separator: yargs treats every following token as a positional, so no
       // server-flag suffix can begin at or after it (P75). Stop -- unless this is a wrapper
@@ -407,6 +435,12 @@ function serverFlagSuffixStart(args: string[], stdio = false): number {
         break;
       }
       i = wrappedBinaryAt; // resume scanning at the token AFTER the wrapped wcli0 binary
+      continue;
+    }
+    if (i === 0) {
+      // The scan visits index 0 only so a separator THERE is honored (P115); an index-0
+      // flag run itself is still the wrapper's own option, never a wcli0 suffix
+      // (P-wrapperflags), so no suffix can start here.
       continue;
     }
     if (args[i].startsWith('-') && isPureServerFlagRun(args.slice(i), true, stdio)) {
@@ -986,11 +1020,13 @@ export function parseServerArgs(
       i = consumeGreedyArrayValues(spec, i);
       continue;
     }
-    if (VALUE_OPTIONS[token] && !isOptionValueToken(args[i + 1])) {
-      // A recognized value option with no value after it (`--shell --debug ...`). Preserved as
+    if (valueOptionKind(token) && !isOptionValueToken(args[i + 1])) {
+      // A value-consuming option with no value after it (`--shell --debug ...`). Preserved as
       // today, but recorded so the reorder guard below can re-emit it safely. Looked up in
       // VALUE_OPTIONS directly rather than through optionFor(), so a stdio entry's transport flags
-      // (which P30 deliberately leaves unmodeled) get the same treatment.
+      // (which P30 deliberately leaves unmodeled) get the same treatment -- and via
+      // valueOptionKind(), so an unmodeled server option such as `--init-config` is recorded too
+      // (P113).
       preserveValueless(token);
       continue;
     }
@@ -1008,7 +1044,9 @@ export function parseServerArgs(
  * extraArgs AFTER the flags it generates from the typed fields, so two tokens the entry kept apart
  * can become neighbours. That is only dangerous in one shape: a recognized value option preserved
  * with NO value (`valuelessAt`) followed later by a real POSITIONAL, which the re-emitted order
- * would feed to it as its value. yargs reads `node dist/index.js --shell --debug cmd` as shell='',
+ * would feed to it as its value. The option need not be one the form models: `--init-config` has no
+ * field, but the server declares it as a string option, so the same rewrite applies (P113). yargs
+ * reads `node dist/index.js --shell --debug cmd` as shell='',
  * debug=true and a positional `cmd`, but the rebuilt `--debug --shell cmd` makes `cmd` the shell
  * (P106); the same reordering turns `--allowedDir --debug C:/work` into an allowed directory, which
  * additionally switches restrictWorkingDirectory ON and injection protection OFF (P109).
@@ -1032,7 +1070,7 @@ function makeExtrasReorderSafe(extras: string[], valuelessAt: Set<number>): stri
   const end = separator === -1 ? extras.length : separator;
   const consumed = new Set<number>();
   for (let i = 0; i < end; i++) {
-    if (VALUE_OPTIONS[extras[i]] && !valuelessAt.has(i) && isOptionValueToken(extras[i + 1])) {
+    if (valueOptionKind(extras[i]) && !valuelessAt.has(i) && isOptionValueToken(extras[i + 1])) {
       consumed.add(i + 1); // this token is that option's value, not a positional
     }
   }
@@ -1054,8 +1092,8 @@ function makeExtrasReorderSafe(extras: string[], valuelessAt: Set<number>): stri
       continue;
     }
     if (token.startsWith('--')) {
-      const spec = VALUE_OPTIONS[token];
-      if (spec && (spec.kind === 'string' || spec.kind === 'csv')) {
+      const kind = valueOptionKind(token);
+      if (kind === 'string' || kind === 'csv') {
         out.push(`${token}=`);
       }
       continue; // number / array: the valueless token is inert, so it is dropped
@@ -1252,10 +1290,10 @@ export function parseMcpEntry(entry: Record<string, unknown>): ParsedEntry {
     // UNRESTRICTED directories (P105). parseServerArgs handles the `--` separator itself, keeping
     // it and its positionals verbatim in extraArgs (P74), so the round-trip stays exact.
     //
-    // For a wrapper command the split is still needed and still starts at index 1: an index-0 flag
-    // run is ambiguous — `mywrapper --transport fast` is the wrapper's own option, not wcli0's — so
-    // the scan keeps looking for a later modeled-flag suffix, recovering the `--shell` in
-    // `wrapper --no-cache --shell bash` instead of stranding it (P-wrapperflags / P43).
+    // For a wrapper command the split is still needed, and still never starts at index 0: that
+    // flag run is ambiguous — `mywrapper --transport fast` is the wrapper's own option, not
+    // wcli0's — so the scan keeps looking for a later modeled-flag suffix, recovering the
+    // `--shell` in `wrapper --no-cache --shell bash` instead of stranding it (P-wrapperflags / P43).
     // This branch only ever parses a stdio entry (http/sse return earlier), so pass stdio=true:
     // a transport flag in the args must not "prove" a server-flag suffix that reorders a wrapper's
     // own options on save, since stdio leaves transport flags in extraArgs verbatim (P77).

--- a/vscode-extension/src/settings.ts
+++ b/vscode-extension/src/settings.ts
@@ -137,6 +137,15 @@ export interface Wcli0Settings {
   transportAllowedOrigins: string[];
 
   extraArgs: string[];
+
+  /**
+   * The verbatim `url` of a loaded http/sse `.vscode/mcp.json` entry, preserved so
+   * a save can write it back unchanged instead of downgrading a custom
+   * scheme/path/default-port URL to the canonical `http://host:port/{mcp,sse}`
+   * shape (P5). Set only by the file-source reverse parser; never a `wcli0.*`
+   * setting, so it is absent for settings-sourced reads.
+   */
+  transportUrl?: string;
 }
 
 /** The workspace folder used as the base for `${workspaceFolder}` resolution. */
@@ -244,6 +253,16 @@ function buildSettings(g: Getter): Wcli0Settings {
   };
 }
 
+/**
+ * A fully-defaulted settings object (every key at its schema default). Used as the
+ * baseline a parsed `.vscode/mcp.json` entry is overlaid onto, so loading a file
+ * source yields a complete {@link Wcli0Settings} the form can render without reading
+ * any VS Code setting.
+ */
+export function defaultSettings(): Wcli0Settings {
+  return buildSettings(<T>(_key: string, def: T): T => def);
+}
+
 /** Whether a single per-shell entry carries any user-set, non-empty field. */
 function isMeaningfulShellConfig(c: PerShellConfig | undefined): boolean {
   if (!c) {
@@ -309,6 +328,17 @@ export function hasPerShellConfig(s: Wcli0Settings): boolean {
   if (s.ignoreInheritedShells) {
     return false;
   }
+  return hasRawPerShellConfig(s);
+}
+
+/**
+ * Like {@link hasPerShellConfig} but IGNORING the `ignoreInheritedShells` mask. The mask is a
+ * settings-only opt-out (it suppresses inherited User-scope shells at launch); it cannot make
+ * the raw `shells` edits in a file-source form representable in a `.vscode/mcp.json` entry. So
+ * a file-source save must gate on the raw objects — otherwise enabling the mask AND editing
+ * Shells lets the save "succeed" while the reparse silently drops those edits (P-maskedshells).
+ */
+export function hasRawPerShellConfig(s: Wcli0Settings): boolean {
   const shells = s.shells ?? {};
   return SHELL_NAMES.some((name) => isMeaningfulShellConfig(shells[name]));
 }
@@ -374,8 +404,19 @@ export function hasProfilesConfig(s: Wcli0Settings): boolean {
   if (s.ignoreInheritedProfiles) {
     return false;
   }
+  return hasRawProfilesConfig(s);
+}
+
+/**
+ * Like {@link hasProfilesConfig} but IGNORING the `ignoreInheritedProfiles` mask — the
+ * profiles twin of {@link hasRawPerShellConfig}, used by file-source saves so the mask cannot
+ * mask away profile edits that the entry still cannot store (P-maskedshells).
+ */
+export function hasRawProfilesConfig(s: Wcli0Settings): boolean {
   const profiles = s.profiles ?? {};
-  return Object.keys(profiles).some((name) => name.trim() !== '' && isMeaningfulProfile(profiles[name]));
+  return Object.keys(profiles).some(
+    (name) => name.trim() !== '' && isMeaningfulProfile(profiles[name]),
+  );
 }
 
 /**

--- a/vscode-extension/src/webview.ts
+++ b/vscode-extension/src/webview.ts
@@ -433,6 +433,31 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
         );
         return;
       }
+      // The same incompatibility one level down: a concurrent LAUNCH-METHOD switch. Each method
+      // owns different fields, so overlaying an edit made against the old one silently drops it --
+      // a `launch.packageSpec` edit made while the panel showed npx would be overlaid onto a
+      // freshly parsed `node` entry, whose emitted launch ignores packageSpec entirely, and the
+      // save would report success while the edit vanished on reparse. Refuse unless the user is
+      // switching the method themselves (P110).
+      const METHOD_FIELDS = {
+        npx: 'launch.packageSpec',
+        node: 'launch.nodeScriptPath',
+        custom: 'launch.customCommand',
+      };
+      if (
+        currentFileParsed &&
+        loadedFileSettings &&
+        currentFileParsed.settings.launchMethod !== loadedFileSettings.launchMethod &&
+        !('launch.method' in msg.values) &&
+        Object.values(METHOD_FIELDS).some((f) => f in (msg.values as Record<string, unknown>))
+      ) {
+        void vscode.window.showErrorMessage(
+          'wcli0: the .vscode/mcp.json entry switched to a different launch method since it was ' +
+            'loaded, so the launch fields you edited no longer apply to it. Reload the source ' +
+            '(switch it away and back) before saving.',
+        );
+        return;
+      }
       const settings = overlaySettings(
         currentFileParsed?.settings ?? loadedFileSettings ?? defaultSettings(),
         msg.values,

--- a/vscode-extension/src/webview.ts
+++ b/vscode-extension/src/webview.ts
@@ -1,14 +1,23 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   CONFIG_SECTION,
   ConfigScope,
+  defaultSettings,
   explicitlySetArrayKeys,
   explicitlySetKeys,
   explicitlySetSelectKeys,
+  INHERITABLE_SELECT_KEYS,
+  OPTIONAL_ARRAY_KEYS,
   OPTIONAL_STRING_KEYS,
   primaryWorkspaceFolder,
   readSettingsForScope,
+  Wcli0Settings,
 } from './settings';
+import { detectWorkspaceMcpJson, parseMcpEntry, readWcli0Entry } from './configSource';
+import { writeMcpJsonFromSettings } from './commands';
 
 /** Keys where an explicit empty string is a meaningful override, not "clear". */
 const OPTIONAL_STRING_KEY_SET = new Set<string>(OPTIONAL_STRING_KEYS);
@@ -46,6 +55,88 @@ const FIELD_KEYS = [
 interface SavePayload {
   target: 'Global' | 'Workspace';
   values: Record<string, unknown>;
+}
+
+/** Which configuration source the form is editing. */
+type ConfigSourceKind = 'settings' | 'mcpJson';
+
+/** A source descriptor sent to the webview for the switcher menu. */
+interface DetectedSource {
+  /** 'settings' / 'mcpJson' are editable; 'homeConfig' is a read-only preview. */
+  kind: ConfigSourceKind | 'homeConfig';
+  label: string;
+  fsPath?: string;
+  /** True for an entry that is listed only for awareness (never a save target). */
+  readOnly?: boolean;
+  /** Whether a detected mcp.json actually holds a wcli0 entry to load. */
+  hasWcli0?: boolean;
+  /** Whether the backing file exists. */
+  exists?: boolean;
+}
+
+/** Dotted form field key -> normalized {@link Wcli0Settings} property. */
+const FIELD_TO_PROP: Record<string, keyof Wcli0Settings> = {
+  'launch.method': 'launchMethod',
+  'launch.packageSpec': 'packageSpec',
+  'launch.nodeScriptPath': 'nodeScriptPath',
+  'launch.customCommand': 'customCommand',
+  'launch.cwd': 'cwd',
+  configFile: 'configFile',
+  shell: 'shell',
+  shells: 'shells',
+  profiles: 'profiles',
+  ignoreInheritedShells: 'ignoreInheritedShells',
+  ignoreInheritedProfiles: 'ignoreInheritedProfiles',
+  allowedDirectories: 'allowedDirectories',
+  initialDir: 'initialDir',
+  commandTimeout: 'commandTimeout',
+  maxCommandLength: 'maxCommandLength',
+  wslMountPoint: 'wslMountPoint',
+  maxOutputLines: 'maxOutputLines',
+  enableTruncation: 'enableTruncation',
+  enableLogResources: 'enableLogResources',
+  logDirectory: 'logDirectory',
+  allowAllDirs: 'allowAllDirs',
+  safetyMode: 'safetyMode',
+  debug: 'debug',
+  'transport.mode': 'transportMode',
+  'transport.host': 'transportHost',
+  'transport.port': 'transportPort',
+};
+
+/** Enum selects whose form value '' means "inherit" (mapped to the default here). */
+const ENUM_INHERIT_FIELDS = new Set([
+  'launch.method',
+  'shell',
+  'safetyMode',
+  'enableTruncation',
+  'enableLogResources',
+  'transport.mode',
+]);
+
+/**
+ * Overlay the form's changed field values onto a baseline settings object, used to
+ * build the settings a file-source "Save to file" writes. Starting from the loaded
+ * file's settings preserves fields the form does not model (extraArgs, blocked lists,
+ * env, custom args) instead of dropping them. A `null` value (the form's Inherit for
+ * a tri-state) or an empty enum select maps to the schema default, since a file has
+ * no scope to inherit from.
+ */
+function overlaySettings(base: Wcli0Settings, values: Record<string, unknown>): Wcli0Settings {
+  const out = { ...base } as unknown as Record<string, unknown>;
+  const defaults = defaultSettings() as unknown as Record<string, unknown>;
+  for (const [field, prop] of Object.entries(FIELD_TO_PROP)) {
+    if (!(field in values)) {
+      continue;
+    }
+    const v = values[field];
+    if (v === null || (v === '' && ENUM_INHERIT_FIELDS.has(field))) {
+      out[prop] = defaults[prop];
+      continue;
+    }
+    out[prop] = v;
+  }
+  return out as unknown as Wcli0Settings;
 }
 
 let panel: vscode.WebviewPanel | undefined;
@@ -86,38 +177,317 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
   // scope (not inherited), so saving never re-writes the other scope's values.
   let currentScope: ConfigScope = primaryWorkspaceFolder() ? 'Workspace' : 'Global';
 
+  // The configuration source the form is editing. 'settings' (the default) edits the
+  // wcli0.* VS Code settings; 'mcpJson' edits the workspace .vscode/mcp.json entry.
+  let currentSource: ConfigSourceKind = 'settings';
+  // The settings parsed from the loaded mcp.json, used as the baseline a "Save to
+  // file" overlays the form's edits onto so unmodeled fields (extraArgs, blocked
+  // lists, env) are preserved rather than dropped.
+  let loadedFileSettings: Wcli0Settings | undefined;
+  // The raw `servers.wcli0` entry as loaded from .vscode/mcp.json. A "Save to file"
+  // merges the regenerated fields onto this so VS Code-supported fields the form does not
+  // model (HTTP headers/oauth, stdio envFile/dev, non-string env, custom/socket URLs) are
+  // preserved rather than dropped (P7/P9/P10/P12).
+  let loadedFileEntry: Record<string, unknown> | undefined;
+  // Notes from reverse-parsing the loaded entry (parts the form cannot fully model).
+  // Carried in every file-source init so a clean reload/save clears stale notes (P11).
+  let loadedFileNotes: string[] = [];
+  // The fsPath of the workspace folder whose .vscode/mcp.json is loaded as the file
+  // source. Tracked so that if the primary workspace folder changes (multi-root
+  // removal/reorder), the stale file source is reset rather than saved back to the
+  // new folder, which would overwrite it with the previous folder's config (P2).
+  let loadedFileFolder: string | undefined;
+  // Cached detected sources for the switcher. Refreshed on ready / workspace-folder
+  // change / after a file save, so post() (which must stay synchronous — a config
+  // change re-posts synchronously) can include it without awaiting detection.
+  let detectedSources: DetectedSource[] = [];
+
+  const refreshDetection = async (): Promise<void> => {
+    const sources: DetectedSource[] = [];
+    const folder = primaryWorkspaceFolder();
+    if (folder) {
+      const d = await detectWorkspaceMcpJson(folder);
+      sources.push({
+        kind: 'mcpJson',
+        label: '.vscode/mcp.json',
+        fsPath: d.fsPath,
+        exists: d.exists,
+        hasWcli0: d.hasWcli0,
+      });
+    }
+    // The server's implicit ~/.win-cli-mcp/config.json is listed READ-ONLY only: it
+    // is never an editable/save target, so a save can't silently overwrite it.
+    const home = path.join(os.homedir(), '.win-cli-mcp', 'config.json');
+    let homeExists = false;
+    try {
+      homeExists = fs.existsSync(home);
+    } catch {
+      homeExists = false;
+    }
+    if (homeExists) {
+      sources.push({ kind: 'homeConfig', label: '~/.win-cli-mcp/config.json', fsPath: home, readOnly: true });
+    }
+    detectedSources = sources;
+  };
+
   // `external` marks a reload triggered by a background configuration change (not
   // an explicit ready/scope-change). The webview ignores such a reload while the
   // form has unsaved edits so it doesn't silently overwrite the user's work.
   const post = (external = false) => {
     const scope = primaryWorkspaceFolder()?.uri;
+    // When editing a file source the form shows the file's concrete values, so every
+    // optional/inheritable key is reported "set" (the form would otherwise render an
+    // unset value as "Inherit" — meaningless for a file with no scope to inherit).
+    const fileSource = currentSource === 'mcpJson';
+    const fileSettings = loadedFileSettings ?? defaultSettings();
     webview.postMessage({
       type: 'init',
       external,
+      source: currentSource,
+      detected: detectedSources,
+      // The file-source parse notes (empty off the file source), sent on EVERY init so a
+      // clean reload or save clears notes that no longer apply (P11).
+      notes: fileSource ? loadedFileNotes : [],
       hasWorkspace: !!primaryWorkspaceFolder(),
       // The open folder names, so the form can resolve ${workspaceFolder:name} tokens
       // exactly as the host does when deciding whether a profile isolates (P110).
       workspaceFolderNames: (vscode.workspace.workspaceFolders ?? []).map((f) => f.name),
       scope: currentScope,
-      settings: readSettingsForScope(currentScope, scope),
+      settings: fileSource ? fileSettings : readSettingsForScope(currentScope, scope),
       // Which optional-string keys are explicitly set at this scope, so the form
       // can distinguish an empty override from "Inherit" (both read as empty).
-      setKeys: explicitlySetKeys(currentScope, scope),
+      setKeys: fileSource ? [...OPTIONAL_STRING_KEYS] : explicitlySetKeys(currentScope, scope),
       // Which inheritable enum/boolean keys are explicitly set at this scope, so the
       // form can show "Inherit" for an unset field instead of the schema default it
       // reads back (which would misreport e.g. an unset safetyMode as "safe").
-      setSelectKeys: explicitlySetSelectKeys(currentScope, scope),
+      setSelectKeys: fileSource
+        ? [...INHERITABLE_SELECT_KEYS]
+        : explicitlySetSelectKeys(currentScope, scope),
       // Which optional-array keys (allowedDirectories) are explicitly set at this
       // scope, so the form can show an explicit empty override as set rather than as
       // "Inherit" (both render an empty textarea otherwise — see P69).
-      setArrayKeys: explicitlySetArrayKeys(currentScope, scope),
+      setArrayKeys: fileSource ? [...OPTIONAL_ARRAY_KEYS] : explicitlySetArrayKeys(currentScope, scope),
     });
   };
 
-  webview.html = renderHtml(webview);
-  const msgSub = webview.onDidReceiveMessage(async (msg: { type: string } & Partial<SavePayload>) => {
-    if (msg.type === 'ready') {
+  // Switch the active source and re-post the form populated from it. For the file
+  // source, read and reverse-parse the workspace .vscode/mcp.json wcli0 entry; an
+  // absent entry or no folder is reported and the switch is refused.
+  const switchSource = async (target: ConfigSourceKind): Promise<boolean> => {
+    if (target === 'mcpJson') {
+      const folder = primaryWorkspaceFolder();
+      if (!folder) {
+        void vscode.window.showErrorMessage('wcli0: open a workspace folder first.');
+        return false;
+      }
+      const entry = await readWcli0Entry(folder);
+      if (!entry) {
+        void vscode.window.showErrorMessage(
+          'wcli0: no wcli0 server entry found in .vscode/mcp.json to load.',
+        );
+        return false;
+      }
+      const { settings, notes } = parseMcpEntry(entry);
+      loadedFileSettings = settings;
+      loadedFileEntry = entry;
+      loadedFileNotes = notes;
+      loadedFileFolder = folder.uri.fsPath;
+      currentSource = 'mcpJson';
+      // post() carries the notes in its init message (cleared on a note-free reload, P11).
       post();
+      return true;
+    }
+    currentSource = 'settings';
+    loadedFileSettings = undefined;
+    loadedFileEntry = undefined;
+    loadedFileNotes = [];
+    loadedFileFolder = undefined;
+    post();
+    return true;
+  };
+
+  webview.html = renderHtml(webview);
+  // After a file-source reset (the loaded .vscode/mcp.json's folder is no longer the
+  // primary one) the form still holds that file's values and a file-relative dirty
+  // baseline. Both save and export persist these via applySettings, which would
+  // silently corrupt wcli0.* settings with file-shaped edits — so confirm first (P28).
+  // Returns true when the user agrees to write to settings, false when they decline.
+  const confirmStaleFileSourceWrite = async (): Promise<boolean> => {
+    const pick = await vscode.window.showWarningMessage(
+      'wcli0: these values came from a .vscode/mcp.json source that is no longer active ' +
+        '(the workspace folder changed). Save them to your VS Code settings anyway?',
+      { modal: true },
+      'Save to settings',
+    );
+    return pick === 'Save to settings';
+  };
+  const msgSub = webview.onDidReceiveMessage(async (msg: { type: string } & Partial<SavePayload> & { source?: ConfigSourceKind; fromResetFileSource?: boolean }) => {
+    if (msg.type === 'ready') {
+      await refreshDetection();
+      post();
+    } else if ((msg.type === 'sourceChange' || msg.type === 'sourceChangeRequest') && msg.source) {
+      // Switching the source reloads the form from that source (a non-external init
+      // bypassing the dirty guard), so a dirty form confirms first — mirroring the
+      // scope-switch guard (P70). The webview reverts its UI optimistically and only a
+      // confirmed request proceeds.
+      if (msg.type === 'sourceChangeRequest') {
+        const choice = await vscode.window.showWarningMessage(
+          'Discard unsaved changes and switch the configuration source?',
+          { modal: true },
+          'Discard changes',
+        );
+        if (choice !== 'Discard changes') {
+          return;
+        }
+      }
+      // Only the editable kinds are accepted as a target; the read-only home config
+      // can never become a load/save target here (REQ-6).
+      if (msg.source === 'settings' || msg.source === 'mcpJson') {
+        await switchSource(msg.source);
+      }
+    } else if (msg.type === 'revertFileRequest') {
+      // Reload the wcli0 entry from disk, discarding unsaved form edits. The webview
+      // only sends this when the form is dirty (a clean form has nothing to revert and
+      // gives its own inline feedback), so always confirm before discarding. Uses
+      // revert-specific wording rather than the generic source-switch prompt, and
+      // signals 'reverted' on success so the webview can flash a confirmation.
+      const choice = await vscode.window.showWarningMessage(
+        'Discard unsaved changes and reload the wcli0 entry from .vscode/mcp.json?',
+        { modal: true },
+        'Discard changes',
+      );
+      if (choice === 'Discard changes' && (await switchSource('mcpJson'))) {
+        webview.postMessage({ type: 'reverted' });
+      }
+    } else if (msg.type === 'openHomeConfig') {
+      // Open the server's implicit ~/.win-cli-mcp/config.json as a read-only preview.
+      // It is never an editable/save target here (REQ-6); the menu row just opens it so
+      // the user can inspect what can silently override their settings. Recompute the
+      // path host-side rather than trusting the message so this can only open that file,
+      // and mark the editor read-only in-session to prevent accidental edits.
+      const home = path.join(os.homedir(), '.win-cli-mcp', 'config.json');
+      try {
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(home));
+        await vscode.window.showTextDocument(doc, { preview: true });
+        await vscode.commands.executeCommand(
+          'workbench.action.files.setActiveEditorReadonlyInSession',
+        );
+      } catch {
+        void vscode.window.showErrorMessage(
+          'wcli0: could not open ~/.win-cli-mcp/config.json.',
+        );
+      }
+    } else if (msg.type === 'saveToFile' && msg.values) {
+      const folder = primaryWorkspaceFolder();
+      if (!folder) {
+        void vscode.window.showErrorMessage('wcli0: open a workspace folder first.');
+        return;
+      }
+      // Reject a stale file-source save. If the primary workspace folder changed while the
+      // form had unsaved edits, the host already reset the file source (wsSub) but a dirty
+      // webview ignores that external init and still posts saveToFile. Writing the stale form
+      // values to the NEW folder would overwrite ITS .vscode/mcp.json with the previous
+      // folder's config — the very wrong-folder overwrite the reset avoids (P6). Only proceed
+      // while still in mcpJson mode for THIS folder, with the loaded entry intact.
+      if (
+        currentSource !== 'mcpJson' ||
+        loadedFileFolder !== folder.uri.fsPath ||
+        !loadedFileEntry
+      ) {
+        void vscode.window.showErrorMessage(
+          'wcli0: the workspace folder changed, so the loaded .vscode/mcp.json is no longer ' +
+            'active. Switch the source to .vscode/mcp.json again to reload it before saving.',
+        );
+        return;
+      }
+      // Overlay the form's changed values onto the loaded file baseline so unmodeled
+      // fields survive, then merge the regenerated entry onto the loaded raw entry (so
+      // unmodeled VS Code keys are preserved, P7/P12) and write it back to
+      // .vscode/mcp.json. Never touches wcli0.* settings.
+      // Overlay onto the CURRENT on-disk entry, not the snapshot loaded into the panel. Another
+      // process may have edited .vscode/mcp.json while the form was open, and the form submits
+      // ONLY the fields the user actually changed (collectChanged), so re-parsing the entry here
+      // keeps every unchanged MODELED field (--shell, safety mode, limits, ...) at its current
+      // on-disk value. Overlaying onto the stale snapshot instead re-emitted the loaded values,
+      // and because buildLaunchSpec replaces the whole `args` array a Debug-only save silently
+      // reverted a concurrent `--shell cmd` -> `--shell bash` edit (P80). The argv fields with no
+      // form control are re-derived from disk again at write time (P40); this covers the modeled
+      // ones. Falls back to the loaded snapshot when nothing is on disk (a deleted/malformed
+      // entry), matching the merge-base fallback (P23).
+      const currentFileEntry = await readWcli0Entry(folder);
+      const currentFileParsed = currentFileEntry ? parseMcpEntry(currentFileEntry) : undefined;
+      // A concurrent transport-mode switch changes WHICH fields the entry can model at all, so
+      // the form's edits cannot be overlaid meaningfully (stdio edits onto an http entry, or the
+      // reverse). Refuse and ask for a reload rather than guessing -- unless the user is
+      // deliberately switching the mode themselves, which rebuilds the entry for the new mode.
+      if (
+        currentFileParsed &&
+        loadedFileSettings &&
+        currentFileParsed.settings.transportMode !== loadedFileSettings.transportMode &&
+        !('transport.mode' in msg.values)
+      ) {
+        void vscode.window.showErrorMessage(
+          'wcli0: the .vscode/mcp.json entry switched to a different transport type since it was ' +
+            'loaded, so your edits no longer apply to it. Reload the source (switch it away and ' +
+            'back) before saving.',
+        );
+        return;
+      }
+      const settings = overlaySettings(
+        currentFileParsed?.settings ?? loadedFileSettings ?? defaultSettings(),
+        msg.values,
+      );
+      // An http/sse entry stores only {type, url}; no other field round-trips through it. The
+      // form disables the non-transport tabs when the mode is network (applyFileTransportLock),
+      // but disabling a control does not discard an edit made while the entry was still stdio:
+      // collectChanged() still submits it, the network save writes only {type, url}, and the
+      // post-save reparse silently drops it under a misleading "Saved". Refuse while any
+      // non-transport field is among the submitted changes so the loss is explicit (P55). Use
+      // the changed-field keys (collectChanged), which name exactly the user's edits, rather
+      // than re-deriving them from the settings — only transport.mode/host/port are storable.
+      if (settings.transportMode === 'http' || settings.transportMode === 'sse') {
+        const NETWORK_SAVABLE_KEYS = new Set(['transport.mode', 'transport.host', 'transport.port']);
+        const stale = Object.keys(msg.values).filter((k) => !NETWORK_SAVABLE_KEYS.has(k));
+        if (stale.length > 0) {
+          void vscode.window.showErrorMessage(
+            'wcli0: an http/sse .vscode/mcp.json entry stores only the transport type and URL, so ' +
+              'other edits (launch command, config file, per-shell config, profiles, safety, limits, ' +
+              '...) cannot be saved from this form. Revert them, or switch the entry back to stdio ' +
+              '(or use VS Code Settings) to keep them.',
+          );
+          return;
+        }
+      }
+      // Hand the writer the exact entry these settings were overlaid on, so it can refuse a
+      // concurrent write that landed between this read and its own full-file snapshot rather than
+      // merging stale modeled fields onto a newer entry (P95).
+      const ok = await writeMcpJsonFromSettings(settings, folder, {
+        baseEntry: loadedFileEntry,
+        expectedEntryJson: JSON.stringify(currentFileEntry ?? null),
+      });
+      if (!ok) {
+        return;
+      }
+      // Re-baseline from what was actually written to disk rather than the pre-write
+      // form state, so fields the form does not model match the file. In particular,
+      // when the user chose "Omit environment" the written entry has no env; reusing
+      // `settings` (which still carries the old env) as the baseline would let
+      // overlaySettings resurrect that omitted secret on a later unrelated save (P4).
+      const written = await readWcli0Entry(folder);
+      if (written) {
+        const reparsed = parseMcpEntry(written);
+        loadedFileSettings = reparsed.settings;
+        loadedFileEntry = written;
+        loadedFileNotes = reparsed.notes;
+      } else {
+        loadedFileSettings = settings;
+        loadedFileNotes = [];
+      }
+      loadedFileFolder = folder.uri.fsPath;
+      await refreshDetection();
+      post();
+      webview.postMessage({ type: 'saved' });
+      void vscode.window.showInformationMessage('wcli0: saved to .vscode/mcp.json.');
     } else if (msg.type === 'scopeChange' && msg.target) {
       currentScope = msg.target;
       post();
@@ -138,6 +508,14 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
         post();
       }
     } else if (msg.type === 'save' && msg.values && msg.target) {
+      // After a file-source reset (folder change), the form still holds the now-gone
+      // file's values and a file-relative dirty baseline. Writing them into wcli0.*
+      // settings would silently corrupt the scope with file-shaped edits the user made
+      // for a file, not for settings — so confirm before doing it (P28). The webview only
+      // sets this flag while that stale baseline is in effect; a clean re-baseline clears it.
+      if (msg.fromResetFileSource && !(await confirmStaleFileSourceWrite())) {
+        return; // declined — leave settings untouched
+      }
       // A refused save (e.g. Workspace target with no folder open, P89) leaves the
       // form untouched: skip the re-post, saved indicator and success toast.
       if (!(await applySettings(msg as SavePayload))) {
@@ -165,11 +543,31 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
       msg.type === 'writeMcpJson' ||
       msg.type === 'showCommand'
     ) {
+      // Export actions read and persist wcli0.* settings. While editing a file source
+      // the form holds the .vscode/mcp.json entry, not settings, so persisting its
+      // values would corrupt wcli0.* settings and the export would be generated from
+      // settings rather than the loaded file. The webview disables the export buttons
+      // in file mode; refuse here too as defense in depth (P1).
+      if (currentSource === 'mcpJson') {
+        void vscode.window.showErrorMessage(
+          'wcli0: export actions are unavailable while editing a .vscode/mcp.json source. ' +
+            'Switch to VS Code Settings to export.',
+        );
+        return;
+      }
       // Export actions operate on persisted settings. Persist the form's current
       // edits first so what the user sees in the form is what gets exported —
       // otherwise unsaved changes (e.g. Limits & Safety) would be silently
       // dropped from the generated config.json / mcp.json / launch command.
       if (msg.values && msg.target) {
+        // After a file-source reset (folder change) the form still holds the now-gone
+        // file's values; the export's applySettings would write them into wcli0.*
+        // settings just like a plain save would, so confirm first — matching the save
+        // path's guard. Without this the re-enabled export buttons bypass the P28
+        // confirmation and silently persist stale file-source edits into settings.
+        if (msg.fromResetFileSource && !(await confirmStaleFileSourceWrite())) {
+          return; // declined — leave settings untouched, skip the export
+        }
         // A refused save (Workspace target with no folder open, P89) must abort the
         // export too: it would otherwise operate on unsaved/stale persisted settings.
         if (!(await applySettings(msg as SavePayload))) {
@@ -212,7 +610,39 @@ function setupWebview(webview: vscode.Webview): vscode.Disposable {
     if (!primaryWorkspaceFolder() && currentScope === 'Workspace') {
       currentScope = 'Global';
     }
+    // A file source is workspace-relative and tied to the folder it was loaded from.
+    // Reset it whenever the primary folder no longer matches that folder — either no
+    // folder remains, or a multi-root removal/reorder changed the primary. Keeping the
+    // stale source would let the next "Save to file" overwrite the new folder's
+    // .vscode/mcp.json with the previously loaded folder's config (P2).
+    let sourceWasReset = false;
+    if (currentSource === 'mcpJson' && primaryWorkspaceFolder()?.uri.fsPath !== loadedFileFolder) {
+      currentSource = 'settings';
+      loadedFileSettings = undefined;
+      loadedFileEntry = undefined;
+      loadedFileNotes = [];
+      loadedFileFolder = undefined;
+      sourceWasReset = true;
+    }
+    // Post synchronously from the cached detection (a test asserts the re-post happens
+    // synchronously on folder change). Then refresh the detection cache and push a
+    // detection-only update so a folder added/changed while the panel is open updates the
+    // source switcher and the "Load & edit" banner for a workspace that already has
+    // .vscode/mcp.json (P16) — without it the detection only appears on the next unrelated
+    // post. A dedicated `detected` message (not a full init) is used so it cannot race a
+    // concurrent save's scope realignment by re-posting a stale scope (P96).
     post(true);
+    // The post above is an external reload, which a DIRTY form ignores so it does not discard
+    // unsaved edits — but that also means it never applies the source reset, leaving the UI
+    // showing and saving as the now-gone file source until a save is rejected. Push a
+    // dedicated source-reset message that switches the UI off the file source even while
+    // dirty (field values and dirty state are left untouched, P25).
+    if (sourceWasReset) {
+      webview.postMessage({ type: 'sourceReset', source: 'settings', detected: detectedSources });
+    }
+    void refreshDetection().then(() =>
+      webview.postMessage({ type: 'detected', detected: detectedSources }),
+    );
   });
 
   return {
@@ -402,12 +832,33 @@ function renderHtml(webview: vscode.Webview): string {
     background: var(--vscode-button-background); color: var(--vscode-button-foreground);
     border: 1px solid var(--vscode-button-border, transparent); border-radius: 4px;
   }
-  button:hover { background: var(--vscode-button-hoverBackground); }
+  button:not(:disabled):hover { background: var(--vscode-button-hoverBackground); }
+  button:disabled { opacity: .5; cursor: default; }
   button.secondary { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); }
-  button.secondary:hover { background: var(--vscode-button-secondaryHoverBackground); }
+  button.secondary:not(:disabled):hover { background: var(--vscode-button-secondaryHoverBackground); }
   .scope-radio { display: inline-flex; gap: 14px; align-items: center; flex-wrap: wrap; }
   .scope-radio > span { font-weight: 600; }
-  .scope-radio label { display: inline-flex; align-items: center; gap: 5px; font-weight: 400; margin: 0; }
+  .scope-radio label {
+    display: inline-flex; align-items: center; gap: 6px; font-weight: 400; margin: 0;
+    padding: 3px 9px; border-radius: 4px; cursor: pointer;
+    border: 1px solid transparent;
+  }
+  /* Native radios render as dark-on-dark in most VS Code themes, so the selected
+     option is nearly invisible. Tint the control with the theme focus color and
+     visibly highlight the checked label (chip outline + accent text). */
+  .scope-radio input[type=radio] {
+    accent-color: var(--vscode-focusBorder, var(--vscode-button-background));
+    width: 15px; height: 15px; margin: 0; cursor: pointer;
+  }
+  .scope-radio label:hover { background: var(--vscode-list-hoverBackground, transparent); }
+  .scope-radio label:has(input:checked) {
+    border-color: var(--vscode-focusBorder, var(--vscode-button-background));
+    background: var(--vscode-list-activeSelectionBackground, var(--vscode-button-background));
+    color: var(--vscode-list-activeSelectionForeground, var(--vscode-button-foreground));
+    font-weight: 600;
+  }
+  .scope-radio input[type=radio]:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
+  .scope-radio label:has(input:disabled) { opacity: 0.5; cursor: not-allowed; }
   details.shell-block {
     margin-top: 10px; padding: 10px 12px; border-radius: 5px;
     border: 1px solid var(--vscode-panel-border, var(--vscode-editorWidget-border, transparent));
@@ -467,6 +918,15 @@ function renderHtml(webview: vscode.Webview): string {
 </head>
 <body>
   <div class="scopebar">
+    <div class="source-row" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px">
+      <span class="hint">Editing:</span>
+      <span id="sourceChip" class="statuschip sc-ok" title="The configuration source the form is editing">VS Code Settings</span>
+      <span id="sourcePath" class="hint" style="font-family:var(--vscode-editor-font-family);max-width:360px;overflow-wrap:anywhere;word-break:break-word"></span>
+      <span class="switcher" style="position:relative">
+        <button type="button" id="switchSourceBtn" class="secondary">Switch source &#9662;</button>
+        <div id="sourceMenu" style="display:none;position:absolute;top:calc(100% + 4px);left:0;z-index:20;min-width:320px;padding:6px;border-radius:6px;background:var(--vscode-editorWidget-background,#252526);border:1px solid var(--vscode-panel-border,#3c3c3c);box-shadow:0 6px 24px #0008"></div>
+      </span>
+    </div>
     <div class="savebar">
       <div class="scope-radio">
         <span>Save to:</span>
@@ -475,13 +935,26 @@ function renderHtml(webview: vscode.Webview): string {
       </div>
       <div class="saveactions">
         <span id="isolationChip" class="statuschip sc-warn" title="Whether an implicit config.json could override these settings. Open the Config source tab.">Overridable</span>
+        <span id="dirtyMsg" class="saved-msg" style="display:none;color:var(--vscode-charts-yellow,#d7a930)">Unsaved changes</span>
         <span id="savedMsg" class="saved-msg" style="display:none">Saved &#10003;</span>
+        <button id="revertFile" class="secondary" style="display:none">Revert to file</button>
         <button id="save">Save settings</button>
       </div>
     </div>
-    <div class="hint" style="margin-top:6px">
+    <div id="settingsHint" class="hint" style="margin-top:6px">
       Workspace: this project's .vscode/settings.json &middot; User: your global settings.
     </div>
+    <div id="fileHint" class="hint" style="display:none;margin-top:6px">
+      Editing a file directly. Save writes the wcli0 entry back to this file; other servers are preserved.
+    </div>
+    <div id="detectBanner" class="hint" style="display:none;margin-top:8px;padding:10px 12px;border-radius:6px;border:1px solid var(--vscode-panel-border,#3c3c3c);border-left:3px solid var(--vscode-charts-blue,#6fb3e0);background:var(--vscode-editorWidget-background,#252526)">
+      <span>You are editing <strong>VS Code Settings</strong>. A <strong>wcli0</strong> server also exists in <code>.vscode/mcp.json</code> &mdash; its values are <strong>not loaded here</strong>. Load it to edit that file instead.</span>
+      <span style="display:inline-flex;gap:8px;margin-left:8px">
+        <button type="button" id="loadMcpJson">Load &amp; edit .vscode/mcp.json</button>
+        <button type="button" id="dismissBanner" class="secondary">Dismiss</button>
+      </span>
+    </div>
+    <div id="sourceNotes" class="hint" style="display:none;margin-top:8px;color:var(--vscode-charts-yellow,#d7a930)"></div>
     <div id="noWorkspace" class="hint" style="display:none;color:var(--vscode-errorForeground)">
       No workspace folder open — only User scope is available.
     </div>
@@ -494,6 +967,13 @@ function renderHtml(webview: vscode.Webview): string {
       <button type="button" class="tab" data-tab="transport">Transport</button>
       <button type="button" class="tab" data-tab="export">Export</button>
     </div>
+  </div>
+
+  <div id="networkLockNote" class="hint" style="display:none;margin:0 0 10px;color:var(--vscode-charts-yellow,#d7a930)">
+    This .vscode/mcp.json entry is an http/sse server, so it stores only its URL. The Launch,
+    Config file, Shells, Profiles, and Limits &amp; Safety options cannot be written to it and are
+    disabled here &mdash; edit them in VS Code Settings, or switch this entry to stdio on the
+    Transport tab.
   </div>
 
   <div class="tabpanel active" data-tab="config">
@@ -629,8 +1109,8 @@ function renderHtml(webview: vscode.Webview): string {
   <section>
   <h2>Limits & Safety</h2>
   <div class="row">
-    <div><label>Command timeout (s)</label><input type="number" id="commandTimeout" min="1" step="any" /></div>
-    <div><label>Max command length</label><input type="number" id="maxCommandLength" min="1" step="any" /></div>
+    <div><label>Command timeout (s)</label><input type="number" id="commandTimeout" min="0" step="any" /></div>
+    <div><label>Max command length</label><input type="number" id="maxCommandLength" min="0" step="any" /></div>
     <div><label>Max output lines</label><input type="number" id="maxOutputLines" min="1" max="10000" step="any" /></div>
   </div>
   <div class="row">
@@ -1058,6 +1538,22 @@ function renderHtml(webview: vscode.Webview): string {
     return Object.keys(collectChanged()).length > 0;
   }
 
+  // Enable "Revert to file" only when the form has unsaved edits — a clean form already
+  // matches the file, so there is nothing to revert. The button is also hidden entirely
+  // outside the file source (see setActiveSource). Called on every reload/save (via
+  // setActiveSource) and live on each field edit (delegated input/change listeners).
+  function reflectDirty() {
+    const dirty = isDirty();
+    const rb = $('revertFile');
+    if (rb) rb.disabled = !dirty;
+    // Surface the "Unsaved changes" indicator only while editing the file source, where
+    // there is no per-scope Save cue: a clean form (or any settings-source form) hides it,
+    // a dirty file form shows it. Toggled live via the delegated input/change listeners and
+    // on every reload/save through setActiveSource (P22).
+    const dm = $('dirtyMsg');
+    if (dm) dm.style.display = dirty && currentSourceClient === 'mcpJson' ? '' : 'none';
+  }
+
   function updateLaunchRows() {
     const m = $('launch.method').value;
     // '' is Inherit (no method chosen): hide all method-specific rows.
@@ -1076,8 +1572,38 @@ function renderHtml(webview: vscode.Webview): string {
     $('transport.host').disabled = !networked;
     $('transport.port').disabled = !networked;
     $('transportHint').style.display = networked ? 'none' : '';
+    // The set of editable tabs depends on the mode for a file source (see below).
+    applyFileTransportLock();
   }
   $('transport.mode').addEventListener('change', updateTransportRows);
+
+  // The data-tab panels whose fields cannot be stored in a network (http/sse)
+  // .vscode/mcp.json entry — which is just type + url: the launch command, the referenced
+  // config file, per-shell config, profiles, and limits/safety/logging/allowed-directories.
+  const NETWORK_LOCKED_PANELS = ['config', 'launch', 'shells', 'profiles', 'safety'];
+  // When editing an http/sse FILE source, disable those panels' controls (and show a notice)
+  // so edits that the entry cannot store are not made and then silently dropped on the
+  // post-save reparse (P-httpdrop). The Transport tab stays editable so the URL can be changed
+  // or the entry switched back to stdio. A settings source keeps everything editable (the
+  // values persist in wcli0.* settings), and so does a stdio file source.
+  function applyFileTransportLock() {
+    const modeEl = $('transport.mode');
+    if (!modeEl || typeof document.querySelector !== 'function') return; // minimal test DOM
+    const mode = modeEl.value;
+    const lock = currentSourceClient === 'mcpJson' && (mode === 'http' || mode === 'sse');
+    for (const name of NETWORK_LOCKED_PANELS) {
+      const panel = document.querySelector('.tabpanel[data-tab="' + name + '"]');
+      if (!panel || !panel.querySelectorAll) continue;
+      for (const el of panel.querySelectorAll('input, select, textarea, button')) {
+        el.disabled = lock;
+      }
+    }
+    const note = $('networkLockNote');
+    if (note) note.style.display = lock ? '' : 'none';
+    // Unlocking blanket-enabled every control above, so restore the conditional disabled
+    // states (the Workspace-only inherited-config masks) that other logic owns (P97).
+    if (!lock) applyScopeAvailability(formScope);
+  }
 
   // ---- Design 5: tabs, per-shell segmented enable, isolation status ----
   // Tab switching. Only runs in the real webview; the test harness exposes no
@@ -1254,13 +1780,19 @@ function renderHtml(webview: vscode.Webview): string {
   }
 
   // Block any out-of-range numeric input before a save or export posts values. The
-  // port (1..65535), the global/per-shell timeouts and command lengths (>= 1) and
-  // maxOutputLines (1..10000) all carry min/max constraints; without this only the
-  // port was checked, so an invalid value such as commandTimeout=0 or
-  // maxOutputLines=10001 would persist and then make validateLaunchSpec register no
-  // server (and the export handlers would emit a config the server rejects at
-  // startup). Mirror the host-side validateLaunchSpec bounds with native validity UI
-  // so the form fails fast on the first offending control. (P100)
+  // port (1..65535) and maxOutputLines (1..10000) carry min/max constraints; without this
+  // only the port was checked, so an invalid value such as maxOutputLines=10001 would persist
+  // and then make validateLaunchSpec register no server (and the export handlers would emit a
+  // config the server rejects at startup). Mirror the host-side validateLaunchSpec bounds with
+  // native validity UI so the form fails fast on the first offending control. (P100)
+  //
+  // commandTimeout / maxCommandLength carry only min="0": the strict managed bound is >= 1
+  // (the value is written into a generated config validateConfig re-checks), but the server
+  // accepts any CLI value > 0 (applied verbatim by applyCliSecurityOverrides). A hand-authored
+  // file-source entry can carry a sub-1-second value (e.g. --commandTimeout 0.5) that the
+  // typed field must be able to re-submit; min="0" lets it pass here while the host's
+  // managed/non-managed bound (validateLaunchSpec) still rejects an actually-invalid value
+  // (<= 0, or < 1 in managed mode) with a precise message (P58).
   function validateNumbers() {
     for (const el of document.querySelectorAll('input[type=number]')) {
       if (el.disabled || el.value === '') continue;
@@ -1272,17 +1804,48 @@ function renderHtml(webview: vscode.Webview): string {
     return true;
   }
 
+  // The active configuration source ('settings' or 'mcpJson'), set from each init.
+  let currentSourceClient = 'settings';
+  let bannerDismissed = false;
+  // True after a sourceReset switched the form off a file source while it was dirty: the
+  // form still holds the (now-gone) file's values and a file-relative dirty baseline, so a
+  // plain "Save settings" would silently write those file edits into wcli0.* settings.
+  // Guarded in the save handler; cleared whenever the form re-baselines to real values.
+  let resetFromFileSource = false;
+
   $('save').addEventListener('click', () => {
     if (!validateNumbers() || !validateProfiles()) return;
+    if (currentSourceClient === 'mcpJson') {
+      // Editing a file: write the entry back to .vscode/mcp.json, not to settings.
+      vscode.postMessage({ type: 'saveToFile', values: collectChanged() });
+      return;
+    }
     const target = document.querySelector('input[name=scope]:checked').value;
-    vscode.postMessage({ type: 'save', target, values: collectChanged() });
+    // After a file-source reset the form's values/baseline are file-derived; flag the
+    // save so the host confirms before writing them into settings rather than doing it
+    // silently (P28). isDirty() guards against a no-op save re-prompting needlessly.
+    vscode.postMessage({
+      type: 'save',
+      target,
+      values: collectChanged(),
+      fromResetFileSource: resetFromFileSource && isDirty(),
+    });
   });
   // Export actions carry the current form state so the host can persist unsaved
   // edits before generating, keeping the output in sync with what is on screen.
   function exportAction(type) {
     if (!validateNumbers() || !validateProfiles()) return;
     const target = document.querySelector('input[name=scope]:checked').value;
-    vscode.postMessage({ type, target, values: collectChanged() });
+    // After a file-source reset the form's values/baseline are file-derived; flag the
+    // export so the host confirms before applySettings writes them into settings,
+    // matching the Save button's guard — otherwise an export would silently persist
+    // stale file-source edits into wcli0.* settings (P28).
+    vscode.postMessage({
+      type,
+      target,
+      values: collectChanged(),
+      fromResetFileSource: resetFromFileSource && isDirty(),
+    });
   }
   $('genConfig').addEventListener('click', () => exportAction('generateConfig'));
   $('writeMcp').addEventListener('click', () => exportAction('writeMcpJson'));
@@ -1307,14 +1870,23 @@ function renderHtml(webview: vscode.Webview): string {
   }
 
   let savedTimer;
-  function showSaved() {
+  // Check-mark glyph built from its code point so the source stays ASCII (no literal
+  // non-ASCII characters in code, matching the HTML template's &#10003; convention).
+  const CHECK = String.fromCharCode(0x2713);
+  // Briefly show a transient status message in the shared indicator span, then restore
+  // its default "Saved" label. Used for save, revert, and "nothing to revert" feedback.
+  function flashStatus(text) {
     const el = $('savedMsg');
     if (!el) return;
-    // Re-baseline so the indicator clears once further edits are made.
-    initial = collect();
+    el.textContent = text;
     el.style.display = '';
     clearTimeout(savedTimer);
-    savedTimer = setTimeout(() => { el.style.display = 'none'; }, 2500);
+    savedTimer = setTimeout(() => { el.style.display = 'none'; el.textContent = 'Saved ' + CHECK; }, 2500);
+  }
+  function showSaved() {
+    // Re-baseline so the indicator clears once further edits are made.
+    initial = collect();
+    flashStatus('Saved ' + CHECK);
   }
 
   // Reflect whether a workspace folder is available: enable/disable the Workspace
@@ -1358,27 +1930,237 @@ function renderHtml(webview: vscode.Webview): string {
   // persisting them globally (P97).
   function applyScopeAvailability(scope) {
     const isUser = scope === 'Global';
+    // The masks are VS Code settings-only opt-outs that no .vscode/mcp.json entry can store,
+    // so disable them on ANY file source regardless of mode — editing one on a stdio file
+    // source would otherwise let Save to file "succeed" while the post-save reparse drops the
+    // edit and reports Saved (P-maskfile). http/sse file sources already disable the whole
+    // Shells/Profiles panels via applyFileTransportLock; this also covers the stdio case.
+    const isFile = currentSourceClient === 'mcpJson';
     const ign = $('ignoreInheritedShells');
     if (ign) {
-      ign.disabled = isUser;
+      ign.disabled = isUser || isFile;
       const note = $('ignoreInheritedShellsUserNote');
       if (note) note.style.display = isUser ? '' : 'none';
     }
     // The inherited-profiles mask is Workspace-only for the same reason (a Global
     // value would suppress the user's own profiles everywhere), so disable it while
-    // editing User scope and show why.
+    // editing User scope and show why; disable it on a file source too (P-maskfile).
     const ignProf = $('ignoreInheritedProfiles');
     if (ignProf) {
-      ignProf.disabled = isUser;
+      ignProf.disabled = isUser || isFile;
       const noteProf = $('ignoreInheritedProfilesUserNote');
       if (noteProf) noteProf.style.display = isUser ? '' : 'none';
     }
   }
 
+  // ---- Configuration source switcher (source bar) ----
+  // Request a switch to the given editable source, guarding unsaved edits with the
+  // host modal (mirrors the scope-switch guard). A clean form switches immediately.
+  function requestSource(target) {
+    if (target === currentSourceClient) { hideSourceMenu(); return; }
+    hideSourceMenu();
+    vscode.postMessage({ type: isDirty() ? 'sourceChangeRequest' : 'sourceChange', source: target });
+  }
+  function hideSourceMenu() { const m = $('sourceMenu'); if (m) m.style.display = 'none'; }
+  // Build the switcher menu from the detected sources. Editable entries post a switch;
+  // the read-only home config is shown disabled and never becomes a target.
+  function renderSourceMenu(detected) {
+    const menu = $('sourceMenu');
+    if (!menu) return;
+    // The menu is built with createElement; the unit-test DOM harness has none, so
+    // no-op there (menu interaction is not unit-tested). Real webview builds it.
+    if (typeof document.createElement !== 'function') return;
+    menu.textContent = '';
+    const add = (label, sub, onClick, opts) => {
+      opts = opts || {};
+      const row = document.createElement('div');
+      // The active (currently loaded) source gets a highlighted row + an "active"
+      // badge so it is unmistakable which source the form values come from. A bare
+      // checkmark was too easy to miss and competed with the detection banner's
+      // highlight on a different file.
+      row.style.cssText = 'padding:8px 10px;border-radius:4px;' +
+        (opts.disabled ? 'opacity:.55;' : 'cursor:pointer;') +
+        (opts.active ? 'background:var(--vscode-list-activeSelectionBackground,#04395e);border-left:3px solid var(--vscode-focusBorder,#0078d4);' : '');
+      const main = document.createElement('div');
+      main.style.cssText = 'font-weight:600;display:flex;align-items:center;gap:8px';
+      const labelEl = document.createElement('span');
+      labelEl.textContent = label;
+      main.appendChild(labelEl);
+      if (opts.active) {
+        const badge = document.createElement('span');
+        badge.textContent = 'active';
+        badge.style.cssText = 'font-size:.72em;font-weight:600;text-transform:uppercase;letter-spacing:.04em;padding:1px 6px;border-radius:8px;background:var(--vscode-focusBorder,#0078d4);color:var(--vscode-button-foreground,#fff)';
+        main.appendChild(badge);
+      }
+      row.appendChild(main);
+      if (sub) {
+        const s = document.createElement('div');
+        s.style.cssText = 'opacity:.7;font-size:.83em;font-family:var(--vscode-editor-font-family)';
+        s.textContent = sub;
+        row.appendChild(s);
+      }
+      if (!opts.disabled && onClick && !opts.active) {
+        row.addEventListener('mouseenter', () => { row.style.background = '#ffffff14'; });
+        row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+        row.addEventListener('click', onClick);
+      } else if (!opts.disabled && onClick) {
+        // Active row: clicking the already-loaded source is a no-op, so keep its
+        // highlight static and don't rebind hover (which would wipe the background).
+        row.addEventListener('click', onClick);
+      }
+      menu.appendChild(row);
+    };
+    add('VS Code Settings', 'wcli0.* · User & Workspace', () => requestSource('settings'), { active: currentSourceClient === 'settings' });
+    for (const d of (detected || [])) {
+      if (d.kind === 'mcpJson') {
+        const tag = d.hasWcli0 ? ' (wcli0 entry)' : (d.exists ? ' (no wcli0 entry)' : ' (not present)');
+        add('.vscode/mcp.json' + tag, d.fsPath || '', d.hasWcli0 ? () => requestSource('mcpJson') : null, { disabled: !d.hasWcli0, active: currentSourceClient === 'mcpJson' });
+      } else if (d.kind === 'homeConfig') {
+        // Not an editable source, but clicking opens it read-only so the row is not a
+        // dead item — it lets the user inspect the global config that can override them.
+        add(d.label, 'read-only · click to open (never a save target)', () => {
+          hideSourceMenu();
+          vscode.postMessage({ type: 'openHomeConfig' });
+        }, {});
+      }
+    }
+  }
+  // Reflect the active source: scope radio + hints + Save button label/behavior.
+  function setActiveSource(source, detected) {
+    currentSourceClient = source || 'settings';
+    const isFile = currentSourceClient === 'mcpJson';
+    const chip = $('sourceChip');
+    if (chip) {
+      chip.textContent = isFile ? 'mcp.json' : 'VS Code Settings';
+      chip.className = 'statuschip ' + (isFile ? 'sc-warn' : 'sc-ok');
+    }
+    const fileEntry = (detected || []).find((d) => d.kind === 'mcpJson');
+    const sp = $('sourcePath');
+    if (sp) {
+      const pathLabel = isFile && fileEntry ? (fileEntry.fsPath || '') + ' (servers.wcli0)' : '';
+      sp.textContent = pathLabel;
+      // Full path as a hover tooltip (it wraps but can still be long); empty string
+      // clears it when not editing a file.
+      sp.title = pathLabel;
+    }
+    const sr = document.querySelector('.scope-radio');
+    if (sr) sr.style.display = isFile ? 'none' : '';
+    if ($('settingsHint')) $('settingsHint').style.display = isFile ? 'none' : '';
+    if ($('fileHint')) $('fileHint').style.display = isFile ? '' : 'none';
+    if ($('revertFile')) {
+      $('revertFile').style.display = isFile ? '' : 'none';
+      $('revertFile').title = 'Discard unsaved edits and reload the wcli0 entry from the file on disk.';
+    }
+    if ($('save')) {
+      $('save').textContent = isFile ? 'Save to file' : 'Save settings';
+      $('save').title = isFile
+        ? 'Write the wcli0 entry back to the loaded file. Other servers in the file are preserved.'
+        : 'Save these values to your VS Code settings at the selected scope.';
+    }
+    // Export actions read/write wcli0.* settings, so they do not apply while editing a
+    // file source — disable them to match the host's refusal (P1). Off the file source,
+    // restore them: writeMcp additionally depends on a workspace folder being open.
+    for (const id of ['showCommand', 'genConfig', 'writeMcp']) {
+      const btn = $(id);
+      if (!btn) continue;
+      btn.disabled = isFile || (id === 'writeMcp' && !currentHasWorkspace);
+      btn.title = isFile
+        ? 'Switch to VS Code Settings to export. Export actions operate on settings, not a file source.'
+        : '';
+    }
+    applyDetected(detected);
+    // Lock the non-transport tabs when this is an http/sse file source (their fields cannot
+    // be saved to a network entry); re-enable them otherwise. Runs after the mode is set.
+    applyFileTransportLock();
+    // The just-loaded form is clean (baseline === values), so disable Revert until an
+    // edit is made. Live edits re-evaluate via the delegated input/change listeners.
+    reflectDirty();
+  }
+  // Update the detection-dependent UI (source-switcher rows + the "Load & edit" banner) from
+  // the current detected sources, using the active source already on screen. Kept separate
+  // from setActiveSource so a background detection refresh (e.g. after a workspace-folder
+  // change, P16) can refresh just this without re-posting scope/field values.
+  function applyDetected(detected) {
+    const fileEntry = (detected || []).find((d) => d.kind === 'mcpJson');
+    // The detection banner only makes sense while editing settings and a wcli0 entry
+    // exists in the workspace mcp.json (and the user has not dismissed it).
+    const banner = $('detectBanner');
+    if (banner) {
+      const show =
+        currentSourceClient !== 'mcpJson' && !bannerDismissed && !!(fileEntry && fileEntry.hasWcli0);
+      banner.style.display = show ? '' : 'none';
+    }
+    renderSourceMenu(detected);
+  }
+  // Re-evaluate the Revert button's enabled state on any field edit. input/change
+  // bubble, so a single delegated listener covers every control in the form. Guarded
+  // for the unit-test DOM harness, which has no document-level addEventListener.
+  if (typeof document.addEventListener === 'function') {
+    document.addEventListener('input', reflectDirty);
+    document.addEventListener('change', reflectDirty);
+  }
+  const switchBtn = $('switchSourceBtn');
+  if (switchBtn) switchBtn.addEventListener('click', () => {
+    const m = $('sourceMenu');
+    if (m) m.style.display = m.style.display === 'none' ? 'block' : 'none';
+  });
+  const loadBtn = $('loadMcpJson');
+  if (loadBtn) loadBtn.addEventListener('click', () => requestSource('mcpJson'));
+  const dismissBtn = $('dismissBanner');
+  if (dismissBtn) dismissBtn.addEventListener('click', () => {
+    bannerDismissed = true;
+    if ($('detectBanner')) $('detectBanner').style.display = 'none';
+  });
+  const revertBtn = $('revertFile');
+  if (revertBtn) revertBtn.addEventListener('click', () => {
+    // The button is disabled on a clean form (reflectDirty), so a click means there are
+    // unsaved edits. Guard anyway, then ask the host to confirm and reload from disk (it
+    // flashes "Reverted" on success).
+    if (!isDirty()) return;
+    vscode.postMessage({ type: 'revertFileRequest' });
+  });
+
   window.addEventListener('message', (e) => {
     const msg = e.data;
     if (msg.type === 'saved') {
       showSaved();
+      return;
+    }
+    if (msg.type === 'reverted') {
+      // The host already re-posted the file values (re-baselining the form via init);
+      // just flash a confirmation so the click has a visible effect.
+      flashStatus('Reverted from file ' + CHECK);
+      return;
+    }
+    if (msg.type === 'detected') {
+      // A background detection refresh (workspace folder added/changed). Update only the
+      // switcher rows and the "Load & edit" banner; never touches scope/fields, so it cannot
+      // disturb a dirty form or a just-saved scope (P16/P96).
+      applyDetected(msg.detected);
+      return;
+    }
+    if (msg.type === 'sourceReset') {
+      // The host reset the active source because the loaded .vscode/mcp.json's folder is no
+      // longer the primary one. Switch the UI off the file source even while the form is
+      // dirty — the file is gone, so continuing to show and save as it is wrong (P25). Field
+      // values and the dirty state are left untouched so unsaved edits are not discarded;
+      // setActiveSource re-evaluates the dirty indicator for the new (settings) source.
+      setActiveSource(msg.source, msg.detected);
+      // The form keeps the file's values and a file-relative dirty baseline (P25), so a
+      // subsequent "Save settings" must be confirmed before writing them into settings (P28).
+      // Only arm the guard when the form is actually dirty: the wsSub flow sends an external
+      // init (post(true)) BEFORE this sourceReset, and for a CLEAN form that init re-baselines
+      // to real settings values (clearing the flag), so arming unconditionally here would
+      // flag a settings-derived save and trip a false P28 confirmation (P38).
+      if (isDirty()) {
+        resetFromFileSource = true;
+      }
+      // Off the file source there are never parse notes — clear any left from the file (P11).
+      const notesEl = $('sourceNotes');
+      if (notesEl) {
+        notesEl.textContent = '';
+        notesEl.style.display = 'none';
+      }
       return;
     }
     if (msg.type === 'init') {
@@ -1407,11 +2189,28 @@ function renderHtml(webview: vscode.Webview): string {
       }
       setVal(msg.settings, msg.setKeys, msg.setSelectKeys, msg.setArrayKeys);
       initial = collect();
+      // The form now reflects real persisted values (settings or a freshly loaded file),
+      // so the post-reset file-derived baseline is gone — drop the P28 save guard.
+      resetFromFileSource = false;
       // Record the scope the form now reflects so a cancelled scope switch can
       // revert the radio to it (P70).
       formScope = msg.scope || formScope;
       // Enable/disable the Workspace-only inherited-shell mask for the loaded scope (P97).
       applyScopeAvailability(formScope);
+      // Reflect the active configuration source (source bar, switcher, banner, Save
+      // button) from this init. Clear stale parse notes when not on a file source.
+      setActiveSource(msg.source, msg.detected);
+      // Render the file-source parse notes from this init. Every file-source init carries
+      // the current notes (empty when none apply), so a clean reload or save clears stale
+      // notes rather than leaving an obsolete warning visible (P11); off the file source
+      // there are never notes.
+      const notesEl = $('sourceNotes');
+      if (notesEl) {
+        const notes =
+          currentSourceClient === 'mcpJson' && Array.isArray(msg.notes) ? msg.notes : [];
+        notesEl.textContent = notes.join(' ');
+        notesEl.style.display = notes.length ? '' : 'none';
+      }
     }
   });
   vscode.postMessage({ type: 'ready' });

--- a/vscode-extension/test/integration/mcpJson.test.js
+++ b/vscode-extension/test/integration/mcpJson.test.js
@@ -175,4 +175,29 @@ describe('wcli0: Write .vscode/mcp.json', function () {
     assert.equal(entry.url, 'http://127.0.0.1:8080/mcp');
     assert.equal(entry.args, undefined);
   });
+
+  // The file-source "Save to file" path and this command share
+  // writeMcpJsonFromSettings, whose merge must preserve any other server entries in
+  // an existing .vscode/mcp.json. Verify that end-to-end against a real file.
+  it('preserves other servers when merging the wcli0 entry into an existing file', async function () {
+    await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(folder().uri, '.vscode'));
+    const existing = {
+      servers: {
+        other: { type: 'stdio', command: 'echo', args: ['hi'] },
+        wcli0: { type: 'stdio', command: 'stale' },
+      },
+    };
+    await vscode.workspace.fs.writeFile(mcpUri(), Buffer.from(JSON.stringify(existing), 'utf8'));
+
+    await setAll({ shell: 'cmd' });
+    await vscode.commands.executeCommand('wcli0.writeWorkspaceMcpJson');
+
+    const raw = await vscode.workspace.fs.readFile(mcpUri());
+    const parsed = JSON.parse(Buffer.from(raw).toString('utf8'));
+    assert.ok(parsed.servers.other, 'unrelated server preserved');
+    assert.equal(parsed.servers.other.command, 'echo');
+    assert.deepEqual(parsed.servers.other.args, ['hi']);
+    assert.equal(parsed.servers.wcli0.command, 'npx', 'wcli0 entry rewritten from settings');
+    assert.ok(parsed.servers.wcli0.args.includes('--shell'), JSON.stringify(parsed.servers.wcli0.args));
+  });
 });

--- a/vscode-extension/test/unit/argsBuilder.test.cjs
+++ b/vscode-extension/test/unit/argsBuilder.test.cjs
@@ -225,6 +225,205 @@ test('--allowAllDirs is emitted only when no dirs/initialDir are configured', ()
   );
 });
 
+test('a file-source round-trip preserves --allowAllDirs even with dirs/initialDir set (P57)', () => {
+  // For a file source (preserveRelativePaths) a hand-authored --allowAllDirs the form shows as
+  // set must survive an unrelated save: with --initialDir, dropping it silently re-tightens the
+  // server to initialDir; with --allowedDir it is server-inert but would flip the tri-select on
+  // reparse. Both keep the flag here, unlike the settings-export/provider paths above.
+  const opts = { resolvePaths: false, preserveRelativePaths: true };
+  assert.deepEqual(buildServerArgs(defaults({ allowAllDirs: true, initialDir: '/x' }), opts), [
+    '--initialDir', '/x', '--allowAllDirs',
+  ]);
+  assert.deepEqual(
+    buildServerArgs(defaults({ allowAllDirs: true, allowedDirectories: ['/srv'] }), opts),
+    ['--allowedDir', '/srv', '--allowAllDirs'],
+  );
+});
+
+test('P73: dash-prefixed scalar path values stay attached to their flag', () => {
+  // buildServerArgs emits scalar path options space-separated, but a value that starts with a
+  // dash (e.g. a directory literally named `--unsafe`, preserved verbatim from a file-source
+  // round-trip) would be parsed by yargs as a separate flag. pushOption keeps it attached via the
+  // --opt=value form so the launch semantics are not changed (P73).
+  const opts = { resolvePaths: false, preserveRelativePaths: true };
+  const args = buildServerArgs(
+    defaults({
+      configFile: '--cfg',
+      allowedDirectories: ['--dir'],
+      initialDir: '--init',
+      logDirectory: '--unsafe',
+      wslMountPoint: '--wsl',
+    }),
+    opts,
+  );
+  assert.ok(args.includes('--config=--cfg'), 'config uses attached form');
+  assert.ok(args.includes('--allowedDir=--dir'), 'allowedDir uses attached form');
+  assert.ok(args.includes('--initialDir=--init'), 'initialDir uses attached form');
+  assert.ok(args.includes('--logDirectory=--unsafe'), 'logDirectory uses attached form');
+  assert.ok(args.includes('--wslMountPoint=--wsl'), 'wslMountPoint uses attached form');
+  // None of the dash-prefixed values leaked as a standalone token a server would read as a flag.
+  assert.ok(
+    !args.includes('--unsafe'),
+    'the directory name is not emitted as a bare safety flag',
+  );
+
+  // A normal (non-dash) value still emits as separate tokens — unchanged behavior.
+  const normal = buildServerArgs(defaults({ logDirectory: '/var/log' }), opts);
+  const idx = normal.indexOf('--logDirectory');
+  assert.ok(idx >= 0, 'logDirectory flag is present');
+  assert.equal(normal[idx + 1], '/var/log', 'non-dash value stays space-separated');
+});
+
+test('an emitted log limit drops a duplicate diverted copy from extraArgs (P59)', () => {
+  // The parser diverts an out-of-range log limit into extraArgs to round-trip it verbatim.
+  // When the form then supplies an in-range typed value, the builder emits that and must drop
+  // the stale extraArgs copy of the same flag, or yargs would merge two into an array the
+  // server applies neither of.
+  assert.deepEqual(
+    buildServerArgs(defaults({ maxOutputLines: 50, extraArgs: ['--maxOutputLines', '99999'] })),
+    ['--maxOutputLines', '50'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ maxReturnLines: 200, extraArgs: ['--max-return-lines=50000'] })),
+    ['--maxReturnLines', '200'],
+  );
+  // A diverted log limit with no competing typed value is preserved verbatim.
+  assert.deepEqual(
+    buildServerArgs(defaults({ extraArgs: ['--maxReturnLines', '50000'] })),
+    ['--maxReturnLines', '50000'],
+  );
+});
+
+test('an emitted modeled scalar flag drops a diverted duplicate from extraArgs (P61)', () => {
+  // The parser diverts a malformed modeled value into extraArgs to round-trip it verbatim:
+  // an unparseable number is kept as `['--commandTimeout', 'bad']` (P34), and a string flag
+  // whose value is itself a flag (`--logDirectory --debug`) is kept as the bare `--logDirectory`
+  // (the following `--debug` is parsed as the debug field, not preserved). Once the form
+  // supplies a typed value the builder emits its own flag and must drop the stale diverted
+  // copy, or yargs merges the two into an array the server's applyCli* helpers apply none of
+  // (and the edited value is ignored / crashes startup).
+
+  // Unparseable security-override number: the flag AND its diverted value token are removed.
+  // Both spellings (camel + kebab) the parser may have produced are stripped.
+  assert.deepEqual(
+    buildServerArgs(defaults({ commandTimeout: 30, extraArgs: ['--commandTimeout', 'bad'] })),
+    ['--commandTimeout', '30'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ commandTimeout: 30, extraArgs: ['--command-timeout=bad'] })),
+    ['--commandTimeout', '30'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ maxCommandLength: 4096, extraArgs: ['--maxCommandLength', 'bad'] })),
+    ['--maxCommandLength', '4096'],
+  );
+
+  // String options the parser kept as a bare diverted flag (its value was a flag): the
+  // duplicate is dropped once the typed field re-emits it.
+  assert.deepEqual(
+    buildServerArgs(defaults({ logDirectory: '/logs', extraArgs: ['--logDirectory'] })),
+    ['--logDirectory', '/logs'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ shell: 'cmd', extraArgs: ['--shell'] })),
+    ['--shell', 'cmd'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ initialDir: '/start', extraArgs: ['--initial-dir'] })),
+    ['--initialDir', '/start'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ wslMountPoint: '/mnt/', extraArgs: ['--wslMountPoint'] })),
+    ['--wslMountPoint', '/mnt/'],
+  );
+
+  // The strip stops at the flag: an unrelated following extraArg flag is NOT swallowed.
+  assert.deepEqual(
+    buildServerArgs(defaults({ commandTimeout: 30, extraArgs: ['--commandTimeout', '--keepme'] })),
+    ['--commandTimeout', '30', '--keepme'],
+  );
+
+  // A transport scalar (http/sse port) diverted as a bad number is dropped when the form
+  // supplies a valid one.
+  assert.deepEqual(
+    buildServerArgs(
+      defaults({
+        transportMode: 'http',
+        transportHost: '',
+        transportPort: 8080,
+        extraArgs: ['--http-port', 'abc'],
+      }),
+    ),
+    ['--transport', 'http', '--http-port', '8080'],
+  );
+
+  // An UNSET field still round-trips its preserved malformed value verbatim (no over-strip).
+  assert.deepEqual(
+    buildServerArgs(defaults({ extraArgs: ['--commandTimeout', 'bad'] })),
+    ['--commandTimeout', 'bad'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ extraArgs: ['--logDirectory'] })),
+    ['--logDirectory'],
+  );
+
+  // Array options are exempt: the server merges repeats, so a preserved --allowedDir is kept
+  // even when the form adds its own (no array-coercion hazard).
+  assert.deepEqual(
+    buildServerArgs(
+      defaults({ allowedDirectories: ['/a'], extraArgs: ['--allowedDir', '/b'] }),
+    ),
+    ['--allowedDir', '/a', '--allowedDir', '/b'],
+  );
+});
+
+test('an emitted scalar flag strips a preserved yargs negation of the same option (P65)', () => {
+  // A loaded file may carry a scalar negation (`--no-shell`, `--no-logDirectory`,
+  // `--no-commandTimeout`) in extraArgs; the parser does not model these. Once the form supplies
+  // a typed value the builder must drop the negation, or yargs parses the option as an array
+  // (`shell: ['cmd', false]`) the server's scalar applyCli* helpers apply none of — ignoring the
+  // edit or crashing the server. The negation carries no value, so only the token is dropped.
+  assert.deepEqual(
+    buildServerArgs(defaults({ shell: 'cmd', extraArgs: ['--no-shell'] })),
+    ['--shell', 'cmd'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ logDirectory: '/logs', extraArgs: ['--no-logDirectory'] })),
+    ['--logDirectory', '/logs'],
+  );
+  assert.deepEqual(
+    buildServerArgs(defaults({ commandTimeout: 30, extraArgs: ['--no-commandTimeout'] })),
+    ['--commandTimeout', '30'],
+  );
+  // The kebab-case negation the parser may have kept is stripped too.
+  assert.deepEqual(
+    buildServerArgs(defaults({ initialDir: '/start', extraArgs: ['--no-initial-dir'] })),
+    ['--initialDir', '/start'],
+  );
+  // A transport scalar negation is dropped once the form emits the positive flag.
+  assert.deepEqual(
+    buildServerArgs(
+      defaults({
+        transportMode: 'http',
+        transportHost: '',
+        transportPort: 8080,
+        extraArgs: ['--no-http-port'],
+      }),
+    ),
+    ['--transport', 'http', '--http-port', '8080'],
+  );
+  // The strip does not swallow a following unrelated extraArg.
+  assert.deepEqual(
+    buildServerArgs(defaults({ shell: 'cmd', extraArgs: ['--no-shell', '--keepme'] })),
+    ['--shell', 'cmd', '--keepme'],
+  );
+  // An UNSET field still round-trips its preserved negation verbatim (no over-strip).
+  assert.deepEqual(
+    buildServerArgs(defaults({ extraArgs: ['--no-shell'] })),
+    ['--no-shell'],
+  );
+});
+
 test('an unresolved config file path is blocking', () => {
   vscodeStub.workspace.workspaceFolders = undefined;
   const s = defaults({ configFile: '${workspaceFolder}/c.json' });
@@ -419,6 +618,37 @@ test('P1: resolvePaths:false normalizes backslash relative paths to forward-slas
     resolvePaths: false,
   });
   assert.ok(args.includes('${workspaceFolder}/src/nested'));
+});
+
+test('P27: preserveRelativePaths keeps relative path args verbatim for a file source', () => {
+  vscodeStub.workspace.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];
+  const s = defaults({
+    allowedDirectories: ['src', '${workspaceFolder}/lib', '/abs/dir'],
+    configFile: 'config.json',
+    initialDir: 'work',
+    cwd: 'server',
+  });
+  const args = buildServerArgs(s, { resolvePaths: false, preserveRelativePaths: true });
+  // A loaded entry's relative args were authored relative to its own cwd, so they
+  // round-trip verbatim rather than being anchored to ${workspaceFolder} (which would
+  // resolve config.json under the workspace root instead of <cwd>/config.json).
+  assert.ok(args.includes('config.json'), 'relative --config kept verbatim');
+  assert.ok(args.includes('src'), 'relative --allowedDir kept verbatim');
+  assert.ok(args.includes('work'), 'relative --initialDir kept verbatim');
+  assert.ok(args.includes('${workspaceFolder}/lib'), 'tokenized path still verbatim');
+  assert.ok(args.includes('/abs/dir'), 'absolute path still verbatim');
+  assert.equal(args.includes('${workspaceFolder}/config.json'), false, 'not re-anchored');
+  // The relative cwd is likewise preserved (VS Code resolves it against the workspace).
+  const spec = buildLaunchSpec(s, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(spec.cwd, 'server');
+});
+
+test('P27: without preserveRelativePaths a settings export still anchors to ${workspaceFolder}', () => {
+  vscodeStub.workspace.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];
+  const s = defaults({ configFile: 'config.json', cwd: 'server' });
+  const args = buildServerArgs(s, { resolvePaths: false });
+  assert.ok(args.includes('${workspaceFolder}/config.json'), 'relative config anchored for export');
+  assert.equal(args.includes('config.json'), false, 'not kept bare for a settings export');
 });
 
 test('P2: a fractional maxOutputLines is accepted (server only range-checks it)', () => {
@@ -1125,4 +1355,19 @@ test('P102: custom args keep --config/--transport as an escape hatch on a plain 
     validateLaunchSpec(s, false).filter((p) => /customArgs.*--(config|transport)/.test(p.message)).length,
     0,
   );
+});
+
+test('P84: a dash-prefixed shell value is emitted attached', () => {
+  // yargs reads `--shell=--unsafe` as the shell name "--unsafe", but the two-token
+  // `--shell --unsafe` as an empty shell PLUS the active unsafe boolean -- so re-emitting a
+  // hand-authored dash-prefixed value unattached would disable every safety restriction.
+  const s = defaults({ shell: '--unsafe' });
+  const args = buildLaunchSpec(s, { resolvePaths: false }).args;
+  assert.ok(args.includes('--shell=--unsafe'), 'attached form keeps it a shell value');
+  assert.equal(args.includes('--unsafe'), false, 'no bare safety flag is introduced');
+});
+
+test('P84: an ordinary shell value is still emitted as two tokens', () => {
+  const args = buildLaunchSpec(defaults({ shell: 'cmd' }), { resolvePaths: false }).args;
+  assert.equal(args[args.indexOf('--shell') + 1], 'cmd');
 });

--- a/vscode-extension/test/unit/commands.test.cjs
+++ b/vscode-extension/test/unit/commands.test.cjs
@@ -862,6 +862,59 @@ test('P88: editing host/port still writes a url for an entry that had none', asy
   assert.equal(wcli0Entry().url, 'http://10.0.0.5:9444/mcp');
 });
 
+test('P107: a transport host carrying a delimiter is refused', async () => {
+  // `gateway.example/api` would be pasted between http:// and :9444, producing
+  // http://gateway.example/api:9444/mcp -- which reparses as host gateway.example with no explicit
+  // port, so the accepted edit is lost and the path is malformed.
+  for (const host of ['gateway.example/api', 'user@gateway.example', 'gateway.example:8080', 'a b']) {
+    vscode.__reset();
+    vscode.__state.workspaceFolders = WS;
+    const base = { type: 'http', url: 'http://127.0.0.1:9444/mcp' };
+    const s = defaultSettings();
+    s.transportMode = 'http';
+    s.transportHost = host;
+    s.transportPort = 9444;
+    const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+    assert.equal(ok, false, `${host} is refused`);
+    assert.ok(
+      vscode.__state.calls.error.some((m) => /cannot be used as the host/.test(m)),
+      `${host} refusal explains why`,
+    );
+    assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
+  }
+});
+
+test('P107: ordinary hosts and IPv6 literals still save', async () => {
+  for (const [host, expected] of [
+    ['gateway.example', 'http://gateway.example:9444/mcp'],
+    ['10.0.0.5', 'http://10.0.0.5:9444/mcp'],
+    ['::1', 'http://[::1]:9444/mcp'],
+    ['[::1]', 'http://[::1]:9444/mcp'],
+  ]) {
+    vscode.__reset();
+    vscode.__state.workspaceFolders = WS;
+    const base = { type: 'http', url: 'http://127.0.0.1:9444/mcp' };
+    const s = defaultSettings();
+    s.transportMode = 'http';
+    s.transportHost = host;
+    s.transportPort = 9444;
+    const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+    assert.equal(ok, true, `${host} saves`);
+    assert.equal(wcli0Entry().url, expected);
+  }
+});
+
+test('P107: a preserved verbatim url is not blocked by the host check', async () => {
+  // The host field is inert for a URL that round-trips verbatim, so it must not gate the save.
+  const base = { type: 'http', url: 'https://gateway.example/custom/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'gateway.example'; // as parseMcpEntry sets for a default-port URL
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'https://gateway.example/custom/mcp');
+});
+
 test('P81: a file save refuses a host/port edit for a url it cannot decompose', async () => {
   // parseMcpEntry models neither host nor port for a socket/named-pipe URL and leaves both at
   // the form defaults, and the save preserves the URL verbatim. The controls stay editable, so

--- a/vscode-extension/test/unit/commands.test.cjs
+++ b/vscode-extension/test/unit/commands.test.cjs
@@ -5,10 +5,13 @@ const vscode = require('../stubs/vscode.cjs');
 const {
   generateConfigFile,
   writeWorkspaceMcpJson,
+  writeMcpJsonFromSettings,
   showLaunchCommand,
   refreshServerDefinition,
   parseJsonc,
 } = require('../../dist/commands.js');
+const { defaultSettings } = require('../../dist/settings.js');
+const { parseMcpEntry } = require('../../dist/configSource.js');
 
 const WS = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];
 
@@ -673,4 +676,1009 @@ test('P58: a workspace child whose name starts with ".." keeps a portable config
     vscode.workspace.getConfiguration('wcli0').get('configFile', ''),
     '${workspaceFolder}/..generated/wcli0.config.json',
   );
+});
+
+// ---- writeMcpJsonFromSettings (file-source "Save to file") ----
+
+test('writeMcpJsonFromSettings writes the entry from explicit settings and returns true', async () => {
+  const s = defaultSettings();
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0]);
+  assert.equal(ok, true);
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.type, 'stdio');
+  assert.ok(parsed.servers.wcli0.args.includes('--shell'));
+  // It writes the file only — no wcli0.* setting is persisted.
+  assert.equal(vscode.__state.configWorkspace.has('wcli0.shell'), false);
+});
+
+test('writeMcpJsonFromSettings preserves other servers in the file', async () => {
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { other: { type: 'stdio' } } })),
+  );
+  const ok = await writeMcpJsonFromSettings(defaultSettings(), WS[0]);
+  assert.equal(ok, true);
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.ok(parsed.servers.other, 'existing server preserved');
+  assert.ok(parsed.servers.wcli0, 'wcli0 server written');
+});
+
+test('P5: writeMcpJsonFromSettings preserves a loaded http url verbatim when host/port are unchanged', async () => {
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'gateway.example';
+  s.transportPort = 0; // default port — only valid because the URL is preserved
+  s.transportUrl = 'https://gateway.example/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0]);
+  assert.equal(ok, true);
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.url, 'https://gateway.example/custom/mcp');
+});
+
+test('P5: writeMcpJsonFromSettings rebuilds the url when the host/port were edited', async () => {
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 8123; // edited away from the preserved URL's host/port
+  s.transportUrl = 'https://gateway.example/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0]);
+  assert.equal(ok, true);
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.url, 'http://127.0.0.1:8123/mcp');
+});
+
+test('writeMcpJsonFromSettings returns false and does not write a malformed file', async () => {
+  vscode.__state.files.set('/ws/.vscode/mcp.json', Buffer.from('not json'));
+  const before = vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8');
+  const ok = await writeMcpJsonFromSettings(defaultSettings(), WS[0]);
+  assert.equal(ok, false);
+  assert.equal(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'), before);
+  assert.ok(vscode.__state.calls.error.length >= 1);
+});
+
+// ---- writeMcpJsonFromSettings file-source merge (baseEntry) ----
+
+const wcli0Entry = () =>
+  JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8')).servers.wcli0;
+
+test('P7: a file save merges onto the loaded http entry, preserving headers/oauth', async () => {
+  const base = {
+    type: 'http',
+    url: 'http://127.0.0.1:9444/mcp',
+    headers: { Authorization: 'Bearer x' },
+    oauth: { clientId: 'abc' },
+  };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 9444;
+  s.transportUrl = 'http://127.0.0.1:9444/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.deepEqual(e.headers, { Authorization: 'Bearer x' }, 'headers preserved');
+  assert.deepEqual(e.oauth, { clientId: 'abc' }, 'oauth preserved');
+  assert.equal(e.url, 'http://127.0.0.1:9444/mcp');
+});
+
+test('P12: a file save preserves unmodeled stdio fields (envFile, dev, sandboxEnabled)', async () => {
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    envFile: '.env',
+    dev: { watch: true },
+    sandboxEnabled: false,
+  };
+  const s = defaultSettings();
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.equal(e.envFile, '.env', 'envFile preserved');
+  assert.deepEqual(e.dev, { watch: true }, 'dev preserved');
+  assert.equal(e.sandboxEnabled, false, 'sandboxEnabled preserved');
+  assert.ok(e.args.includes('--shell'), 'the edited flag is still written');
+});
+
+test('P9: a file save round-trips non-string env values', async () => {
+  vscode.__state.calls.warnReturn = 'Include environment';
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    env: { PORT: 3000, FLAG: null, NAME: 'x' },
+  };
+  const ok = await writeMcpJsonFromSettings(defaultSettings(), WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.deepEqual(wcli0Entry().env, { PORT: 3000, FLAG: null, NAME: 'x' });
+});
+
+test('P9/P4: omitting env on a file save drops it even when the baseline had non-string values', async () => {
+  vscode.__state.calls.warnReturn = 'Omit environment';
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    env: { PORT: 3000 },
+  };
+  const ok = await writeMcpJsonFromSettings(defaultSettings(), WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().env, undefined, 'env omitted from the written entry');
+});
+
+test('P10: a file save preserves a socket url it cannot decompose', async () => {
+  const base = { type: 'http', url: 'unix:///tmp/server.sock#/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportUrl = 'unix:///tmp/server.sock#/mcp';
+  // host/port stay at their defaults, as parseMcpEntry leaves them for a socket URL.
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'unix:///tmp/server.sock#/mcp');
+});
+
+test('P92: a file save keeps a url whose authority holds a VS Code variable', async () => {
+  const base = { type: 'http', url: 'http://${input:host}:8080/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://${input:host}:8080/mcp', 'the variable URL is intact');
+});
+
+test('P88: a file save does not manufacture a url for an entry that has none', async () => {
+  // {"type":"http"} has no url to preserve; the canonical fallback would write
+  // http://127.0.0.1:9444/mcp on a no-op save, turning an incomplete entry into a live endpoint.
+  const base = { type: 'http' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'the no-op save is not refused');
+  const e = wcli0Entry();
+  assert.equal(e.type, 'http');
+  assert.equal('url' in e, false, 'no url is invented');
+});
+
+test('P88: an empty url round-trips as an empty url', async () => {
+  const base = { type: 'sse', url: '' };
+  const s = defaultSettings();
+  s.transportMode = 'sse';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, '', 'the original invalid state is preserved');
+});
+
+test('P88: editing host/port still writes a url for an entry that had none', async () => {
+  // A real host/port edit is a deliberate "set the endpoint" and must take effect.
+  const base = { type: 'http' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '10.0.0.5';
+  s.transportPort = 9444;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://10.0.0.5:9444/mcp');
+});
+
+test('P81: a file save refuses a host/port edit for a url it cannot decompose', async () => {
+  // parseMcpEntry models neither host nor port for a socket/named-pipe URL and leaves both at
+  // the form defaults, and the save preserves the URL verbatim. The controls stay editable, so
+  // a host change was accepted, the original URL written back, and the edit silently dropped by
+  // the reparse behind a "Saved" -- refuse it instead.
+  const base = { type: 'http', url: 'unix:///tmp/server.sock#/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '10.0.0.5'; // edited away from the default the parser left
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'the unsavable host edit is refused');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /cannot be represented by the host and port/.test(m)),
+    'the refusal explains why',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing was written');
+});
+
+test('P81: a port edit for an opaque url is refused too', async () => {
+  const base = { type: 'sse', url: 'unix:///tmp/server.sock#/sse' };
+  const s = defaultSettings();
+  s.transportMode = 'sse';
+  s.transportPort = 9999;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false);
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false);
+});
+
+test('P81: switching the transport mode still rebuilds an opaque url from host/port', async () => {
+  // A mode switch is a deliberate rebuild, so the host/port fields DO reach the written URL
+  // and must not be refused.
+  const base = { type: 'http', url: 'unix:///tmp/server.sock#/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'sse';
+  s.transportHost = '10.0.0.5';
+  s.transportPort = 9444;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://10.0.0.5:9444/sse');
+});
+
+test('P8: a file save round-trips a default-port url without a port error', async () => {
+  const base = { type: 'http', url: 'https://gateway.example/custom/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'gateway.example'; // as parseMcpEntry sets for a default-port URL
+  s.transportUrl = 'https://gateway.example/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'the default port (9444) does not trip the port check');
+  assert.equal(wcli0Entry().url, 'https://gateway.example/custom/mcp');
+});
+
+test('P8: editing the host of a default-port url rebuilds the canonical url', async () => {
+  const base = { type: 'http', url: 'https://gateway.example/custom/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'other.example'; // host edited away from the loaded URL's host
+  s.transportPort = 9444;
+  s.transportUrl = 'https://gateway.example/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://other.example:9444/mcp');
+});
+
+test('P67: a port-only edit of a default-port url rebuilds the canonical url', async () => {
+  // A default-port URL loads with the host modeled and the port left at the form default (9444).
+  // A port-only edit must rebuild the canonical http://host:port form rather than preserve the
+  // URL verbatim and silently drop the edit (the next reparse would lose it).
+  const base = { type: 'http', url: 'https://gateway.example/custom/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'gateway.example'; // host unchanged
+  s.transportPort = 8080; // port edited away from the default-port form value (9444)
+  s.transportUrl = 'https://gateway.example/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://gateway.example:8080/mcp');
+});
+
+test('P101: an edit landing during a modal is not overwritten', async () => {
+  // The snapshot is taken before the env prompt; a concurrent write while it is open must be
+  // reported, not silently replaced by the pre-modal snapshot -- including another server's edit.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    env: { SECRET: 'x' },
+  };
+  const seed = (servers) =>
+    vscode.__state.files.set('/ws/.vscode/mcp.json', Buffer.from(JSON.stringify({ servers })));
+  seed({ wcli0: loaded, other: { type: 'http', url: 'http://elsewhere/mcp' } });
+  Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+    configurable: true,
+    get() {
+      seed({ wcli0: loaded, other: { type: 'http', url: 'http://moved/mcp' } });
+      return 'Include environment';
+    },
+  });
+  try {
+    const s = defaultSettings();
+    s.shell = 'cmd';
+    vscode.__state.calls.error.length = 0;
+    const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+    assert.equal(ok, false, 'the stale write is refused');
+    assert.ok(vscode.__state.calls.error.some((m) => /changed while saving/.test(m)));
+    const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+    assert.equal(parsed.servers.other.url, 'http://moved/mcp', "the other server's edit survives");
+    assert.equal(parsed.servers.wcli0.args.includes('--shell'), false, 'nothing was written');
+  } finally {
+    Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+  }
+});
+
+test('P101: an untouched file still saves normally', async () => {
+  vscode.__state.calls.warnReturn = 'Include environment';
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: base } })),
+  );
+  const s = defaultSettings();
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'no false refusal when nothing changed');
+  assert.ok(wcli0Entry().args.includes('--shell'));
+});
+
+test('P69/P101: a file deleted during a modal is not rewritten from the stale snapshot', async () => {
+  // The up-front snapshot captures the whole file (wcli0 + other), but it is taken BEFORE the env
+  // modal. A concurrent delete while that modal is open makes the snapshot stale, so the save must
+  // refuse rather than resurrect the file from it (P101). P69's guarantee still holds -- the other
+  // server is never dropped -- because nothing is written at all.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    env: { SECRET: 'x' },
+  };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: { wcli0: loaded, other: { type: 'http', url: 'http://elsewhere/mcp' } },
+      }),
+    ),
+  );
+  // Delete the file at the moment the env modal is shown (warnReturn is read then).
+  Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+    configurable: true,
+    get() {
+      vscode.__state.files.delete('/ws/.vscode/mcp.json');
+      return 'Include environment';
+    },
+  });
+  try {
+    const s = defaultSettings();
+    s.shell = 'cmd';
+    vscode.__state.calls.error.length = 0;
+    const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+    assert.equal(ok, false, 'the stale write is refused');
+    assert.ok(
+      vscode.__state.calls.error.some((m) => /changed while saving/.test(m)),
+      'the concurrent delete is reported',
+    );
+    assert.equal(
+      vscode.__state.files.has('/ws/.vscode/mcp.json'),
+      false,
+      'the deleted file is not resurrected, and no server is written from the stale snapshot',
+    );
+  } finally {
+    Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+  }
+});
+
+test('P13: a file save allows a VS Code variable --config path that cannot be read locally', async () => {
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--config', '${input:cfg}'] };
+  const s = defaultSettings();
+  s.configFile = '${input:cfg}';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'the unresolved ${input:...} path is not treated as blocking');
+  const e = wcli0Entry();
+  assert.ok(e.args.includes('--config'), 'the --config flag is kept');
+  assert.ok(e.args.includes('${input:cfg}'), 'the variable path is round-tripped verbatim');
+});
+
+test('P29: a file save refuses per-shell/profile edits that cannot be persisted to the file', async () => {
+  // A loaded file source referencing a config file. parseMcpEntry never loads
+  // shells/profiles back from that file, so any in the form are unsaved edits this save
+  // (which only writes the entry, not the referenced file) would silently drop on the
+  // post-write reparse — refuse instead of reporting a false success.
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', '${workspaceFolder}/wcli0.json'],
+  };
+  const s = defaultSettings();
+  s.configFile = '${workspaceFolder}/wcli0.json';
+  s.profiles = { ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } } };
+  const ok = await writeMcpJsonFromSettings(s, WS[0], {
+    baseEntry: base,
+    configFileLoadable: () => true,
+  });
+  assert.equal(ok, false, 'the save is refused');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /cannot be saved from this form/.test(m)),
+    'explains the edits cannot be saved from a file-source form',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
+});
+
+test('P29: a file save with no shell/profile edits is not blocked by the P29 refusal', async () => {
+  // The refusal must only fire on actual shells/profiles edits, not every file save.
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  const s = defaultSettings();
+  s.shell = 'cmd'; // a normal modeled edit, not per-shell config
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'an ordinary file save still succeeds');
+  assert.ok(wcli0Entry().args.includes('--shell'), 'the edit is written');
+});
+
+test('P27: a file save preserves a cwd-relative --config instead of re-anchoring it', async () => {
+  // A loaded entry whose server resolves config.json under a non-workspace cwd.
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', 'config.json'],
+    cwd: '${workspaceFolder}/server',
+  };
+  const s = defaultSettings();
+  s.configFile = 'config.json'; // as parseMcpEntry sets from the relative --config
+  s.cwd = '${workspaceFolder}/server';
+  // An unrelated edit triggers a regenerate; the relative --config must round-trip.
+  s.shell = 'cmd';
+  // The referenced config exists under the server's cwd at launch; inject loadability
+  // so the test isolates the written-entry behavior from the on-disk validation check.
+  const ok = await writeMcpJsonFromSettings(s, WS[0], {
+    baseEntry: base,
+    configFileLoadable: () => true,
+  });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.ok(e.args.includes('config.json'), 'relative --config kept verbatim');
+  assert.equal(
+    e.args.includes('${workspaceFolder}/config.json'),
+    false,
+    'not re-anchored to the workspace root (would load a different file)',
+  );
+  assert.equal(e.cwd, '${workspaceFolder}/server', 'cwd preserved');
+});
+
+test('P-cwdconfig: a file save checks --config loadability against the entry cwd', async () => {
+  // The server resolves a relative --config against the entry's cwd, not the workspace root.
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', 'config.json'],
+    cwd: '${workspaceFolder}/server',
+  };
+  const s = defaultSettings();
+  s.configFile = 'config.json';
+  s.cwd = '${workspaceFolder}/server';
+  let checkedPath;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], {
+    baseEntry: base,
+    configFileLoadable: (p) => {
+      checkedPath = p;
+      return true;
+    },
+  });
+  assert.equal(ok, true);
+  // Loadability was checked under the cwd (/ws/server), NOT the workspace root (/ws).
+  assert.equal(checkedPath, '/ws/server/config.json');
+});
+
+test('P-port0: a file save rebuilds an explicit :0 url from the port field', async () => {
+  const base = { type: 'http', url: 'http://host:0/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'host';
+  s.transportPort = 9444; // the form's default, since the :0 port cannot be held (min=1)
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  // The invalid :0 is NOT round-tripped verbatim; the canonical URL is rebuilt from the port.
+  assert.equal(wcli0Entry().url, 'http://host:9444/mcp');
+});
+
+test('P66: a file save rebuilds a malformed non-numeric url port from the port field', async () => {
+  // A URL with an explicit non-numeric port (`:abc`) must not be preserved verbatim as a
+  // default-port URL: editing the port field has to be able to fix it. The save rebuilds the
+  // canonical URL from the (edited) port instead of round-tripping the malformed host:abc URL.
+  const base = { type: 'http', url: 'http://host:abc/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = 'host';
+  s.transportPort = 8080; // the user fixes the port via the form field
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://host:8080/mcp');
+});
+
+test('P-varsyntax: a file save rejects a --config path with an unknown ${...} token', async () => {
+  // `${PATH}` is a bare shell variable VS Code does not substitute, so the value is a real
+  // (broken) local path and must face validation rather than be bypassed as a VS Code var.
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', '${PATH}/cfg.json'],
+  };
+  const s = defaultSettings();
+  s.configFile = '${PATH}/cfg.json';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'an unknown-variable config path is validated, not bypassed');
+});
+
+test('P-varsyntax: a file save still allows a recognized VS Code variable config path', async () => {
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', '${input:cfg}'],
+  };
+  const s = defaultSettings();
+  s.configFile = '${input:cfg}'; // VS Code resolves this at launch
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'a known VS Code variable is bypassed and round-tripped');
+  assert.ok(wcli0Entry().args.includes('${input:cfg}'), 'the variable is written verbatim');
+});
+
+test('P-staleargs: a file save preserves an unmodeled flag added to args on disk after load', async () => {
+  // The panel loaded this stale snapshot...
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  // ...but another process then added an unmodeled escape-hatch flag to the on-disk entry.
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: {
+          wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--futureFlag', 'x'] },
+        },
+      }),
+    ),
+  );
+  const s = defaultSettings();
+  s.shell = 'cmd'; // an unrelated modeled edit triggers a regenerate
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.ok(
+    e.args.includes('--futureFlag') && e.args.includes('x'),
+    'the externally-added unmodeled flag survives the save',
+  );
+  assert.ok(e.args.includes('--shell'), 'the modeled edit is written too');
+});
+
+test('P-httpshells: a file save to an http source refuses unsavable per-shell/profile edits', async () => {
+  // The stdio branch already refused these (P29); the http/sse branch must too, instead of
+  // writing {type,url} and reporting a false "Saved" while the edits silently disappear.
+  const base = { type: 'http', url: 'http://127.0.0.1:9444/mcp' };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.profiles = { ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } } };
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'an http file source also refuses shells/profiles edits');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /cannot be saved from this form/.test(m)),
+    'explains the edits cannot be saved from a file-source form',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
+});
+
+test('P-maskedshells: a file save refuses profile edits even when ignoreInheritedProfiles is set', async () => {
+  // The mask is a settings-only opt-out; it must not let the guard pass while the raw profile
+  // edits (which the entry still cannot store) are silently dropped on the post-save reparse.
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  const s = defaultSettings();
+  s.ignoreInheritedProfiles = true; // masked helper would report no profiles
+  s.profiles = { ora19: { env: { ORACLE_HOME: 'C:/oracle/19' } } }; // raw edit the entry can't store
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'masked profile edits are still refused for a file source');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /cannot be saved from this form/.test(m)),
+    'explains the edits cannot be saved from a file-source form',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
+});
+
+test('P-varcwd: a file save skips --config loadability when the cwd is a VS Code variable', async () => {
+  // The server resolves config.json under a cwd VS Code expands at launch, so the config
+  // cannot (and must not) be located/validated against the workspace root.
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', 'config.json'],
+    cwd: '${input:cwd}',
+  };
+  const s = defaultSettings();
+  s.configFile = 'config.json';
+  s.cwd = '${input:cwd}';
+  let consulted = false;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], {
+    baseEntry: base,
+    configFileLoadable: () => {
+      consulted = true;
+      return false; // would block the save if the check ran
+    },
+  });
+  assert.equal(ok, true, 'a variable-cwd relative config is not blocked by a local check');
+  assert.equal(consulted, false, 'loadability was not consulted for the variable-cwd config');
+  assert.ok(wcli0Entry().args.includes('config.json'), 'the relative --config round-trips');
+});
+
+test('a file save switching http->stdio drops the stale url field', async () => {
+  const base = { type: 'http', url: 'http://127.0.0.1:9444/mcp', headers: { A: '1' } };
+  const s = defaultSettings(); // stdio (npx)
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.equal(e.type, 'stdio');
+  assert.equal(e.url, undefined, 'the http url is removed on a mode switch');
+  assert.equal(e.command, 'npx');
+});
+
+test('P19: switching http->stdio drops the other transport unmodeled fields (headers/oauth)', async () => {
+  const base = {
+    type: 'http',
+    url: 'http://127.0.0.1:9444/mcp',
+    headers: { A: '1' },
+    oauth: { id: 'x' },
+  };
+  const s = defaultSettings(); // stdio (npx)
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.equal(e.type, 'stdio');
+  assert.equal(e.headers, undefined, 'http headers removed on switch to stdio');
+  assert.equal(e.oauth, undefined, 'http oauth removed on switch to stdio');
+});
+
+test('P19: switching stdio->http drops the other transport unmodeled fields (envFile/dev)', async () => {
+  const base = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    envFile: '.env',
+    dev: { watch: true },
+  };
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 9444;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true);
+  const e = wcli0Entry();
+  assert.equal(e.type, 'http');
+  assert.equal(e.envFile, undefined, 'stdio envFile removed on switch to http');
+  assert.equal(e.dev, undefined, 'stdio dev removed on switch to http');
+  assert.ok(e.url, 'an http url is written');
+});
+
+test('P18: a file save allows a VS Code variable in cwd', async () => {
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'], cwd: '${env:PROJECT}' };
+  const s = defaultSettings();
+  s.cwd = '${env:PROJECT}';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'a variable cwd does not block the save');
+  assert.equal(wcli0Entry().cwd, '${env:PROJECT}', 'the variable cwd round-trips verbatim');
+});
+
+test('P18: a file save allows a VS Code variable node script path', async () => {
+  const base = { type: 'stdio', command: 'node', args: ['${input:script}', '--shell', 'cmd'] };
+  const s = defaultSettings();
+  s.launchMethod = 'node';
+  s.nodeScriptPath = '${input:script}';
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, true, 'a variable node script does not block the save');
+  assert.ok(wcli0Entry().args.includes('${input:script}'), 'the variable script round-trips');
+});
+
+test('P20: a file save merges onto the CURRENT on-disk entry, preserving external additions', async () => {
+  // The panel loaded a snapshot with no headers...
+  const loaded = { type: 'http', url: 'http://127.0.0.1:9444/mcp' };
+  // ...but the file was edited externally afterwards to add headers to the same entry.
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: {
+          wcli0: { type: 'http', url: 'http://127.0.0.1:9444/mcp', headers: { A: '1' } },
+          other: { type: 'stdio' },
+        },
+      }),
+    ),
+  );
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 9444;
+  s.transportUrl = 'http://127.0.0.1:9444/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.deepEqual(
+    parsed.servers.wcli0.headers,
+    { A: '1' },
+    'externally added headers preserved via the on-disk merge',
+  );
+  assert.ok(parsed.servers.other, 'other server preserved');
+});
+
+test('P40: a file save carries forward an on-disk argv addition (e.g. --blockedCommand)', async () => {
+  // The panel loaded a snapshot with no blocked command...
+  const loaded = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  // ...but the file on disk now has --blockedCommand rm (added externally after load).
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--blockedCommand', 'rm'] } },
+      }),
+    ),
+  );
+  // The form only edits the shell; the uneditable blockedCommand must survive from disk.
+  const s = defaultSettings();
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  const args = wcli0Entry().args;
+  assert.ok(args.includes('--shell'), 'the edited shell flag is written');
+  assert.ok(args.includes('rm'), 'the externally added --blockedCommand rm is carried forward');
+});
+
+test('P41: a file save preserves the CURRENT on-disk url when host/port match', async () => {
+  // The panel loaded a canonical URL...
+  const loaded = { type: 'http', url: 'http://127.0.0.1:9444/mcp' };
+  // ...but the file on disk now uses a custom scheme/path with the SAME host/port.
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: { wcli0: { type: 'http', url: 'https://127.0.0.1:9444/custom/mcp' } },
+      }),
+    ),
+  );
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 9444;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  // The current on-disk URL (custom scheme/path) is preserved, not the stale canonical one.
+  assert.equal(wcli0Entry().url, 'https://127.0.0.1:9444/custom/mcp');
+});
+
+test('P46: the merge base and preservation data come from one on-disk snapshot', async () => {
+  // The panel snapshot and the single up-front on-disk read both see env {A} plus an unmodeled
+  // envFile. An external edit then lands DURING the env modal (adding a var, dropping envFile,
+  // adding an unmodeled `dev`). Writing the up-front snapshot would be internally coherent but
+  // would silently discard that edit, so the save refuses instead (P101). P46's guarantee still
+  // holds: the write never mixes a stale generated env with a freshly re-read base, because there
+  // is no write.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest'],
+    env: { A: '1' },
+    envFile: '.env',
+  };
+  const seed = (entry) =>
+    vscode.__state.files.set(
+      '/ws/.vscode/mcp.json',
+      Buffer.from(JSON.stringify({ servers: { wcli0: entry } })),
+    );
+  seed(loaded);
+  // Mutate the on-disk file at the moment the env modal is shown (warnReturn is read then).
+  Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+    configurable: true,
+    get() {
+      seed({
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', 'wcli0@latest'],
+        env: { A: '1', B: '2' },
+        dev: { watch: true },
+      });
+      return 'Include environment';
+    },
+  });
+  try {
+    const s = defaultSettings();
+    s.shell = 'cmd';
+    vscode.__state.calls.error.length = 0;
+    const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+    assert.equal(ok, false, 'the stale write is refused');
+    assert.ok(vscode.__state.calls.error.some((m) => /changed while saving/.test(m)));
+    // The concurrent edit is intact: nothing was overwritten, and no incoherent mix was written.
+    const e = wcli0Entry();
+    assert.deepEqual(e.env, { A: '1', B: '2' }, 'the external edit survives');
+    assert.deepEqual(e.dev, { watch: true });
+    assert.equal(e.envFile, undefined);
+    assert.equal(e.args.includes('--shell'), false, 'the form edit was not written');
+  } finally {
+    Object.defineProperty(vscode.__state.calls, 'warnReturn', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+  }
+});
+
+test('P48: a no-op save of an uppercase HTTP entry preserves the custom url', async () => {
+  // The entry's type is written uppercase (HTTP) with a custom scheme/path; parseMcpEntry
+  // models it as http, so a no-op save must preserve the URL rather than read the case
+  // difference as a mode switch and rebuild the canonical http://host:port/mcp form.
+  const loaded = { type: 'HTTP', url: 'https://127.0.0.1:9444/custom/mcp' };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: { wcli0: { type: 'HTTP', url: 'https://127.0.0.1:9444/custom/mcp' } },
+      }),
+    ),
+  );
+  const s = defaultSettings();
+  s.transportMode = 'http';
+  s.transportHost = '127.0.0.1';
+  s.transportPort = 9444;
+  s.transportUrl = 'https://127.0.0.1:9444/custom/mcp';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'https://127.0.0.1:9444/custom/mcp');
+});
+
+test('P59: a file save round-trips a loaded out-of-range --maxReturnLines without refusing', async () => {
+  // A hand-authored stdio entry carries a server-valid-but-typed-field-invalid --maxReturnLines
+  // (the server applies any CLI value > 0; 50000 is outside the config-file 1..10000 bound the
+  // typed field enforces). Loading it through parseMcpEntry diverts it to extraArgs (it has no
+  // form control), so validateLaunchSpec no longer refuses, and an unrelated edit round-trips
+  // the value verbatim with no duplicate.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--maxReturnLines', '50000'],
+  };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: loaded } })),
+  );
+  const s = parseMcpEntry(loaded).settings;
+  s.shell = 'cmd'; // edit an unrelated field
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  const args = wcli0Entry().args;
+  assert.ok(args.includes('--shell'), 'the edited flag is written');
+  assert.equal(
+    args.filter((a) => a === '--maxReturnLines').length,
+    1,
+    'the out-of-range log limit is not duplicated',
+  );
+  assert.equal(args[args.indexOf('--maxReturnLines') + 1], '50000', 'value preserved verbatim');
+});
+
+test('P60: a port-only edit of a wildcard http url keeps the untouched IPv4 host', async () => {
+  // The host came from a user-authored CONNECT url, so a port-only edit must not apply the
+  // bind->connect mapping (0.0.0.0 -> 127.0.0.1) that the settings export uses.
+  const loaded = { type: 'http', url: 'http://0.0.0.0:9444/mcp' };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: loaded } })),
+  );
+  const s = parseMcpEntry(loaded).settings;
+  s.transportPort = 8080; // edit ONLY the port
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://0.0.0.0:8080/mcp');
+});
+
+test('P60: a port-only edit of an IPv6 wildcard http url keeps the untouched host', async () => {
+  const loaded = { type: 'http', url: 'http://[::]:9444/mcp' };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: loaded } })),
+  );
+  const s = parseMcpEntry(loaded).settings;
+  s.transportPort = 8080;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  assert.equal(wcli0Entry().url, 'http://[::]:8080/mcp');
+});
+
+test('P-fileextratransport: a stdio file save preserves a hand-authored --transport flag', async () => {
+  // The panel loaded a stdio entry whose args carry a hand-written `--transport http` and a
+  // companion `--http-port` (parseMcpEntry keeps both in extraArgs without flipping the mode,
+  // P30). An unrelated edit must round-trip those verbatim, not strip --transport and orphan
+  // the --http-port.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--transport', 'http', '--http-port', '9000'],
+  };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: loaded } })),
+  );
+  const s = defaultSettings();
+  s.shell = 'cmd'; // an unrelated modeled edit triggers a regenerate
+  s.extraArgs = ['--transport', 'http', '--http-port', '9000']; // as parseMcpEntry models it
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  const args = wcli0Entry().args;
+  assert.ok(args.includes('--shell'), 'the modeled edit is written');
+  const ti = args.indexOf('--transport');
+  assert.ok(ti !== -1 && args[ti + 1] === 'http', 'the authored --transport http is preserved');
+  const pi = args.indexOf('--http-port');
+  assert.ok(pi !== -1 && args[pi + 1] === '9000', 'the companion --http-port is not orphaned');
+});
+
+test('P-fileextratransport: the settings export still strips a stray --transport from a stdio entry', async () => {
+  // The safety strip must remain for the settings-driven export (no baseEntry): a stray
+  // extraArgs --transport must never turn a stdio registration into a network listener.
+  const s = defaultSettings();
+  s.extraArgs = ['--transport', 'http'];
+  const ok = await writeMcpJsonFromSettings(s, WS[0]);
+  assert.equal(ok, true);
+  const args = wcli0Entry().args;
+  assert.equal(args.includes('--transport'), false, 'the stray --transport is stripped on export');
+});
+
+test('P-wslmount: a stdio file save carries forward an on-disk --wslMountPoint change', async () => {
+  // --wslMountPoint round-trips but has no form control, so it must be re-derived from the
+  // CURRENT on-disk entry — an unrelated save must not rebuild args from the stale loaded value
+  // and drop a --wslMountPoint another process changed after the panel loaded.
+  const loaded = {
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--wslMountPoint', '/mnt'],
+  };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(
+      JSON.stringify({
+        servers: {
+          wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--wslMountPoint', '/wsl'] },
+        },
+      }),
+    ),
+  );
+  const s = defaultSettings();
+  s.shell = 'cmd'; // an unrelated modeled edit triggers a regenerate
+  s.wslMountPoint = '/mnt'; // the stale loaded value the form holds
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: loaded });
+  assert.equal(ok, true);
+  const args = wcli0Entry().args;
+  const i = args.indexOf('--wslMountPoint');
+  assert.ok(i !== -1 && args[i + 1] === '/wsl', 'the current on-disk /wsl value is carried forward');
+  assert.equal(args.includes('/mnt'), false, 'the stale loaded /mnt value is not re-emitted');
+});
+
+test('P-unknowntype: a file save refuses an unknown transport type instead of normalizing it to stdio', async () => {
+  // A future/custom transport such as "websocket" is parsed as stdio for its editable fields,
+  // but saving would overwrite the original type with stdio. Refuse rather than silently
+  // normalize after an unrelated edit.
+  const base = { type: 'websocket', command: 'npx', args: ['-y', 'wcli0@latest'], url: 'ws://x' };
+  vscode.__state.files.set(
+    '/ws/.vscode/mcp.json',
+    Buffer.from(JSON.stringify({ servers: { wcli0: base } })),
+  );
+  const before = vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8');
+  const s = defaultSettings();
+  s.shell = 'cmd';
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'the unknown-type save is refused');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /not stdio\/http\/sse/.test(m)),
+    'explains the type cannot be saved from the form',
+  );
+  assert.equal(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+    before,
+    'the file is left untouched',
+  );
+});
+
+test('P-emptyprofile: a file save refuses a non-empty but non-emittable profile', async () => {
+  // The Profiles editor accepts any JSON object, so a profile with no emittable env
+  // (`{"p":{"description":"x","env":{}}}`) is not launch-meaningful yet is still an unsaved
+  // edit the entry cannot store; the reparse would drop it while reporting Saved. Refuse it.
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  const s = defaultSettings();
+  s.profiles = { p: { description: 'x', env: {} } };
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'the non-emittable profile edit is refused');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /cannot be saved from this form/.test(m)),
+    'explains the edit cannot be saved from a file-source form',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
+});
+
+test('P-maskfile: a file save refuses a non-default ignoreInheritedShells mask', async () => {
+  // The masks are settings-only opt-outs no entry can store; a non-default value reaching the
+  // save is an unsaved edit the reparse would drop while reporting Saved. Refuse it.
+  const base = { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] };
+  const s = defaultSettings();
+  s.ignoreInheritedShells = true;
+  const ok = await writeMcpJsonFromSettings(s, WS[0], { baseEntry: base });
+  assert.equal(ok, false, 'the masked-edit save is refused');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /ignore inherited/i.test(m)),
+    'explains the mask is a settings-only option',
+  );
+  assert.equal(vscode.__state.files.has('/ws/.vscode/mcp.json'), false, 'nothing written');
 });

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1,0 +1,1675 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const vscode = require('../stubs/vscode.cjs');
+const {
+  detectWorkspaceMcpJson,
+  readWcli0Entry,
+  parseServerArgs,
+  parseMcpEntry,
+  parseHttpUrl,
+  mcpJsonUri,
+} = require('../../dist/configSource.js');
+const { buildLaunchSpec } = require('../../dist/argsBuilder.js');
+
+const FOLDER = { uri: vscode.Uri.file('/ws'), name: 'ws', index: 0 };
+const MCP_PATH = '/ws/.vscode/mcp.json';
+
+function seedMcpJson(obj) {
+  vscode.__state.files.set(MCP_PATH, Buffer.from(JSON.stringify(obj)));
+}
+
+function defaults(overrides = {}) {
+  return {
+    launchMethod: 'npx',
+    packageSpec: 'wcli0@latest',
+    nodeScriptPath: '',
+    customCommand: '',
+    customArgs: [],
+    cwd: '',
+    env: {},
+    configFile: '',
+    shell: 'all',
+    shells: {},
+    profiles: {},
+    ignoreInheritedShells: false,
+    ignoreInheritedProfiles: false,
+    allowedDirectories: [],
+    initialDir: '',
+    commandTimeout: null,
+    maxCommandLength: null,
+    wslMountPoint: '',
+    blockedCommands: [],
+    blockedArguments: [],
+    blockedOperators: [],
+    maxOutputLines: null,
+    enableTruncation: 'default',
+    enableLogResources: 'default',
+    maxReturnLines: null,
+    logDirectory: '',
+    allowAllDirs: false,
+    safetyMode: 'safe',
+    debug: false,
+    transportMode: 'stdio',
+    transportHost: '127.0.0.1',
+    transportPort: 9444,
+    transportAllowedOrigins: [],
+    extraArgs: [],
+    ...overrides,
+  };
+}
+
+test.beforeEach(() => {
+  vscode.__reset();
+  vscode.__state.workspaceFolders = [FOLDER];
+});
+
+// ---- detection -----------------------------------------------------------
+
+test('detectWorkspaceMcpJson finds a wcli0 server entry', async () => {
+  seedMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx' }, other: {} } });
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, true);
+  assert.equal(d.hasWcli0, true);
+  assert.equal(d.fsPath, MCP_PATH);
+});
+
+test('detectWorkspaceMcpJson reports no entry when wcli0 absent', async () => {
+  seedMcpJson({ servers: { other: { type: 'stdio' } } });
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, true);
+  assert.equal(d.hasWcli0, false);
+});
+
+test('detectWorkspaceMcpJson reports absent when the file is missing', async () => {
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, false);
+  assert.equal(d.hasWcli0, false);
+});
+
+test('detectWorkspaceMcpJson tolerates JSONC comments', async () => {
+  vscode.__state.files.set(
+    MCP_PATH,
+    Buffer.from('{\n  // wcli0 entry\n  "servers": { "wcli0": { "type": "stdio" } },\n}'),
+  );
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.hasWcli0, true);
+});
+
+test('detectWorkspaceMcpJson reports existing-but-no-entry on malformed JSON', async () => {
+  vscode.__state.files.set(MCP_PATH, Buffer.from('{ not valid'));
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, true);
+  assert.equal(d.hasWcli0, false);
+});
+
+test('detectWorkspaceMcpJson does not throw on a non-not-found read error', async () => {
+  const err = new Error('permission denied');
+  err.code = 'NoPermissions';
+  vscode.__state.readError = err;
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, false);
+});
+
+test('readWcli0Entry returns the entry object or undefined', async () => {
+  seedMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  const entry = await readWcli0Entry(FOLDER);
+  assert.equal(entry.command, 'npx');
+  vscode.__reset();
+  vscode.__state.workspaceFolders = [FOLDER];
+  assert.equal(await readWcli0Entry(FOLDER), undefined);
+});
+
+test('mcpJsonUri points at .vscode/mcp.json', () => {
+  assert.equal(mcpJsonUri(FOLDER).fsPath, MCP_PATH);
+});
+
+// ---- parseServerArgs -----------------------------------------------------
+
+test('parseServerArgs maps recognized value flags', () => {
+  const { settings } = parseServerArgs([
+    '--shell', 'powershell',
+    '--commandTimeout', '30',
+    '--maxCommandLength', '8000',
+    '--initialDir', '/work',
+    '--logDirectory', '/logs',
+  ]);
+  assert.equal(settings.shell, 'powershell');
+  assert.equal(settings.commandTimeout, 30);
+  assert.equal(settings.maxCommandLength, 8000);
+  assert.equal(settings.initialDir, '/work');
+  assert.equal(settings.logDirectory, '/logs');
+});
+
+test('parseServerArgs collects repeated flags into arrays', () => {
+  const { settings } = parseServerArgs([
+    '--allowedDir', '/a',
+    '--allowedDir', '/b',
+    '--blockedCommand', 'rm',
+    '--blockedCommand', 'del',
+  ]);
+  assert.deepEqual(settings.allowedDirectories, ['/a', '/b']);
+  assert.deepEqual(settings.blockedCommands, ['rm', 'del']);
+});
+
+test('parseServerArgs accepts the --opt=value form', () => {
+  const { settings } = parseServerArgs(['--blockedArgument=-rf', '--shell=cmd']);
+  assert.deepEqual(settings.blockedArguments, ['-rf']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('parseServerArgs handles boolean, safety and tri-state flags', () => {
+  const a = parseServerArgs(['--allowAllDirs', '--debug', '--unsafe', '--no-enableTruncation']);
+  assert.equal(a.settings.allowAllDirs, true);
+  assert.equal(a.settings.debug, true);
+  assert.equal(a.settings.safetyMode, 'unsafe');
+  assert.equal(a.settings.enableTruncation, 'disabled');
+  const b = parseServerArgs(['--yolo', '--enableLogResources']);
+  assert.equal(b.settings.safetyMode, 'yolo');
+  assert.equal(b.settings.enableLogResources, 'enabled');
+});
+
+test('P63: parseServerArgs consumes negated boolean flags instead of preserving them in extraArgs', () => {
+  // A loaded entry may carry yargs negations for the server's boolean options. They must be
+  // modeled (and removed from extraArgs), or a preserved `--no-debug` survives a save and
+  // yargs parses `--debug --no-debug` as debug=false, silently dropping the user's form edit.
+  const a = parseServerArgs([
+    '--no-allowAllDirs',
+    '--no-debug',
+    '--no-yolo',
+    '--shell',
+    'cmd',
+  ]);
+  assert.equal(a.settings.allowAllDirs, false);
+  assert.equal(a.settings.debug, false);
+  // parseServerArgs returns a partial: with no positive safety flag it leaves safetyMode unset,
+  // so parseMcpEntry overlays the default 'safe'. A single-family negation must not leak into
+  // extraArgs. (A negation from BOTH families together defines both keys and conflicts — the
+  // server rejects it and it round-trips verbatim instead; see the P71 test.)
+  assert.equal(a.settings.safetyMode, undefined);
+  assert.equal(a.settings.shell, 'cmd');
+  assert.deepEqual(a.extraArgs, [], 'no negated boolean leaks into extraArgs');
+
+  // The kebab-case alias of the multi-word boolean is recognized too.
+  const b = parseServerArgs(['--no-allow-all-dirs']);
+  assert.equal(b.settings.allowAllDirs, false);
+  assert.deepEqual(b.extraArgs, []);
+
+  // `--unsafe --no-yolo` DEFINES both safety keys (yargs sets yolo=false for --no-yolo), so the
+  // server's .conflicts check rejects it. It is treated as a conflict and round-trips verbatim
+  // rather than collapsing to a valid `--unsafe` launch — see the dedicated P71 test. (P63 still
+  // consumes single-family negations, as the cases above and below show.)
+  const c = parseServerArgs(['--unsafe', '--no-yolo']);
+  assert.equal(c.settings.safetyMode, undefined);
+  assert.deepEqual(c.extraArgs, ['--unsafe', '--no-yolo']);
+
+  // Mirrors yargs last-wins for a contradictory SAME-family pair (not a conflict): `--yolo
+  // --no-yolo` resolves to safe and is consumed.
+  const d = parseServerArgs(['--yolo', '--no-yolo']);
+  assert.equal(d.settings.safetyMode, 'safe');
+  assert.deepEqual(d.extraArgs, []);
+});
+
+test('P68: parseServerArgs honors explicit true/false values for boolean flags', () => {
+  // yargs declares these options type:'boolean' and consumes a following bare true/false as the
+  // value (e.g. `--debug false` => debug=false). The parser must model that explicit value
+  // instead of recording the flag as true and stranding `false` in extraArgs, which would show
+  // the opposite of what the server runs.
+  const a = parseServerArgs(['--debug', 'false', '--allowAllDirs', 'true', '--shell', 'bash']);
+  assert.equal(a.settings.debug, false);
+  assert.equal(a.settings.allowAllDirs, true);
+  assert.equal(a.settings.shell, 'bash');
+  assert.deepEqual(a.extraArgs, [], 'the consumed true/false do not leak into extraArgs');
+
+  // The kebab-case and tri-state spellings honor explicit values too.
+  const b = parseServerArgs(['--enable-truncation', 'false', '--enableLogResources', 'true']);
+  assert.equal(b.settings.enableTruncation, 'disabled');
+  assert.equal(b.settings.enableLogResources, 'enabled');
+  assert.deepEqual(b.extraArgs, []);
+
+  // `--yolo false` is not a positive: it leaves the default safety mode and consumes its value.
+  const c = parseServerArgs(['--yolo', 'false']);
+  assert.equal(c.settings.safetyMode, undefined);
+  assert.deepEqual(c.extraArgs, []);
+
+  // Only an exact true/false is consumed; any other following token stays a positional and the
+  // flag reads true, matching yargs (`--debug notabool` => debug=true, 'notabool' preserved).
+  const d = parseServerArgs(['--debug', 'notabool']);
+  assert.equal(d.settings.debug, true);
+  assert.deepEqual(d.extraArgs, ['notabool']);
+});
+
+test('P70: parseServerArgs preserves a conflicting --yolo/--unsafe pair verbatim', () => {
+  // The server declares yolo/unsafe mutually exclusive (.conflicts), so an entry with both is
+  // rejected. Collapsing the pair to one would let a no-op save turn that rejected entry into a
+  // valid launch, so both are preserved verbatim in extraArgs and safetyMode is left at default.
+  const a = parseServerArgs(['--shell', 'cmd', '--yolo', '--unsafe']);
+  assert.equal(a.settings.safetyMode, undefined, 'neither flag is modeled into safetyMode');
+  assert.equal(a.settings.shell, 'cmd');
+  assert.deepEqual(a.extraArgs, ['--yolo', '--unsafe'], 'both flags round-trip verbatim');
+
+  // Explicit-true positives also conflict; the true values round-trip alongside their flags.
+  const b = parseServerArgs(['--yolo', 'true', '--unsafe', 'true']);
+  assert.equal(b.settings.safetyMode, undefined);
+  assert.deepEqual(b.extraArgs, ['--yolo', 'true', '--unsafe', 'true']);
+
+  // A trailing negation does NOT remove the conflict: yargs still defines both keys (yolo=false
+  // via --no-yolo, unsafe=true), so .conflicts rejects it. All three tokens round-trip verbatim
+  // rather than collapsing to a valid `--unsafe` launch (P71).
+  const c = parseServerArgs(['--yolo', '--unsafe', '--no-yolo']);
+  assert.equal(c.settings.safetyMode, undefined);
+  assert.deepEqual(c.extraArgs, ['--yolo', '--unsafe', '--no-yolo']);
+});
+
+test('P71: parseServerArgs preserves false/negated safety flags that still conflict', () => {
+  // yargs' .conflicts('unsafe','yolo') fails whenever BOTH keys are DEFINED, and yargs-parser
+  // defines the key for `--yolo false`, `--no-yolo`, and `--yolo=false` just as for `--yolo`.
+  // So pairing --unsafe with any of these is server-rejected; the parser must round-trip every
+  // safety token verbatim rather than model the entry as a valid single-mode launch.
+
+  // Explicit `--yolo false` alongside --unsafe: both keys defined => conflict.
+  const a = parseServerArgs(['--yolo', 'false', '--unsafe']);
+  assert.equal(a.settings.safetyMode, undefined, 'neither flag is modeled into safetyMode');
+  assert.deepEqual(a.extraArgs, ['--yolo', 'false', '--unsafe']);
+
+  // Negated `--no-yolo` alongside --unsafe: yolo=false is still defined => conflict.
+  const b = parseServerArgs(['--no-yolo', '--unsafe']);
+  assert.equal(b.settings.safetyMode, undefined);
+  assert.deepEqual(b.extraArgs, ['--no-yolo', '--unsafe']);
+
+  // Attached `--unsafe=false` alongside --yolo: both keys defined => conflict.
+  const c = parseServerArgs(['--unsafe=false', '--yolo']);
+  assert.equal(c.settings.safetyMode, undefined);
+  assert.deepEqual(c.extraArgs, ['--unsafe=false', '--yolo']);
+
+  // Without the other family it is NOT a conflict: `--no-yolo` alone is consumed (resolves to
+  // safe), not preserved — only the cross-family combination round-trips verbatim.
+  const d = parseServerArgs(['--no-yolo', '--shell', 'cmd']);
+  assert.equal(d.settings.safetyMode, undefined);
+  assert.equal(d.settings.shell, 'cmd');
+  assert.deepEqual(d.extraArgs, []);
+
+  // Even two negations conflict: `--no-yolo --no-unsafe` defines both keys (both false), which
+  // .conflicts still rejects (verified against yargs), so both round-trip verbatim.
+  const e = parseServerArgs(['--no-yolo', '--no-unsafe']);
+  assert.equal(e.settings.safetyMode, undefined);
+  assert.deepEqual(e.extraArgs, ['--no-yolo', '--no-unsafe']);
+});
+
+test('P72: parseServerArgs models attached boolean assignments', () => {
+  // yargs declares these type:'boolean', so `--debug=true` / `--enableTruncation=false` set the
+  // option value. The parser must model them (not dump to extraArgs), or the form shows the
+  // default and a later edit is defeated by the stale attached value surviving in argv.
+  const a = parseServerArgs([
+    '--debug=true',
+    '--enableTruncation=false',
+    '--enableLogResources=true',
+    '--allowAllDirs=false',
+  ]);
+  assert.equal(a.settings.debug, true);
+  assert.equal(a.settings.enableTruncation, 'disabled');
+  assert.equal(a.settings.enableLogResources, 'enabled');
+  assert.equal(a.settings.allowAllDirs, false);
+  assert.deepEqual(a.extraArgs, [], 'no attached boolean leaks into extraArgs');
+
+  // Kebab-case aliases are modeled identically.
+  const b = parseServerArgs(['--enable-truncation=true', '--allow-all-dirs=true']);
+  assert.equal(b.settings.enableTruncation, 'enabled');
+  assert.equal(b.settings.allowAllDirs, true);
+  assert.deepEqual(b.extraArgs, []);
+
+  // Attached safety positives are modeled when there is no conflict; `--yolo=false` leaves the
+  // default safe mode and is consumed.
+  const c = parseServerArgs(['--unsafe=true']);
+  assert.equal(c.settings.safetyMode, 'unsafe');
+  assert.deepEqual(c.extraArgs, []);
+  const d = parseServerArgs(['--yolo=false']);
+  assert.equal(d.settings.safetyMode, undefined);
+  assert.deepEqual(d.extraArgs, []);
+
+  // P87: any attached value other than the literal `true` is FALSE to yargs (processValue
+  // coerces a declared boolean with `val === 'true'`), so it is modeled as false rather than
+  // preserved.
+  const e = parseServerArgs(['--debug=verbose']);
+  assert.equal(e.settings.debug, false);
+  assert.deepEqual(e.extraArgs, []);
+});
+
+test('P87: every attached boolean value follows yargs coercion', () => {
+  // yargs-parser: `val === 'true'` -- so 0/1/yes/FALSE all mean false for a declared boolean.
+  for (const value of ['0', '1', 'yes', 'FALSE', '']) {
+    const { settings, extraArgs } = parseServerArgs([`--debug=${value}`]);
+    assert.equal(settings.debug, false, `--debug=${value} is false`);
+    assert.deepEqual(extraArgs, [], `--debug=${value} is modeled, not preserved`);
+  }
+  const truncation = parseServerArgs(['--enableTruncation=0', '--enableLogResources=0']);
+  assert.equal(truncation.settings.enableTruncation, 'disabled');
+  assert.equal(truncation.settings.enableLogResources, 'disabled');
+  assert.deepEqual(truncation.extraArgs, []);
+});
+
+test('P87: a preserved attached value can no longer defeat a later edit', () => {
+  // Before: `--debug=0` stayed in extraArgs, so enabling Debug emitted `--debug --debug=0`,
+  // which yargs resolves last-wins back to false -- the edit silently did nothing.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--debug=0'],
+  });
+  assert.equal(settings.debug, false, 'the loaded entry reads as Debug off');
+  const enabled = { ...settings, debug: true };
+  const args = buildLaunchSpec(enabled, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.ok(args.includes('--debug'), 'the edit is emitted');
+  assert.equal(
+    args.filter((a) => a.startsWith('--debug')).length,
+    1,
+    'no stale attached value survives to override it',
+  );
+});
+
+test('parseServerArgs parses transport flags', () => {
+  const { settings } = parseServerArgs([
+    '--transport', 'http',
+    '--http-host', '0.0.0.0',
+    '--http-port', '7000',
+    '--http-allowed-origins', 'https://a.test,https://b.test',
+  ]);
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, '0.0.0.0');
+  assert.equal(settings.transportPort, 7000);
+  assert.deepEqual(settings.transportAllowedOrigins, ['https://a.test', 'https://b.test']);
+});
+
+test('parseServerArgs preserves unrecognized flags in extraArgs', () => {
+  const { settings, extraArgs } = parseServerArgs(['--shell', 'cmd', '--futureFlag', 'x', '--bare']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(extraArgs, ['--futureFlag', 'x', '--bare']);
+});
+
+// ---- parseMcpEntry -------------------------------------------------------
+
+test('parseMcpEntry parses an npx stdio entry', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@1.2.3', '--shell', 'cmd', '--allowedDir', '/ws'],
+    cwd: '/ws',
+    env: { FOO: 'bar' },
+  });
+  assert.equal(settings.launchMethod, 'npx');
+  assert.equal(settings.packageSpec, 'wcli0@1.2.3');
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.allowedDirectories, ['/ws']);
+  assert.equal(settings.cwd, '/ws');
+  assert.deepEqual(settings.env, { FOO: 'bar' });
+});
+
+test('parseMcpEntry parses a node stdio entry', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['/srv/dist/index.js', '--debug'],
+  });
+  assert.equal(settings.launchMethod, 'node');
+  assert.equal(settings.nodeScriptPath, '/srv/dist/index.js');
+  assert.equal(settings.debug, true);
+});
+
+test('parseMcpEntry splits custom command args from server flags', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'my-wrapper',
+    args: ['run', 'wcli0', '--shell', 'gitbash'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'my-wrapper');
+  assert.deepEqual(settings.customArgs, ['run', 'wcli0']);
+  assert.equal(settings.shell, 'gitbash');
+});
+
+test('P3: parseMcpEntry keeps dash-prefixed custom launcher args before wcli0 flags', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'stdio',
+    command: 'uvx',
+    args: ['--from', 'git+https://example/repo', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'uvx');
+  // The launcher's own --from option stays in customArgs; only the recognized wcli0
+  // flag (--shell) starts the server flags. Nothing leaks into extraArgs.
+  assert.deepEqual(settings.customArgs, ['--from', 'git+https://example/repo', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, []);
+  assert.equal(notes.length, 0);
+});
+
+test('P3: buildLaunchSpec -> parseMcpEntry round-trips custom launcher args in order', () => {
+  const s = defaults({
+    launchMethod: 'custom',
+    customCommand: 'uvx',
+    customArgs: ['--from', 'repo', 'wcli0'],
+    shell: 'cmd',
+  });
+  const spec = buildLaunchSpec(s, { resolvePaths: false });
+  const { settings } = parseMcpEntry({ type: 'stdio', command: spec.command, args: spec.args });
+  assert.equal(settings.customCommand, 'uvx');
+  assert.deepEqual(settings.customArgs, ['--from', 'repo', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P14: parseMcpEntry treats node launcher options as custom args, not a script', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['--inspect', 'dist/index.js', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'node');
+  assert.deepEqual(settings.customArgs, ['--inspect', 'dist/index.js']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P14: a plain node entry is still parsed as node', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'node');
+  assert.equal(settings.nodeScriptPath, 'dist/index.js');
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P17: parseMcpEntry treats npx launcher options as custom, preserving them', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--package=wcli0', '--', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'npx');
+  assert.deepEqual(settings.customArgs, ['--package=wcli0', '--', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P17: a plain `npx -y <pkg>` entry is parsed as the npx launch method', () => {
+  const withY = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@9.9.9', '--shell', 'cmd'],
+  }).settings;
+  assert.equal(withY.launchMethod, 'npx');
+  assert.equal(withY.packageSpec, 'wcli0@9.9.9');
+  assert.equal(withY.shell, 'cmd');
+});
+
+test('P82: `npx <pkg>` without -y is custom, so a save does not add -y', () => {
+  // npx prompts before installing a missing package; -y accepts it automatically. The npx
+  // launch method always emits -y, so an entry that deliberately omitted it must not be
+  // modeled as npx -- an unrelated save would silently suppress the confirmation.
+  const { settings, notes } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['wcli0@1.2.3', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'npx');
+  assert.deepEqual(settings.customArgs, ['wcli0@1.2.3']);
+  assert.equal(settings.shell, 'cmd', 'the server flags after it are still modeled');
+  assert.ok(
+    notes.some((n) => /WITHOUT -y/i.test(n)),
+    'the note explains why it is shown as a custom command',
+  );
+  // A no-op save round-trips the launcher verbatim: still no -y.
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(spec.command, 'npx');
+  assert.deepEqual(spec.args, ['wcli0@1.2.3', '--shell', 'cmd']);
+});
+
+test('P82: an npx entry with no args at all is preserved as a custom command', () => {
+  const { settings } = parseMcpEntry({ type: 'stdio', command: 'npx' });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'npx');
+  assert.deepEqual(settings.customArgs, []);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(spec.command, 'npx');
+  assert.deepEqual(spec.args, [], 'no package spec is invented for it');
+});
+
+test('P83: a generic custom launch does not scan past its `--` separator', () => {
+  // `node --inspect dist/index.js -- --debug` hands `--` and `--debug` to the script, where
+  // yargs leaves them positional. Modeling --debug as an active flag misreported the launch and
+  // appended newly saved flags behind the separator, where the server never reads them.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['--inspect', 'dist/index.js', '--', '--debug'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.debug, false, 'the positional --debug is not modeled as enabled');
+  assert.deepEqual(settings.customArgs, ['--inspect', 'dist/index.js', '--', '--debug']);
+  assert.deepEqual(settings.extraArgs, []);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--inspect', 'dist/index.js', '--', '--debug'], 'round-trips');
+});
+
+test('P83: a wrapper `--` followed by the wcli0 binary is still a pass-through', () => {
+  // The one separator shape that PROVES a pass-through: the wrapped binary is wcli0 itself, so
+  // the flags after it really are server flags and stay editable (P17).
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--package=wcli0', '--', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['--package=wcli0', '--', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test("P83: the wrapped wcli0 binary's OWN `--` stops the scan again", () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--package=wcli0', '--', 'wcli0', '--', '--debug'],
+  });
+  assert.equal(settings.debug, false, 'a positional after the binary is not modeled');
+  assert.deepEqual(settings.customArgs, ['--package=wcli0', '--', 'wcli0', '--', '--debug']);
+});
+
+test('P85: an npx entry with no package token is a custom launch', () => {
+  // buildLaunchSpec substitutes an empty packageSpec with wcli0@latest, so modeling `npx -y`
+  // would turn an incomplete invocation into an automatic install-and-run on an unrelated save.
+  for (const args of [['-y'], ['-y', '']]) {
+    const { settings } = parseMcpEntry({ type: 'stdio', command: 'npx', args });
+    assert.equal(settings.launchMethod, 'custom', `npx ${JSON.stringify(args)} is custom`);
+    assert.equal(settings.customCommand, 'npx');
+    assert.deepEqual(settings.customArgs, args);
+    const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+    assert.equal(spec.command, 'npx');
+    assert.deepEqual(spec.args, args, 'no package spec is invented');
+  }
+});
+
+test('P86: a UTF-8 BOM does not hide the wcli0 entry', async () => {
+  // VS Code can save .vscode/mcp.json as "UTF-8 with BOM"; JSON.parse throws on the leading
+  // U+FEFF, which made detection and loading report the file as absent/malformed.
+  const json = JSON.stringify({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  vscode.__state.files.set(MCP_PATH, Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(json)]));
+  const d = await detectWorkspaceMcpJson(FOLDER);
+  assert.equal(d.exists, true);
+  assert.equal(d.hasWcli0, true, 'the entry is detected through the BOM');
+  const entry = await readWcli0Entry(FOLDER);
+  assert.equal(entry.command, 'npx', 'the entry loads through the BOM');
+});
+
+test('P103: an empty allowed-directory entry survives a file save', () => {
+  // yargs supplies allowedDir as [''], and the server turns restrictWorkingDirectory ON with that
+  // empty allowlist -- the entry denies every directory. Dropping the flag on save restored the
+  // config/default allowed paths, widening what the entry permitted.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--allowedDir', ''],
+  });
+  assert.deepEqual(settings.allowedDirectories, ['']);
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(args, ['-y', 'wcli0@latest', '--allowedDir', ''], 'round-trips verbatim');
+});
+
+test('P103: the settings export still drops a blank allowed-directory line', () => {
+  // Without preserveRelativePaths (the settings/provider paths) an empty entry is editor noise,
+  // not an authored deny-all, so it must not start restricting every directory.
+  const s = defaults({ allowedDirectories: ['', '/ws/a'] });
+  const args = buildLaunchSpec(s, { resolvePaths: false }).args;
+  assert.equal(args.filter((a) => a === '--allowedDir').length, 1, 'only the real entry is emitted');
+  assert.ok(args.includes('/ws/a'));
+});
+
+test('P100: a shell name the select cannot hold is preserved verbatim', () => {
+  // Assigning `fish` to the fixed <select> leaves it on the empty/Inherit value, the form counts
+  // as changed, and a save drops --shell -- turning an entry the server matched to NO shell into
+  // one running every default shell.
+  for (const args of [
+    ['-y', 'wcli0@latest', '--shell', 'fish'],
+    ['-y', 'wcli0@latest', '--shell=zsh'],
+    ['-y', 'wcli0@latest', '--shell', 'ALL'],
+  ]) {
+    const { settings } = parseMcpEntry({ type: 'stdio', command: 'npx', args });
+    assert.equal(settings.shell, defaults().shell, `${args[2]} is not modeled into the field`);
+    const emitted = buildLaunchSpec(settings, {
+      resolvePaths: false,
+      preserveRelativePaths: true,
+    }).args;
+    assert.deepEqual(emitted, args, 'the entry round-trips verbatim');
+  }
+});
+
+test('P100: the five real shell names are still modeled', () => {
+  for (const name of ['powershell', 'cmd', 'gitbash', 'wsl', 'bash']) {
+    const { settings } = parseServerArgs(['--shell', name]);
+    assert.equal(settings.shell, name, `${name} stays editable`);
+  }
+});
+
+test('P102: only the negative forms yargs consumes count as values', () => {
+  // Verified against yargs-parser: `--shell -1e2` => shell '' plus short options 1 and e, and
+  // `-1.` behaves the same, while -1 / -1.5 / -.5 / -0 / -01 ARE consumed as values.
+  for (const value of ['-1', '-1.5', '-.5', '-0', '-01']) {
+    const { settings } = parseServerArgs(['--shell', value]);
+    assert.equal(settings.shell, undefined, `${value} is diverted (not a shell the form holds)`);
+    const { extraArgs } = parseServerArgs(['--shell', value]);
+    assert.deepEqual(extraArgs, ['--shell', value], `${value} round-trips as this option's value`);
+  }
+  for (const value of ['-1e2', '-1.', '-1e-2']) {
+    const { extraArgs } = parseServerArgs(['--shell', value]);
+    assert.deepEqual(extraArgs, ['--shell', value], `${value} round-trips as a separate token`);
+  }
+  // The difference shows up in duplicate detection: a scientific-notation token is NOT this
+  // option's value, so the second --commandTimeout is the only occurrence and is modeled.
+  const sci = parseServerArgs(['--commandTimeout', '-1e2', '--commandTimeout', '5']);
+  assert.equal(sci.settings.commandTimeout, 5, 'yargs sees only one commandTimeout value');
+  const dec = parseServerArgs(['--commandTimeout', '-1', '--commandTimeout', '5']);
+  assert.equal(dec.settings.commandTimeout, undefined, 'a real negative value makes it a duplicate');
+});
+
+test('P99: an array option consumes every following value', () => {
+  // yargs' greedy-arrays (default true) makes `--blockedCommand rm del --debug` => ['rm','del'].
+  // Modeling only `rm` left `del` in extraArgs, and re-emitting it after the modeled pair made it
+  // a positional the server never blocks -- a no-op save silently shrank the blocklist.
+  const { settings, extraArgs } = parseServerArgs(['--blockedCommand', 'rm', 'del', '--debug']);
+  assert.deepEqual(settings.blockedCommands, ['rm', 'del'], 'both values are modeled');
+  assert.equal(settings.debug, true);
+  assert.deepEqual(extraArgs, [], 'no value is stranded');
+});
+
+test('P99: the attached array form is greedy too', () => {
+  const { settings, extraArgs } = parseServerArgs(['--blockedCommand=rm', 'del']);
+  assert.deepEqual(settings.blockedCommands, ['rm', 'del']);
+  assert.deepEqual(extraArgs, []);
+});
+
+test('P99: every array option keeps its full list across a save', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: [
+      '-y', 'wcli0@latest',
+      '--allowedDir', '/a', '/b',
+      '--blockedArgument=-rf',
+      '--blockedOperator', '&&', '||',
+    ],
+  });
+  assert.deepEqual(settings.allowedDirectories, ['/a', '/b']);
+  // Only the ATTACHED form carries a dash-prefixed value: verified against yargs, a bare
+  // `--blockedArgument -rf` leaves the array empty and parses `-rf` as short flags.
+  assert.deepEqual(settings.blockedArguments, ['-rf']);
+  assert.deepEqual(settings.blockedOperators, ['&&', '||']);
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  for (const value of ['/a', '/b', '&&', '||']) {
+    assert.ok(args.includes(value), `${value} kept`);
+  }
+  assert.ok(args.includes('--blockedArgument=-rf'), 'the dash value stays attached (P73)');
+});
+
+test('P99: a dash-prefixed token is not swallowed as an array value', () => {
+  // Verified against yargs: `--blockedArgument -rf` gives blockedArgument: [] and parses `-rf`
+  // as short flags, so the whole run must round-trip verbatim rather than be modeled.
+  const { settings, extraArgs } = parseServerArgs(['--blockedArgument', '-rf', '--force']);
+  assert.deepEqual(settings.blockedArguments, undefined);
+  assert.deepEqual(extraArgs, ['--blockedArgument', '-rf', '--force']);
+});
+
+test('P99: a greedy run stops at the next option and at the separator', () => {
+  const { settings, extraArgs } = parseServerArgs([
+    '--blockedCommand', 'rm', 'del', '--shell', 'cmd', '--', 'tail',
+  ]);
+  assert.deepEqual(settings.blockedCommands, ['rm', 'del']);
+  assert.equal(settings.shell, 'cmd', 'the next option is not swallowed');
+  assert.deepEqual(extraArgs, ['--', 'tail'], 'the positional region is untouched');
+});
+
+test('P99: a wrapper suffix with a multi-value array option is still detected', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--blockedCommand', 'rm', 'del'],
+  });
+  assert.deepEqual(settings.customArgs, ['target'], 'the extra values are not orphans');
+  assert.deepEqual(settings.blockedCommands, ['rm', 'del']);
+});
+
+test('P98: a valueless scalar flag counts as a duplicate occurrence', () => {
+  // Verified against yargs-parser: `--shell --debug --shell bash` => shell: ['', 'bash'], which is
+  // not a usable shell name, so the entry enables NO shell. Modeling only `bash` let the builder
+  // strip the preserved valueless copy and a no-op save enabled command execution through Bash.
+  const { settings, extraArgs } = parseServerArgs(['--shell', '--debug', '--shell', 'bash']);
+  assert.equal(settings.shell, undefined, 'neither occurrence is modeled');
+  assert.equal(settings.debug, true, 'the flag between them is still modeled, as yargs does');
+  assert.deepEqual(extraArgs, ['--shell', '--shell', 'bash']);
+});
+
+test('P98: the valueless duplicate survives a no-op save', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--shell', '--debug', '--shell', 'bash'],
+  });
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(
+    args.filter((a) => a === '--shell' || a === 'bash'),
+    ['--shell', '--shell', 'bash'],
+    'both occurrences round-trip, so the entry still enables no shell',
+  );
+});
+
+test('P98: a valueless --config bundle counts too', () => {
+  const { settings, extraArgs } = parseServerArgs(['-c', '--debug', '--config', '/x.json']);
+  assert.equal(settings.configFile, undefined, 'the repeated config is not modeled');
+  assert.deepEqual(extraArgs, ['-c', '--config', '/x.json']);
+});
+
+test('P98: a single valueless scalar flag is unchanged', () => {
+  const { settings, extraArgs } = parseServerArgs(['--shell', '--debug']);
+  assert.equal(settings.shell, undefined);
+  assert.equal(settings.debug, true);
+  assert.deepEqual(extraArgs, ['--shell'], 'still preserved verbatim, as before (P44)');
+});
+
+test('P93: a negative numeric value counts as a scalar occurrence', () => {
+  // Verified against yargs-parser: `--commandTimeout -1 --commandTimeout 5` => [-1, 5], which the
+  // server ignores (not a number). Reading `-1` as a flag hid the repeat, so the pair was modeled
+  // as a plain `--commandTimeout 5` and the save changed the launch.
+  const { settings, extraArgs } = parseServerArgs([
+    '--commandTimeout', '-1', '--commandTimeout', '5',
+  ]);
+  assert.equal(settings.commandTimeout, undefined, 'neither value is modeled');
+  assert.deepEqual(extraArgs, ['--commandTimeout', '-1', '--commandTimeout', '5']);
+});
+
+test('P93: a single negative numeric value is consumed as the value, not a flag', () => {
+  // A non-positive timeout is diverted (the server ignores it, P64), so both tokens round-trip.
+  const { settings, extraArgs } = parseServerArgs(['--commandTimeout', '-1']);
+  assert.equal(settings.commandTimeout, undefined);
+  assert.deepEqual(extraArgs, ['--commandTimeout', '-1']);
+  // A dash token that is NOT a number is still a separate flag, as yargs treats it.
+  const other = parseServerArgs(['--shell', '-x']);
+  assert.equal(other.settings.shell, undefined);
+  assert.deepEqual(other.extraArgs, ['--shell', '-x']);
+});
+
+test('P93: a stripped option takes its negative value with it', () => {
+  const spec = buildLaunchSpec(
+    { ...defaults(), commandTimeout: 30, extraArgs: ['--commandTimeout', '-1'] },
+    { resolvePaths: false },
+  );
+  assert.equal(spec.args.includes('-1'), false, 'no orphan value is left behind');
+  assert.equal(spec.args[spec.args.indexOf('--commandTimeout') + 1], '30');
+});
+
+test('P94: a wrapper suffix is detected by any attached boolean value', () => {
+  // yargs coerces every attached value other than `true` to false, so `--enableTruncation=0`
+  // really disables truncation; the suffix detector must see it as a modeled wcli0 flag or the
+  // form shows the server default while the entry says otherwise.
+  for (const token of ['--enableTruncation=0', '--enableTruncation=yes', '--debug=0']) {
+    const { settings } = parseMcpEntry({
+      type: 'stdio',
+      command: 'wrapper',
+      args: ['target', token],
+    });
+    assert.deepEqual(settings.customArgs, ['target'], `${token} is a server-flag suffix`);
+    assert.deepEqual(settings.extraArgs, [], `${token} is modeled, not preserved`);
+  }
+  const truncation = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--enableTruncation=0'],
+  }).settings;
+  assert.equal(truncation.enableTruncation, 'disabled', 'the real setting is shown');
+});
+
+test('P96: an explicit --shell all is preserved, not read as the omit sentinel', () => {
+  // The form's `all` means "emit no --shell" (so the server loads its default shells), but the
+  // server's `--shell all` loads only a shell module named "all", which does not exist -- the
+  // entry has NO usable shells. Modeling it as the sentinel let a no-op save enable them all.
+  for (const args of [
+    ['-y', 'wcli0@latest', '--shell', 'all'],
+    ['-y', 'wcli0@latest', '--shell=all'],
+  ]) {
+    const { settings } = parseMcpEntry({ type: 'stdio', command: 'npx', args });
+    const emitted = buildLaunchSpec(settings, {
+      resolvePaths: false,
+      preserveRelativePaths: true,
+    }).args;
+    assert.deepEqual(
+      emitted.filter((a) => a.startsWith('--shell') || a === 'all'),
+      args.slice(2),
+      'the explicit value round-trips verbatim',
+    );
+  }
+});
+
+test('P96: choosing a real shell replaces the preserved --shell all', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--shell', 'all'],
+  });
+  const edited = { ...settings, shell: 'cmd' };
+  const args = buildLaunchSpec(edited, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.equal(args[args.indexOf('--shell') + 1], 'cmd');
+  assert.equal(args.filter((a) => a === '--shell').length, 1, 'the preserved copy is stripped');
+  assert.equal(args.includes('all'), false);
+});
+
+test('P97: a stripper never touches tokens after the `--` separator', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--shell', 'cmd', '--', '--shell', 'bash'],
+  });
+  assert.equal(settings.shell, 'cmd', 'the option before the separator is modeled');
+  assert.deepEqual(settings.extraArgs, ['--', '--shell', 'bash']);
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(
+    args.slice(args.indexOf('--')),
+    ['--', '--shell', 'bash'],
+    'the positional region survives the emitted --shell',
+  );
+});
+
+test('P97: the config and transport strippers also stop at the separator', () => {
+  const s = {
+    ...defaults(),
+    configFile: '/ws/cfg.json',
+    transportMode: 'http',
+    transportHost: '127.0.0.1',
+    transportPort: 9444,
+    extraArgs: ['--', '--config', '/other.json', '--transport', 'stdio'],
+  };
+  const args = buildLaunchSpec(s, { resolvePaths: false }).args;
+  assert.deepEqual(
+    args.slice(args.indexOf('--')),
+    ['--', '--config', '/other.json', '--transport', 'stdio'],
+    'positionals are copied verbatim by both strippers',
+  );
+});
+
+test('P89: a later false value clears a safety mode an earlier flag set', () => {
+  // Verified against the installed yargs-parser: repeated booleans are last-wins, so
+  // `--unsafe --unsafe=false` and `--unsafe --unsafe false` both mean unsafe:false. Modeling
+  // them as the positive mode let a no-op save drop the false and disable every protection.
+  for (const args of [
+    ['--unsafe', '--unsafe=false'],
+    ['--unsafe', '--unsafe', 'false'],
+    ['--yolo', '--yolo=false'],
+  ]) {
+    const { settings } = parseServerArgs(args);
+    assert.equal(settings.safetyMode, 'safe', `${args.join(' ')} is safe`);
+  }
+  // The reverse order is still the positive mode (last-wins the other way).
+  assert.equal(parseServerArgs(['--unsafe=false', '--unsafe']).settings.safetyMode, 'unsafe');
+});
+
+test('P89: a re-emitted safety mode matches what the entry really did', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--unsafe', '--unsafe=false'],
+  });
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.equal(args.includes('--unsafe'), false, 'a no-op save does not enable unsafe mode');
+  assert.equal(args.includes('--yolo'), false);
+});
+
+test('P90: a diverted numeric occurrence still counts as a duplicate', () => {
+  // yargs makes `--commandTimeout bad --commandTimeout 5` the array ['bad', 5], which the
+  // server ignores (not a number). Counting only the representable occurrence modeled it as a
+  // plain `--commandTimeout 5`, and the builder then stripped the preserved malformed copy --
+  // changing a launch that ran on the default timeout into one that applies 5.
+  const { settings, extraArgs } = parseServerArgs(['--commandTimeout', 'bad', '--commandTimeout', '5']);
+  assert.equal(settings.commandTimeout, undefined, 'neither value is modeled');
+  assert.deepEqual(extraArgs, ['--commandTimeout', 'bad', '--commandTimeout', '5']);
+});
+
+test('P90: the duplicate pair survives a no-op save intact', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--commandTimeout', 'bad', '--commandTimeout', '5'],
+  });
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(
+    args.filter((a) => a === '--commandTimeout' || a === 'bad' || a === '5'),
+    ['--commandTimeout', 'bad', '--commandTimeout', '5'],
+    'both occurrences round-trip in order',
+  );
+});
+
+test('P90: a single diverted numeric value is still preserved, not flagged', () => {
+  const { settings, extraArgs } = parseServerArgs(['--commandTimeout', 'bad']);
+  assert.equal(settings.commandTimeout, undefined);
+  assert.deepEqual(extraArgs, ['--commandTimeout', 'bad'], 'unchanged single-occurrence behavior');
+});
+
+test('P91: a url with surrounding whitespace is decomposed like the save path does', () => {
+  const { settings } = parseMcpEntry({ type: 'http', url: '  http://gateway.example:8443/mcp ' });
+  assert.equal(settings.transportHost, 'gateway.example', 'the host is modeled, not the default');
+  assert.equal(settings.transportPort, 8443);
+  assert.equal(settings.transportUrl, 'http://gateway.example:8443/mcp', 'stored trimmed');
+});
+
+test('P92: a url with a VS Code variable in its authority is not decomposed', () => {
+  // The colon inside `${input:...}` is not the host/port delimiter, and the real values are
+  // unknown until launch. Splitting it produced host `${input` and let a save rewrite the URL
+  // as `http://${input:9444/mcp`, destroying both the variable and the endpoint.
+  for (const url of ['http://${input:host}:8080/mcp', 'http://host:${input:port}/mcp']) {
+    assert.equal(parseHttpUrl(url), undefined, `${url} is undecomposable`);
+    const { settings, notes } = parseMcpEntry({ type: 'http', url });
+    assert.equal(settings.transportUrl, url, 'the URL is retained verbatim');
+    assert.equal(settings.transportHost, defaults().transportHost, 'host stays at the default');
+    assert.ok(
+      notes.some((n) => /cannot be represented by the host and port fields/.test(n)),
+      'the preserve-as-is note is shown',
+    );
+  }
+  // A plain URL is still decomposed normally.
+  assert.deepEqual(parseHttpUrl('http://host:8080/mcp'), { host: 'host', port: 8080 });
+});
+
+test('P88: a network entry with no usable url gets a keep-as-is note', () => {
+  const { settings, notes } = parseMcpEntry({ type: 'http' });
+  assert.equal(settings.transportMode, 'http');
+  assert.ok(
+    notes.some((n) => /no usable url/.test(n)),
+    'the note explains the entry is kept as-is',
+  );
+});
+
+test('P79: a safety flag after `--` is positional and is not a conflict', () => {
+  // yargs runs ['--unsafe','--','--yolo'] in unsafe mode: the token after the separator is a
+  // positional and never defines `yolo`. Treating it as a conflict left the form on `safe`
+  // while the server ran unsafe.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--unsafe', '--', '--yolo'],
+  });
+  assert.equal(settings.safetyMode, 'unsafe', 'the real safety mode is modeled');
+  assert.deepEqual(settings.extraArgs, ['--', '--yolo'], 'the positionals round-trip verbatim');
+});
+
+test('P79: both safety flags BEFORE `--` are still a preserved conflict', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--unsafe', '--yolo', '--', 'x'],
+  });
+  assert.equal(settings.safetyMode, 'safe', 'a server-rejected pair is not collapsed to one mode');
+  assert.deepEqual(settings.extraArgs, ['--unsafe', '--yolo', '--', 'x']);
+});
+
+test('P15: parseMcpEntry keeps a custom wrapper option that collides with a wcli0 flag', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['--config', 'wrapper.json', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'mywrapper');
+  // The wrapper's own --config stays in customArgs; only --shell is a wcli0 flag.
+  assert.deepEqual(settings.customArgs, ['--config', 'wrapper.json', 'wcli0']);
+  assert.equal(settings.configFile, '');
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P15: a custom suffix with a trailing extra arg still splits at the wcli0 flags', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['wcli0', '--shell', 'cmd', '--unknownFlag'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['wcli0']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, ['--unknownFlag']);
+});
+
+test('P24: a custom suffix ending in a valued extraArg still parses the modeled flags', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['wcli0', '--shell', 'cmd', '--futureFlag', 'x'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  // The trailing `--futureFlag x` is a valued extraArg, not a launcher positional, so the
+  // split stays at --shell: the launcher keeps only `wcli0`, --shell is modeled, and the
+  // unrecognized flag and its value round-trip verbatim in extraArgs.
+  assert.deepEqual(settings.customArgs, ['wcli0']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, ['--futureFlag', 'x']);
+});
+
+test('P24: a non-trailing bare token still keeps a launcher positional out of the flags', () => {
+  // `repo` follows the unrecognized --from but is NOT the last token, so it is a launcher
+  // positional (uvx's package) and must stay in customArgs, not be eaten as --from's value.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'uvx',
+    args: ['--from', 'repo', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['--from', 'repo', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, []);
+});
+
+test('parseMcpEntry parses an http entry url', () => {
+  const { settings } = parseMcpEntry({ type: 'http', url: 'http://127.0.0.1:9444/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, '127.0.0.1');
+  assert.equal(settings.transportPort, 9444);
+});
+
+test('parseMcpEntry parses an sse entry with a bracketed IPv6 host', () => {
+  const { settings } = parseMcpEntry({ type: 'sse', url: 'http://[::1]:8080/sse' });
+  assert.equal(settings.transportMode, 'sse');
+  assert.equal(settings.transportHost, '[::1]');
+  assert.equal(settings.transportPort, 8080);
+});
+
+test('P8: parseMcpEntry keeps a valid default port and preserves a default-port url', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'http',
+    url: 'https://gateway.example/custom/mcp',
+  });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, 'gateway.example');
+  // The URL omits an explicit port; the form keeps its default port (a valid min=1
+  // value) rather than rendering an invalid 0 that would block Save (P8).
+  assert.equal(settings.transportPort, 9444);
+  // The verbatim URL is retained so a save round-trips the custom scheme/path and the
+  // default port instead of downgrading to http://host:9444/mcp.
+  assert.equal(settings.transportUrl, 'https://gateway.example/custom/mcp');
+  assert.ok(notes.some((n) => /does not specify a port/.test(n)));
+});
+
+test('P21: parseMcpEntry reads host/port past URL userinfo credentials', () => {
+  const { settings } = parseMcpEntry({
+    type: 'http',
+    url: 'https://user:pass@example.com:9444/mcp',
+  });
+  // The userinfo (user:pass@) is skipped, so the real host and explicit port are read.
+  assert.equal(settings.transportHost, 'example.com');
+  assert.equal(settings.transportPort, 9444);
+  assert.equal(settings.transportUrl, 'https://user:pass@example.com:9444/mcp');
+});
+
+test('P-port0: parseHttpUrl distinguishes an omitted port from an explicit :0', () => {
+  // An omitted port is reported as undefined (scheme default); an explicit :0 is a real
+  // (unusable) port, so the two must not collapse to the same sentinel.
+  assert.equal(parseHttpUrl('https://gateway.example/custom/mcp').port, undefined);
+  assert.equal(parseHttpUrl('http://host:0/mcp').port, 0);
+  assert.equal(parseHttpUrl('http://host:9444/mcp').port, 9444);
+});
+
+test('P66: parseHttpUrl reports an explicit non-numeric port as NaN, not omitted', () => {
+  // An explicit but malformed port (`:abc`, `:-1`) must NOT collapse to the omitted-port
+  // sentinel (undefined). Reporting it as NaN keeps the host modeled while marking the port
+  // unusable, so the save path rebuilds the canonical URL from the port field instead of
+  // preserving the malformed URL as if it were a default-port one a port edit cannot fix.
+  assert.ok(Number.isNaN(parseHttpUrl('http://host:abc/mcp').port));
+  assert.ok(Number.isNaN(parseHttpUrl('http://host:-1/mcp').port));
+  assert.equal(parseHttpUrl('http://host:abc/mcp').host, 'host');
+  // An omitted port is still undefined, and a valid numeric port is unaffected.
+  assert.equal(parseHttpUrl('http://host/mcp').port, undefined);
+  assert.equal(parseHttpUrl('http://host:8080/mcp').port, 8080);
+});
+
+test('P-port0: parseMcpEntry does not preserve an explicit :0 url as a default-port url', () => {
+  const { settings, notes } = parseMcpEntry({ type: 'http', url: 'http://host:0/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  // The host is modeled, but the port field cannot hold 0 (min=1), so it keeps the default.
+  assert.equal(settings.transportHost, 'host');
+  assert.equal(settings.transportPort, 9444);
+  // A note explains the unusable port is rebuilt on save, not preserved verbatim.
+  assert.ok(notes.some((n) => /not a usable port/.test(n)));
+});
+
+test('P-portmax: parseMcpEntry keeps the default port for an out-of-range url port (>65535)', () => {
+  // A port above 65535 cannot be held by the form's number input (max=65535); loading it
+  // verbatim would strand the form in an invalid state and block unrelated saves. It is
+  // treated like the unusable :0 case: the host is modeled, the port keeps the form default,
+  // and a note explains the canonical URL is rebuilt on save.
+  const { settings, notes } = parseMcpEntry({ type: 'http', url: 'http://localhost:70000/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, 'localhost');
+  assert.equal(settings.transportPort, 9444, 'keeps the form default rather than the unusable 70000');
+  assert.ok(notes.some((n) => /not a usable port/.test(n)));
+});
+
+test('P66: parseMcpEntry treats a non-numeric url port as unusable, not omitted', () => {
+  // A non-numeric port (`:abc`) must be handled like the unusable :0/:70000 cases: model the
+  // host, keep the form default port, and note that the canonical URL is rebuilt on save — not
+  // classified as a default-port URL preserved verbatim (which a port edit could never fix).
+  const { settings, notes } = parseMcpEntry({ type: 'http', url: 'http://host:abc/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, 'host');
+  assert.equal(settings.transportPort, 9444, 'keeps the form default rather than the malformed port');
+  assert.ok(notes.some((n) => /not a usable port/.test(n)));
+  // The note distinguishes the malformed port from an out-of-range numeric one.
+  assert.ok(notes.some((n) => /non-numeric port/.test(n)));
+});
+
+test('P-wrapperflags: a wrapper command keeps flag-only args in the launcher portion', () => {
+  // `mywrapper --transport fast` is the wrapper's own option, not a wcli0 flag; with no
+  // launcher positional before it there is no unambiguous server-flag boundary, so it must
+  // stay in customArgs rather than be misread as wcli0's transport setting.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['--transport', 'fast'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'mywrapper');
+  assert.deepEqual(settings.customArgs, ['--transport', 'fast']);
+  // None of it leaked into wcli0 settings.
+  assert.equal(settings.transportMode, 'stdio');
+});
+
+test('P-wrapperflags: a wrapper --config option is not parsed as wcli0.configFile', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['--config', 'wrapper.json'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['--config', 'wrapper.json']);
+  assert.equal(settings.configFile, '');
+});
+
+test('P-wrapperflags: an index-0 server-flag run IS trusted when the command is wcli0', () => {
+  // Running the wcli0 binary directly: its args really are server flags, so they are modeled.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: '/usr/local/bin/wcli0',
+    args: ['--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, []);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P10: parseMcpEntry preserves a socket url it cannot decompose', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'http',
+    url: 'unix:///tmp/server.sock#/mcp',
+  });
+  assert.equal(settings.transportMode, 'http');
+  // The host/port fields cannot model a socket URL, so they stay at their defaults...
+  assert.equal(settings.transportHost, '127.0.0.1');
+  assert.equal(settings.transportPort, 9444);
+  // ...but the verbatim URL is retained so an unrelated save does not rewrite it.
+  assert.equal(settings.transportUrl, 'unix:///tmp/server.sock#/mcp');
+  assert.ok(notes.some((n) => /cannot be represented/.test(n)));
+});
+
+test('P5: parseMcpEntry does not note a canonical http url but still preserves it', () => {
+  const { settings, notes } = parseMcpEntry({ type: 'http', url: 'http://127.0.0.1:9444/mcp' });
+  assert.equal(settings.transportUrl, 'http://127.0.0.1:9444/mcp');
+  assert.equal(notes.length, 0);
+});
+
+test('parseMcpEntry notes a referenced --config file', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--config', '/ws/wcli0.config.json'],
+  });
+  assert.equal(settings.configFile, '/ws/wcli0.config.json');
+  assert.ok(notes.some((n) => /--config/.test(n)));
+});
+
+// ---- round trip ----------------------------------------------------------
+
+test('buildLaunchSpec -> parseMcpEntry round-trips modeled stdio fields', () => {
+  const s = defaults({
+    packageSpec: 'wcli0@2.0.0',
+    shell: 'powershell',
+    allowedDirectories: ['/abs/one', '/abs/two'],
+    commandTimeout: 45,
+    maxCommandLength: 9000,
+    safetyMode: 'yolo',
+    debug: true,
+  });
+  const spec = buildLaunchSpec(s, { resolvePaths: false });
+  const entry = { type: 'stdio', command: spec.command, args: spec.args };
+  const { settings } = parseMcpEntry(entry);
+  assert.equal(settings.launchMethod, 'npx');
+  assert.equal(settings.packageSpec, 'wcli0@2.0.0');
+  assert.equal(settings.shell, 'powershell');
+  assert.deepEqual(settings.allowedDirectories, ['/abs/one', '/abs/two']);
+  assert.equal(settings.commandTimeout, 45);
+  assert.equal(settings.maxCommandLength, 9000);
+  assert.equal(settings.safetyMode, 'yolo');
+  assert.equal(settings.debug, true);
+});
+
+test('buildLaunchSpec -> parseMcpEntry round-trips an http endpoint via its url', () => {
+  // A real http server in mcp.json is { type, url }, not a stdio entry carrying transport
+  // flags. Round-trip the URL representation (host/port are recovered from it).
+  const { settings } = parseMcpEntry({ type: 'http', url: 'http://127.0.0.1:7777/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, '127.0.0.1');
+  assert.equal(settings.transportPort, 7777);
+});
+
+// ---- P30: transport flags must not override a stdio entry's type ------------------
+
+test('P30: a stdio entry with --transport http keeps stdio and preserves the flag', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--transport', 'http', '--http-port', '7777'],
+  });
+  // The authoritative `type` wins: transportMode stays stdio, and the transport flags
+  // round-trip verbatim in extraArgs instead of flipping the type / dropping the launcher.
+  assert.equal(settings.transportMode, 'stdio');
+  assert.equal(settings.launchMethod, 'npx');
+  assert.deepEqual(settings.extraArgs, ['--transport', 'http', '--http-port', '7777']);
+});
+
+// ---- P31: unrecognized transport type ---------------------------------------------
+
+test('P31: an uppercase HTTP type is modeled as http, not coerced to stdio', () => {
+  const { settings } = parseMcpEntry({ type: 'HTTP', url: 'http://127.0.0.1:9444/mcp' });
+  assert.equal(settings.transportMode, 'http');
+  assert.equal(settings.transportHost, '127.0.0.1');
+});
+
+test('P31: an unrecognized type is noted and parsed as stdio', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'websocket',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '--shell', 'cmd'],
+  });
+  assert.equal(settings.transportMode, 'stdio');
+  assert.equal(settings.shell, 'cmd');
+  assert.ok(notes.some((n) => /websocket/.test(n)), 'notes the unmodeled type');
+});
+
+// ---- P32: short-form config alias -------------------------------------------------
+
+test('P32: the -c short alias is recognized like --config', () => {
+  const { settings, notes } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', 'wcli0@latest', '-c', '/ws/wcli0.config.json', '--shell', 'cmd'],
+  });
+  assert.equal(settings.configFile, '/ws/wcli0.config.json');
+  assert.ok(notes.some((n) => /--config/.test(n)), 'still emits the config-file note');
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P32: the attached -c=value and --c=value forms are recognized', () => {
+  const a = parseMcpEntry({ type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '-c=/ws/a.json'] });
+  const b = parseMcpEntry({ type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--c=/ws/b.json'] });
+  assert.equal(a.settings.configFile, '/ws/a.json');
+  assert.equal(b.settings.configFile, '/ws/b.json');
+});
+
+// ---- P33: non-string args are stringified, not dropped ----------------------------
+
+test('P33: a numeric arg is stringified rather than coerced to empty', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['--inspect', 9229, 'dist/index.js'],
+  });
+  // node-with-options parses as custom; 9229 round-trips as "9229", not "".
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['--inspect', '9229', 'dist/index.js']);
+});
+
+// ---- P34: an unparseable numeric flag round-trips via extraArgs -------------------
+
+test('P34: an invalid numeric value falls through to extraArgs instead of blocking saves', () => {
+  const { settings, extraArgs } = parseServerArgs(['--commandTimeout', 'abc', '--shell', 'cmd']);
+  // The unparseable value is not stored in the typed field; both tokens survive verbatim.
+  assert.equal(settings.commandTimeout, undefined);
+  assert.deepEqual(extraArgs, ['--commandTimeout', 'abc']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+// ---- P59: an out-of-range log limit round-trips via extraArgs ----------------------
+
+test('P59: a finite out-of-range maxReturnLines falls through to extraArgs', () => {
+  // The server applies any CLI maxReturnLines > 0 (applyCliLogging, no re-validation), but the
+  // typed field's bound (1..10000, integer) cannot hold 50000 and validateLaunchSpec would
+  // refuse it. maxReturnLines has no form control, so modeling it would strand every save;
+  // preserve it verbatim instead. Both the space-separated and attached forms divert.
+  const a = parseServerArgs(['--maxReturnLines', '50000', '--shell', 'cmd']);
+  assert.equal(a.settings.maxReturnLines, undefined);
+  assert.deepEqual(a.extraArgs, ['--maxReturnLines', '50000']);
+  assert.equal(a.settings.shell, 'cmd');
+
+  const b = parseServerArgs(['--max-return-lines=0']);
+  assert.equal(b.settings.maxReturnLines, undefined);
+  assert.deepEqual(b.extraArgs, ['--max-return-lines=0']);
+
+  // An in-range value is still modeled into the typed field so the form stays editable.
+  const c = parseServerArgs(['--maxReturnLines', '200']);
+  assert.equal(c.settings.maxReturnLines, 200);
+  assert.deepEqual(c.extraArgs, []);
+});
+
+test('P59: a finite out-of-range maxOutputLines falls through to extraArgs', () => {
+  const a = parseServerArgs(['--maxOutputLines', '50000']);
+  assert.equal(a.settings.maxOutputLines, undefined);
+  assert.deepEqual(a.extraArgs, ['--maxOutputLines', '50000']);
+
+  // A fractional value in range is accepted by the field (validateLoggingConfig allows it).
+  const b = parseServerArgs(['--maxOutputLines', '1.5']);
+  assert.equal(b.settings.maxOutputLines, 1.5);
+  assert.deepEqual(b.extraArgs, []);
+});
+
+// ---- P64: a non-positive security limit round-trips via extraArgs ------------------
+
+test('P64: a non-positive commandTimeout/maxCommandLength falls through to extraArgs', () => {
+  // The server ignores a non-positive commandTimeout/maxCommandLength and runs on its default,
+  // but the form's number input rejects negatives and validateLaunchSpec blocks any value <= 0.
+  // Modeling it would strand every save; preserve it verbatim so an unrelated edit round-trips
+  // the existing entry. Both the space-separated and attached forms divert.
+  const a = parseServerArgs(['--commandTimeout', '0', '--shell', 'cmd']);
+  assert.equal(a.settings.commandTimeout, undefined);
+  assert.deepEqual(a.extraArgs, ['--commandTimeout', '0']);
+  assert.equal(a.settings.shell, 'cmd');
+
+  const b = parseServerArgs(['--maxCommandLength=-1']);
+  assert.equal(b.settings.maxCommandLength, undefined);
+  assert.deepEqual(b.extraArgs, ['--maxCommandLength=-1']);
+
+  // A positive value is still modeled into the typed field so the form stays editable.
+  const c = parseServerArgs(['--commandTimeout', '30']);
+  assert.equal(c.settings.commandTimeout, 30);
+  assert.deepEqual(c.extraArgs, []);
+});
+
+// ---- P42: multiple unknown value-bearing extras in the suffix ---------------------
+
+test('P42: a suffix with several valued extras still recovers the modeled flags', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--shell', 'cmd', '--future', 'x', '--another', 'y'],
+  });
+  // The modeled --shell is recovered (not stranded in customArgs), and every unknown
+  // flag/value pair round-trips in extraArgs.
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, []);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, ['--future', 'x', '--another', 'y']);
+});
+
+// ---- P43: keep scanning past an ambiguous leading wrapper flag --------------------
+
+test('P43: a wrapper flag before the modeled flags still recovers the server suffix', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['--no-cache', '--shell', 'bash'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  // The index-0 run is ambiguous for a non-wcli0 command, but instead of stranding the whole
+  // argv in the launcher the scan continues and splits at --shell: --no-cache stays in
+  // customArgs and --shell is modeled (so a shell edit replaces it, not appends a second).
+  assert.deepEqual(settings.customArgs, ['--no-cache']);
+  assert.equal(settings.shell, 'bash');
+  assert.deepEqual(settings.extraArgs, []);
+});
+
+test('P43: a leading colliding wrapper flag still keeps a later modeled flag editable', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['--config', 'wrapper.json', '--shell', 'cmd'],
+  });
+  // The wrapper's own --config stays in customArgs (not misread as wcli0.configFile), while
+  // the later --shell is modeled.
+  assert.deepEqual(settings.customArgs, ['--config', 'wrapper.json']);
+  assert.equal(settings.configFile, '');
+  assert.equal(settings.shell, 'cmd');
+});
+
+// ---- P56: an unknown-only wrapper suffix stays with the launcher ------------------
+
+test('P56: an unknown-only wrapper suffix after a positional stays in customArgs', () => {
+  // `wrapper target --verbose`: --verbose is the wrapper's own option and the suffix carries no
+  // modeled wcli0 flag, so it must stay in customArgs. Moving it into extraArgs would reorder it
+  // after the generated server flags on a later save (target --shell cmd --verbose), changing
+  // the wrapper invocation.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--verbose'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['target', '--verbose']);
+  assert.deepEqual(settings.extraArgs, []);
+});
+
+test('P56: a wrapper suffix with a modeled flag among unknown flags still splits', () => {
+  // Evidence of a modeled flag (--shell) means the suffix IS wcli0's, so it is still recovered
+  // even when an unknown flag precedes it; only the truly unknown-only suffix stays put.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--verbose', '--shell', 'cmd'],
+  });
+  assert.deepEqual(settings.customArgs, ['target']);
+  assert.equal(settings.shell, 'cmd');
+  assert.deepEqual(settings.extraArgs, ['--verbose']);
+});
+
+test('P56: the wcli0 binary still models an unknown-only arg run as extraArgs', () => {
+  // For the wcli0 binary the index-0 run is genuinely wcli0's, so an unknown-only flag is a
+  // legitimate extraArg, not a launcher positional — requireModeled does not apply.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: '/usr/local/bin/wcli0',
+    args: ['--verbose'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, []);
+  assert.deepEqual(settings.extraArgs, ['--verbose']);
+});
+
+// ---- P44: a value option followed by another flag must not swallow it -------------
+
+test('P44: a value option followed by another flag preserves both', () => {
+  const { settings, extraArgs } = parseServerArgs(['--blockedCommand', '--debug']);
+  // --blockedCommand has no value (next token is a flag): it round-trips verbatim and --debug
+  // is still applied, instead of modeling blockedCommands=['--debug'] and dropping debug.
+  assert.equal(settings.debug, true);
+  assert.equal(settings.blockedCommands, undefined);
+  assert.deepEqual(extraArgs, ['--blockedCommand']);
+});
+
+// ---- P45: bundled -c config alias forms ------------------------------------------
+
+test('P45: bundled short config aliases are modeled as configFile', () => {
+  // -c with an attached value, and the c alias bundled with other letters (value attached
+  // or as the next token) — all set the server's config, mirroring stripConfigArgs.
+  assert.equal(parseServerArgs(['-c/ws/a.json']).settings.configFile, '/ws/a.json');
+  assert.equal(parseServerArgs(['-xc', '/ws/b.json']).settings.configFile, '/ws/b.json');
+  assert.equal(parseServerArgs(['-xc/ws/c.json']).settings.configFile, '/ws/c.json');
+});
+
+test('P62: a short bundle yargs would NOT read as config is preserved, not fabricated', () => {
+  // yargs (config alias `c`, default parser) only attaches a single-dash bundle remainder as
+  // the config string when it is fully numeric or starts with a non-word, non-dot path char.
+  // A word-character start parses as separate short boolean flags (`-cfoo` => -c -f -o -o,
+  // config=""), and a leading `.` as a dot-notation object — never as the literal remainder.
+  // Modeling those as configFile would fabricate a path the server never used and let a no-op
+  // save emit a spurious `--config <value>`, so they must round-trip verbatim in extraArgs.
+  for (const bundle of ['-cfoo', '-cX', '-cfoo.json', '-cC:/x.json', '-c.foo', '-c.config.json']) {
+    const { settings, extraArgs } = parseServerArgs([bundle]);
+    assert.equal(settings.configFile, undefined, `${bundle} must not set configFile`);
+    assert.deepEqual(extraArgs, [bundle], `${bundle} must round-trip verbatim`);
+  }
+
+  // The shapes yargs DOES read as config still resolve (path separator start, or numeric).
+  assert.equal(parseServerArgs(['-c/etc/x.json']).settings.configFile, '/etc/x.json');
+  assert.equal(parseServerArgs(['-c~/x.json']).settings.configFile, '~/x.json');
+  assert.equal(parseServerArgs(['-c123']).settings.configFile, '123');
+});
+
+// ---- P47: yargs kebab-case option aliases ----------------------------------------
+
+test('P47: kebab-case option aliases are modeled like their camelCase forms', () => {
+  const { settings } = parseServerArgs([
+    '--max-command-length', '1000',
+    '--blocked-command', 'rm',
+    '--allow-all-dirs',
+    '--no-enable-truncation',
+  ]);
+  assert.equal(settings.maxCommandLength, 1000);
+  assert.deepEqual(settings.blockedCommands, ['rm']);
+  assert.equal(settings.allowAllDirs, true);
+  assert.equal(settings.enableTruncation, 'disabled');
+});
+
+// ---- P74-P78: the `--` separator, attached/transport suffix evidence, duplicate scalars ----
+
+test('P74: parseServerArgs preserves the `--` separator and the remainder verbatim', () => {
+  // yargs treats every token after `--` as a positional, not an option, so `-- --shell cmd` must
+  // NOT be modeled as shell=cmd. The parser preserves `--` and everything after it in extraArgs.
+  const a = parseServerArgs(['--', '--shell', 'cmd']);
+  assert.equal(a.settings.shell, undefined, '--shell after -- is a positional, not modeled');
+  assert.deepEqual(a.extraArgs, ['--', '--shell', 'cmd']);
+
+  // Flags BEFORE the separator are still modeled; only the post-`--` remainder is preserved.
+  const b = parseServerArgs(['--debug', '--', '--shell', 'cmd', '--maxCommandLength', '10']);
+  assert.equal(b.settings.debug, true);
+  assert.equal(b.settings.shell, undefined);
+  assert.equal(b.settings.maxCommandLength, undefined);
+  assert.deepEqual(b.extraArgs, ['--', '--shell', 'cmd', '--maxCommandLength', '10']);
+});
+
+test('P74: a plain node entry does not model server flags after a `--` separator', () => {
+  // `node dist/index.js -- --shell cmd`: yargs leaves `--shell`/`cmd` positional, so a no-op save
+  // must not re-emit an active `--shell cmd` that changes the launch behavior.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--', '--shell', 'cmd'],
+  });
+  assert.equal(settings.launchMethod, 'node');
+  assert.equal(settings.nodeScriptPath, 'dist/index.js');
+  assert.equal(settings.shell, 'all', 'shell stays at its default, not cmd');
+  assert.deepEqual(settings.extraArgs, ['--', '--shell', 'cmd']);
+});
+
+test('P75: a `--` separator keeps the remainder with the launcher, not a server suffix', () => {
+  // `command: "wcli0", args: ["--", "--debug"]`: yargs treats `--debug` as a positional after the
+  // separator, so the suffix scan must not split it out and let a no-op save enable debug.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--', '--debug'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'wcli0');
+  assert.deepEqual(settings.customArgs, ['--', '--debug']);
+  assert.equal(settings.debug, false, 'debug stays default; --debug after -- is positional');
+  assert.deepEqual(settings.extraArgs, []);
+});
+
+test('P76: an attached boolean flag proves a wcli0 server suffix for a wrapper', () => {
+  // For a wrapper command, the suffix detector must recognize an attached boolean assignment
+  // (`--debug=true`, `--enableTruncation=false`) as a modeled wcli0 flag; otherwise it stays in
+  // customArgs, the form shows the default, and a save cannot edit it.
+  const a = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--debug=true'],
+  }).settings;
+  assert.equal(a.launchMethod, 'custom');
+  assert.deepEqual(a.customArgs, ['target']);
+  assert.equal(a.debug, true);
+  assert.deepEqual(a.extraArgs, []);
+
+  const b = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--enableTruncation=false'],
+  }).settings;
+  assert.deepEqual(b.customArgs, ['target']);
+  assert.equal(b.enableTruncation, 'disabled');
+});
+
+test('P77: a stdio transport flag does not prove a wcli0 server suffix', () => {
+  // In a stdio entry the transport flags are not modeled (the entry's `type` is authoritative), so
+  // a wrapper's trailing `--transport fast` must not be split out as a server suffix and reordered
+  // before the wrapper's options on save. With no modeled wcli0 flag present it stays in customArgs.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--transport', 'fast'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.deepEqual(settings.customArgs, ['target', '--transport', 'fast']);
+  assert.equal(settings.transportMode, 'stdio');
+  assert.deepEqual(settings.extraArgs, []);
+});
+
+test('P77: a real wcli0 flag still splits a wrapper suffix that also carries a transport flag', () => {
+  // When the suffix DOES contain a modeled wcli0 flag (--shell), the split is legitimate; the
+  // transport flag rides along in extraArgs verbatim rather than flipping the stdio transport.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--shell', 'cmd', '--transport', 'fast'],
+  });
+  assert.deepEqual(settings.customArgs, ['target']);
+  assert.equal(settings.shell, 'cmd');
+  assert.equal(settings.transportMode, 'stdio');
+  assert.deepEqual(settings.extraArgs, ['--transport', 'fast']);
+});
+
+test('P78: a repeated scalar option is preserved verbatim, not collapsed last-wins', () => {
+  // yargs parses `--config a --config b` as config=['a','b'] and `--shell cmd --shell bash` as an
+  // array too, which the single-value fields cannot represent. Collapsing to the last value on a
+  // no-op save would silently change the launch, so every occurrence round-trips in extraArgs.
+  const a = parseServerArgs(['--config', 'a', '--config', 'b']);
+  assert.equal(a.settings.configFile, undefined, 'duplicate --config is not modeled');
+  assert.deepEqual(a.extraArgs, ['--config', 'a', '--config', 'b']);
+
+  const b = parseServerArgs(['--shell', 'cmd', '--shell', 'bash']);
+  assert.equal(b.settings.shell, undefined);
+  assert.deepEqual(b.extraArgs, ['--shell', 'cmd', '--shell', 'bash']);
+
+  // Mixed forms and yargs kebab/camel aliases that resolve to the same key are also duplicates.
+  const c = parseServerArgs(['--config', 'a', '--config=b']);
+  assert.equal(c.settings.configFile, undefined);
+  assert.deepEqual(c.extraArgs, ['--config', 'a', '--config=b']);
+
+  const d = parseServerArgs(['--maxCommandLength', '100', '--max-command-length', '200']);
+  assert.equal(d.settings.maxCommandLength, undefined);
+  assert.deepEqual(d.extraArgs, ['--maxCommandLength', '100', '--max-command-length', '200']);
+});
+
+test('P78: a single scalar occurrence is still modeled, and array options still accumulate', () => {
+  // The duplicate guard must not regress the normal single-value case...
+  const a = parseServerArgs(['--config', 'a', '--shell', 'bash']);
+  assert.equal(a.settings.configFile, 'a');
+  assert.equal(a.settings.shell, 'bash');
+  assert.deepEqual(a.extraArgs, []);
+
+  // ...nor the array-kind options, which legitimately repeat and accumulate into a list.
+  const b = parseServerArgs(['--allowedDir', '/a', '--allowedDir', '/b']);
+  assert.deepEqual(b.settings.allowedDirectories, ['/a', '/b']);
+  assert.deepEqual(b.extraArgs, []);
+});

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1592,6 +1592,97 @@ test('P75/P105: a `--` separator in a direct wcli0 launch keeps its positionals 
   assert.deepEqual(spec.args, ['--', '--debug'], 'a no-op save round-trips the entry verbatim');
 });
 
+test('P106: a valueless scalar flag cannot swallow a later positional on save', () => {
+  // yargs reads `--shell --debug cmd` as shell='', debug=true and a POSITIONAL cmd. The builder
+  // re-emits extraArgs after the modeled flags, so preserving `--shell` verbatim produced
+  // `--debug --shell cmd` -- making cmd the shell value and changing the enabled shell.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--shell', '--debug', 'cmd'],
+  });
+  assert.equal(settings.debug, true);
+  assert.equal(settings.shell, defaults().shell, 'the valueless flag is not modeled');
+  assert.deepEqual(settings.extraArgs, ['--shell=', 'cmd'], 'rewritten to the form that cannot');
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(args, ['dist/index.js', '--debug', '--shell=', 'cmd']);
+  // The rebuilt order does put cmd next to the flag -- what matters is that the attached form is
+  // self-terminating, so yargs cannot take it as the value. Verified against yargs-parser:
+  // `--debug --shell= cmd` => shell '', debug true, cmd positional, exactly like the entry.
+  assert.equal(args.includes('--shell'), false, 'never the bare form, which would swallow cmd');
+});
+
+test('P109: a valueless array flag cannot swallow a later positional on save', () => {
+  // `--allowedDir --debug C:/work` gives yargs an EMPTY allowedDir array and leaves C:/work
+  // positional. Re-emitted as `--debug --allowedDir C:/work` it would become an allowed directory,
+  // which also switches restrictWorkingDirectory ON and injection protection OFF.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--allowedDir', '--debug', 'C:/work'],
+  });
+  assert.equal(settings.debug, true);
+  assert.deepEqual(settings.allowedDirectories, [], 'no directory is modeled');
+  assert.deepEqual(settings.extraArgs, ['C:/work'], 'the inert empty-array flag is dropped');
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.equal(args.includes('--allowedDir'), false, 'no allowed directory is introduced');
+  assert.ok(args.includes('C:/work'), 'the positional still round-trips');
+});
+
+test('P106: a valueless number flag is dropped rather than rewritten', () => {
+  // A valueless number option defines NO key in yargs, while `--flag=` would define 0.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--commandTimeout', '--debug', 'tail'],
+  });
+  assert.equal(settings.commandTimeout, defaults().commandTimeout);
+  assert.deepEqual(settings.extraArgs, ['tail']);
+});
+
+test('P106: a valueless `-c` bundle is re-emitted in its long attached form', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '-dc', '--debug', 'tail'],
+  });
+  assert.deepEqual(settings.extraArgs, ['-d', '--config=', 'tail'], 'the other letters survive');
+  assert.equal(settings.configFile, '', 'no config path is fabricated');
+});
+
+test('P106/P109: a valueless flag with no positional after it round-trips verbatim', () => {
+  // The guard fires only on the dangerous shape; these were already safe in any order.
+  const a = parseServerArgs(['--blockedCommand', '--debug']);
+  assert.deepEqual(a.extraArgs, ['--blockedCommand'], 'P44 preservation is unchanged');
+  const b = parseServerArgs(['--shell', '--debug', '--shell', 'bash']);
+  assert.deepEqual(b.extraArgs, ['--shell', '--shell', 'bash'], 'P98 preservation is unchanged');
+  const c = parseServerArgs(['--transport', 'http'], { stdio: true });
+  assert.deepEqual(c.extraArgs, ['--transport', 'http'], 'P30 preservation is unchanged');
+});
+
+test('P108: an attached negation does not prove a wrapper server suffix', () => {
+  // yargs applies `--name=value` before boolean negation, so `--no-debug=false` defines an
+  // unrelated `no-debug` key rather than setting debug -- it is the wrapper's own token.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--no-debug=false'],
+  });
+  assert.deepEqual(settings.customArgs, ['target', '--no-debug=false'], 'stays with the wrapper');
+  assert.deepEqual(settings.extraArgs, []);
+  assert.equal(settings.debug, defaults().debug, 'debug is not modeled from it');
+});
+
+test('P108: a bare negation still proves a suffix, as yargs really negates it', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['target', '--no-debug'],
+  });
+  assert.deepEqual(settings.customArgs, ['target']);
+  assert.equal(settings.debug, false, 'the real negation is modeled');
+});
+
 test('P105: a positional cannot split a direct wcli0 arg list at the wrong place', () => {
   // `wcli0 --allowAllDirs marker --no-allowAllDirs` is last-wins false to yargs (marker is a
   // positional), so the server runs RESTRICTED. The suffix scan used to fail its purity check on

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1572,9 +1572,12 @@ test('P74: a plain node entry does not model server flags after a `--` separator
   assert.deepEqual(settings.extraArgs, ['--', '--shell', 'cmd']);
 });
 
-test('P75: a `--` separator keeps the remainder with the launcher, not a server suffix', () => {
+test('P75/P105: a `--` separator in a direct wcli0 launch keeps its positionals inert', () => {
   // `command: "wcli0", args: ["--", "--debug"]`: yargs treats `--debug` as a positional after the
-  // separator, so the suffix scan must not split it out and let a no-op save enable debug.
+  // separator, so it must not be modeled and a no-op save must not enable debug. Since P105 the
+  // whole arg list is parsed as the server's own, so the separator and its remainder are held by
+  // parseServerArgs in extraArgs rather than by the launcher split -- the emitted args are
+  // identical either way, which is what the round-trip assertion below pins.
   const { settings } = parseMcpEntry({
     type: 'stdio',
     command: 'wcli0',
@@ -1582,9 +1585,66 @@ test('P75: a `--` separator keeps the remainder with the launcher, not a server 
   });
   assert.equal(settings.launchMethod, 'custom');
   assert.equal(settings.customCommand, 'wcli0');
-  assert.deepEqual(settings.customArgs, ['--', '--debug']);
   assert.equal(settings.debug, false, 'debug stays default; --debug after -- is positional');
-  assert.deepEqual(settings.extraArgs, []);
+  assert.deepEqual(settings.extraArgs, ['--', '--debug']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(spec.command, 'wcli0');
+  assert.deepEqual(spec.args, ['--', '--debug'], 'a no-op save round-trips the entry verbatim');
+});
+
+test('P105: a positional cannot split a direct wcli0 arg list at the wrong place', () => {
+  // `wcli0 --allowAllDirs marker --no-allowAllDirs` is last-wins false to yargs (marker is a
+  // positional), so the server runs RESTRICTED. The suffix scan used to fail its purity check on
+  // `marker`, pick the trailing negation as the "server suffix", and leave the ENABLING flag in
+  // customArgs -- so the form modeled allowAllDirs=false while a no-op save wrote
+  // `--allowAllDirs marker`, flipping the server to UNRESTRICTED directories.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--allowAllDirs', 'marker', '--no-allowAllDirs'],
+  });
+  assert.deepEqual(settings.customArgs, [], 'every arg belongs to the server list');
+  assert.equal(settings.allowAllDirs, false, 'last-wins, as yargs resolves it');
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.equal(
+    spec.args.includes('--allowAllDirs'),
+    false,
+    'the save never re-enables unrestricted directories',
+  );
+  // The pair collapses to the value yargs computes for it; the launch is unchanged.
+  assert.deepEqual(spec.args, ['marker']);
+});
+
+test('P105: a direct wcli0 launch still models its flags and keeps unknown ones', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--shell', 'cmd', '--futureFlag', 'x'],
+  });
+  assert.deepEqual(settings.customArgs, []);
+  assert.equal(settings.shell, 'cmd', 'modeled flags stay editable');
+  assert.deepEqual(settings.extraArgs, ['--futureFlag', 'x'], 'unknown flags round-trip');
+});
+
+test('P105: a wrapper command is still split at its server-flag suffix', () => {
+  // The scan is unchanged for anything that is not the wcli0 binary itself.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wrapper',
+    args: ['--no-cache', '--shell', 'bash'],
+  });
+  assert.deepEqual(settings.customArgs, ['--no-cache'], "the wrapper's own option stays put");
+  assert.equal(settings.shell, 'bash');
+});
+
+test('P105: a wcli0 binary behind a wrapper separator is still a pass-through', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--package=wcli0', '--', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.deepEqual(settings.customArgs, ['--package=wcli0', '--', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
 });
 
 test('P76: an attached boolean flag proves a wcli0 server suffix for a wrapper', () => {

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1824,3 +1824,95 @@ test('P78: a single scalar occurrence is still modeled, and array options still 
   assert.deepEqual(b.settings.allowedDirectories, ['/a', '/b']);
   assert.deepEqual(b.extraArgs, []);
 });
+
+test('P111: a trailing valueless numeric duplicate is preserved verbatim', () => {
+  // yargs is order-sensitive: it drops a valueless number option only while the key is still
+  // undefined, so `--maxCommandLength 1000000 --maxCommandLength` becomes [1000000, null] -- an
+  // array applyCliSecurityOverrides ignores, leaving the server's much stricter default limit in
+  // force. Modeling 1000000 and stripping the preserved valueless token turned an unrelated save
+  // into one that activates the weaker limit.
+  const { settings, extraArgs } = parseServerArgs([
+    '--maxCommandLength',
+    '1000000',
+    '--maxCommandLength',
+  ]);
+  assert.equal(settings.maxCommandLength, undefined, 'neither occurrence is modeled');
+  assert.deepEqual(extraArgs, ['--maxCommandLength', '1000000', '--maxCommandLength']);
+});
+
+test('P111: the trailing valueless pair survives a no-op save intact', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['dist/index.js', '--commandTimeout', '600', '--commandTimeout'],
+  });
+  assert.equal(settings.commandTimeout, defaults().commandTimeout, 'the form shows no timeout');
+  const args = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true }).args;
+  assert.deepEqual(args, ['dist/index.js', '--commandTimeout', '600', '--commandTimeout']);
+});
+
+test('P111/P102: a LEADING valueless number is still dropped by yargs, so it is not a duplicate', () => {
+  // `--commandTimeout --commandTimeout 5` defines no key for the first token, so yargs resolves
+  // it to the scalar 5 -- counting it would leave the form showing no timeout at all (P102).
+  const { settings, extraArgs } = parseServerArgs(['--commandTimeout', '--commandTimeout', '5']);
+  assert.equal(settings.commandTimeout, 5, 'the value yargs actually applies is modeled');
+  assert.deepEqual(extraArgs, ['--commandTimeout'], 'the inert leading token is preserved');
+});
+
+test('P112: a leading positional is not swallowed by a rebuilt allowed-directory array', () => {
+  // yargs reads `wcli0 marker --allowedDir C:/trusted` as the positional `marker` plus ONE
+  // allowed directory. extraArgs is appended after the generated flags, so re-emitting it as
+  // `--allowedDir C:/trusted marker` made `marker` a SECOND allowed directory, silently widening
+  // the server's permitted working directories on an unrelated save.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['marker', '--allowedDir', 'C:/trusted'],
+  });
+  assert.deepEqual(settings.allowedDirectories, ['C:/trusted'], 'the directory stays editable');
+  assert.deepEqual(settings.extraArgs, ['marker']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['marker', '--allowedDir', 'C:/trusted'], 'authored order is kept');
+});
+
+test('P112: an edited allowed-directory list still cannot capture the positional', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['marker', '--allowedDir', 'C:/trusted'],
+  });
+  const edited = { ...settings, allowedDirectories: ['C:/trusted', 'C:/extra'] };
+  const spec = buildLaunchSpec(edited, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, [
+    'marker',
+    '--allowedDir',
+    'C:/trusted',
+    '--allowedDir',
+    'C:/extra',
+  ]);
+});
+
+test('P112: a leading positional is kept out of the blocked lists too', () => {
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['marker', '--blockedCommand', 'rm'],
+  });
+  assert.deepEqual(settings.blockedCommands, ['rm']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['marker', '--blockedCommand', 'rm']);
+});
+
+test('P112: array flags keep their usual position when extraArgs lead with a flag', () => {
+  // The hoist fires only on the dangerous shape: a later positional already has a `-`-prefixed
+  // token in front of it, which is where yargs stops consuming array values.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--allowedDir', 'C:/trusted', '--futureFlag', 'x'],
+  });
+  assert.deepEqual(settings.allowedDirectories, ['C:/trusted']);
+  assert.deepEqual(settings.extraArgs, ['--futureFlag', 'x']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--allowedDir', 'C:/trusted', '--futureFlag', 'x']);
+});

--- a/vscode-extension/test/unit/configSource.test.cjs
+++ b/vscode-extension/test/unit/configSource.test.cjs
@@ -1916,3 +1916,130 @@ test('P112: array flags keep their usual position when extraArgs lead with a fla
   const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
   assert.deepEqual(spec.args, ['--allowedDir', 'C:/trusted', '--futureFlag', 'x']);
 });
+
+test('P113: a valueless --init-config cannot swallow a later positional on save', () => {
+  // yargs reads `--init-config --debug path` as an EMPTY init-config (falsy, so the server keeps
+  // running) plus the positional `path`. Re-emitted as `--debug --init-config path` the option
+  // takes `path` as its value, and the server writes a default config there and EXITS.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--init-config', '--debug', 'path'],
+  });
+  assert.equal(settings.debug, true);
+  assert.deepEqual(settings.extraArgs, ['--init-config=', 'path'], 'rewritten to the inert form');
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--debug', '--init-config=', 'path']);
+  assert.equal(spec.args.includes('--init-config'), false, 'never the bare, value-taking form');
+});
+
+test('P113: the camelCase --initConfig spelling is guarded too', () => {
+  // yargs accepts `--initConfig` as the camel-case alias of the server's `init-config` option.
+  const { extraArgs } = parseServerArgs(['--initConfig', '--debug', 'path']);
+  assert.deepEqual(extraArgs, ['--initConfig=', 'path']);
+});
+
+test('P113: an --init-config that HAS a value round-trips verbatim', () => {
+  // The guard fires only on the valueless shape; here `path` is already the option's value, so it
+  // is not a positional and nothing needs rewriting.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['--init-config', 'path', '--debug'],
+  });
+  assert.deepEqual(settings.extraArgs, ['--init-config', 'path']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--debug', '--init-config', 'path']);
+});
+
+test('P113: a valueless scalar before an --init-config value is left alone', () => {
+  // `--init-config` consumes `x`, so there is no positional and the preserved `--shell` needs no
+  // rewrite: yargs reads both orders as shell='' plus init-config='x'.
+  const { extraArgs } = parseServerArgs(['--shell', '--debug', '--init-config', 'x']);
+  assert.deepEqual(extraArgs, ['--shell', '--init-config', 'x']);
+});
+
+test('P114: a boolean-like positional is not swallowed by a rebuilt boolean flag', () => {
+  // yargs reads `false --enableTruncation=true` as the positional `false` plus truncation ON, but
+  // the rebuilt `--enableTruncation false` feeds the positional to the flag: truncation goes OFF
+  // and the positional disappears.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['false', '--enableTruncation=true'],
+  });
+  assert.equal(settings.enableTruncation, 'enabled');
+  assert.deepEqual(settings.extraArgs, ['false']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--enableTruncation=true', 'false'], 'attached form cannot consume');
+});
+
+test('P114: the array hoist does not park the positional behind a boolean flag', () => {
+  // The P112 hoist re-emits the array flags after the leading positional run, which puts the last
+  // NON-array flag in front of it -- a bare `--debug` there would swallow the `false`.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['false', '--allowedDir', 'C:/trusted', '--debug'],
+  });
+  assert.equal(settings.debug, true);
+  assert.deepEqual(settings.allowedDirectories, ['C:/trusted']);
+  assert.deepEqual(settings.extraArgs, ['false']);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--debug=true', 'false', '--allowedDir', 'C:/trusted']);
+});
+
+test('P114: a positional that is not true/false keeps the bare boolean spelling', () => {
+  // yargs consumes ONLY a literal `true`/`false` after a declared boolean, so every other
+  // positional is already safe and the emission is unchanged.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'wcli0',
+    args: ['marker', '--debug'],
+  });
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--debug', 'marker']);
+});
+
+test('P115: a leading `--` separator keeps the wrapper args out of the server suffix', () => {
+  // node documents `--` as the end of its own options, so `node -- wrapper.js --debug` hands
+  // `--debug` to the wrapper. The suffix scan started at index 1 and never saw the separator, so
+  // it modeled that token as wcli0's Debug setting -- and turning the setting off then saved
+  // `['--', 'wrapper.js']`, deleting the wrapper's own option.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'node',
+    args: ['--', 'wrapper.js', '--debug'],
+  });
+  assert.equal(settings.launchMethod, 'custom');
+  assert.equal(settings.customCommand, 'node');
+  assert.deepEqual(settings.customArgs, ['--', 'wrapper.js', '--debug']);
+  assert.equal(settings.debug, false, 'the wrapper option is not modeled as wcli0 Debug');
+  assert.deepEqual(settings.extraArgs, []);
+  const spec = buildLaunchSpec(settings, { resolvePaths: false, preserveRelativePaths: true });
+  assert.deepEqual(spec.args, ['--', 'wrapper.js', '--debug'], 'a no-op save is verbatim');
+});
+
+test('P115: a leading separator still passes through to a wrapped wcli0 binary', () => {
+  // The P17 exception is unchanged: a separator followed by the wcli0 binary PROVES a
+  // pass-through, so the flags after that binary really are the server's.
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'npx',
+    args: ['--', 'wcli0', '--shell', 'cmd'],
+  });
+  assert.deepEqual(settings.customArgs, ['--', 'wcli0']);
+  assert.equal(settings.shell, 'cmd');
+});
+
+test('P115: an index-0 flag run still stays with the wrapper', () => {
+  // Visiting index 0 is only about honoring a separator there; a flag run at index 0 is still the
+  // wrapper's own option, never a wcli0 suffix (P-wrapperflags).
+  const { settings } = parseMcpEntry({
+    type: 'stdio',
+    command: 'mywrapper',
+    args: ['--transport', 'fast'],
+  });
+  assert.deepEqual(settings.customArgs, ['--transport', 'fast']);
+  assert.deepEqual(settings.extraArgs, []);
+});

--- a/vscode-extension/test/unit/webview.test.cjs
+++ b/vscode-extension/test/unit/webview.test.cjs
@@ -996,6 +996,81 @@ test('P95: a save is refused when the entry changes between the two reads', asyn
   assert.equal(args.includes('--debug'), false, 'nothing was written');
 });
 
+test('P110: a save is refused when the launch method changed on disk', async () => {
+  // The panel loaded an npx entry and the user edited only the package spec; the file then became
+  // a node entry. Overlaying the package edit onto the node launch would report success while the
+  // edit vanished on reparse, so the save must refuse and ask for a reload.
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'node', args: ['dist/index.js'] } },
+  });
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({
+    type: 'saveToFile',
+    values: { 'launch.packageSpec': 'wcli0@9.9.9' },
+  });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no false Saved');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /different launch method/.test(m)),
+    'the refusal asks for a reload',
+  );
+  const entry = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0;
+  assert.equal(entry.command, 'node', 'the on-disk entry is untouched');
+});
+
+test('P110: a non-launch edit still saves across a concurrent method change', async () => {
+  // Only method-specific fields are incompatible; an unrelated edit merges onto the new entry.
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'node', args: ['dist/index.js'] } },
+  });
+  vscode.__state.calls.error.length = 0;
+  await panel.webview._handler({ type: 'saveToFile', values: { debug: true } });
+  const entry = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0;
+  assert.equal(entry.command, 'node', 'the concurrent method change is respected');
+  assert.ok(entry.args.includes('--debug'), 'the unrelated edit is written');
+});
+
+test('P110: switching the method deliberately is still allowed', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'node', args: ['dist/index.js'] } },
+  });
+  vscode.__state.calls.error.length = 0;
+  await panel.webview._handler({
+    type: 'saveToFile',
+    values: { 'launch.method': 'npx', 'launch.packageSpec': 'wcli0@9.9.9' },
+  });
+  const entry = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0;
+  assert.equal(entry.command, 'npx', 'the explicit switch wins');
+  assert.ok(entry.args.includes('wcli0@9.9.9'));
+});
+
 test('P80: a file save is refused when the entry changed transport type on disk', async () => {
   // The two modes model different fields, so the form's stdio edits cannot be overlaid onto an
   // http entry (nor the reverse); ask for a reload rather than guessing.

--- a/vscode-extension/test/unit/webview.test.cjs
+++ b/vscode-extension/test/unit/webview.test.cjs
@@ -56,6 +56,111 @@ test('save message persists values to the chosen scope', async () => {
   assert.equal(vscode.__state.calls.info.length, 1);
 });
 
+test('P28: a save flagged from a file-source reset is confirmed before writing settings', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  // Decline the confirmation modal: the file-derived edits must not reach settings.
+  vscode.__state.calls.warnReturn = undefined;
+  await panel.webview._handler({
+    type: 'save',
+    target: 'Workspace',
+    values: { commandTimeout: 99 },
+    fromResetFileSource: true,
+  });
+  assert.equal(
+    vscode.workspace.getConfiguration('wcli0').get('commandTimeout', null),
+    null,
+    'declining the confirm leaves settings unwritten',
+  );
+  assert.ok(
+    vscode.__state.calls.warn.some((w) => /no longer active/.test(w.message)),
+    'a confirmation modal was shown',
+  );
+});
+
+test('P28: confirming a file-source-reset save writes the values to settings', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  vscode.__state.calls.warnReturn = 'Save to settings';
+  await panel.webview._handler({
+    type: 'save',
+    target: 'Workspace',
+    values: { commandTimeout: 99 },
+    fromResetFileSource: true,
+  });
+  assert.equal(
+    vscode.workspace.getConfiguration('wcli0').get('commandTimeout', null),
+    99,
+    'the confirmed save persists',
+  );
+});
+
+test('P28: an export flagged from a file-source reset is confirmed before writing settings', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  // Decline the confirmation modal: the file-derived edits must not reach settings,
+  // and the export command must not run on the stale/unwritten state.
+  vscode.__state.calls.warnReturn = undefined;
+  vscode.__state.calls.executedCommands = [];
+  await panel.webview._handler({
+    type: 'generateConfig',
+    target: 'Workspace',
+    values: { commandTimeout: 99 },
+    fromResetFileSource: true,
+  });
+  assert.equal(
+    vscode.workspace.getConfiguration('wcli0').get('commandTimeout', null),
+    null,
+    'declining the confirm leaves settings unwritten',
+  );
+  assert.ok(
+    vscode.__state.calls.warn.some((w) => /no longer active/.test(w.message)),
+    'a confirmation modal was shown',
+  );
+  assert.ok(
+    !vscode.__state.calls.executedCommands.some((c) => c.id === 'wcli0.generateConfigFile'),
+    'the export command does not run after declining',
+  );
+});
+
+test('P28: confirming a file-source-reset export writes settings then exports', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  vscode.__state.calls.warnReturn = 'Save to settings';
+  vscode.__state.calls.executedCommands = [];
+  await panel.webview._handler({
+    type: 'generateConfig',
+    target: 'Workspace',
+    values: { commandTimeout: 99 },
+    fromResetFileSource: true,
+  });
+  assert.equal(
+    vscode.workspace.getConfiguration('wcli0').get('commandTimeout', null),
+    99,
+    'the confirmed export persists the values first',
+  );
+  assert.ok(
+    vscode.__state.calls.executedCommands.some((c) => c.id === 'wcli0.generateConfigFile'),
+    'the export command runs after confirming',
+  );
+});
+
+test('P28: an ordinary settings save is not gated by the reset confirm', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  vscode.__state.calls.warnReturn = undefined; // no modal expected for an unflagged save
+  await panel.webview._handler({
+    type: 'save',
+    target: 'Workspace',
+    values: { commandTimeout: 77 },
+  });
+  assert.equal(
+    vscode.workspace.getConfiguration('wcli0').get('commandTimeout', null),
+    77,
+    'an unflagged save persists without a prompt',
+  );
+});
+
 test('scope change reloads values stored at the selected scope', async () => {
   vscode.__setConfig(vscode.ConfigurationTarget.Global, 'wcli0.shell', 'powershell');
   vscode.__setConfig(vscode.ConfigurationTarget.Workspace, 'wcli0.shell', 'cmd');
@@ -440,6 +545,21 @@ test('P103: fraction-accepting numeric inputs set step=any so valid 1.5 values a
   assert.match(port, /step="1"/, 'port stays integer');
 });
 
+test('P58: commandTimeout/maxCommandLength inputs use min="0" so a loaded sub-1s value can save', () => {
+  openConfigPanel(makeContext());
+  const html = vscode.__state.lastWebviewPanel.webview.html;
+  // The server accepts any CLI commandTimeout/maxCommandLength > 0 (the >= 1 bound is the
+  // managed/config-file one). A hand-authored file-source entry can carry e.g.
+  // --commandTimeout 0.5, which the typed field must be able to re-submit; min="1" would make
+  // validateNumbers reject the untouched value and strand every save. The host's
+  // validateLaunchSpec still rejects an actually-invalid value with a precise message.
+  for (const id of ['commandTimeout', 'maxCommandLength']) {
+    const input = html.match(new RegExp(`<input type="number" id="${id}"[^>]*>`))[0];
+    assert.match(input, /min="0"/, `${id} should allow sub-1s values`);
+    assert.doesNotMatch(input, /min="1"/, `${id} must not carry the managed >= 1 client bound`);
+  }
+});
+
 test('P100: save and export validate all numeric inputs before posting', () => {
   openConfigPanel(makeContext());
   const html = vscode.__state.lastWebviewPanel.webview.html;
@@ -450,4 +570,631 @@ test('P100: save and export validate all numeric inputs before posting', () => {
   assert.match(html, /querySelectorAll\('input\[type=number\]'\)/);
   assert.match(html, /\$\('save'\)\.addEventListener\('click', \(\) => \{\s*if \(!validateNumbers\(\) \|\| !validateProfiles\(\)\) return;/);
   assert.match(html, /function exportAction\(type\) \{\s*if \(!validateNumbers\(\) \|\| !validateProfiles\(\)\) return;/);
+});
+
+// ---- Configuration source switcher (auto-detect / load / save) ----
+
+function seedWorkspaceMcpJson(obj) {
+  vscode.__state.files.set('/ws/.vscode/mcp.json', Buffer.from(JSON.stringify(obj)));
+}
+
+test('init reports the settings source and detects a workspace mcp.json wcli0 entry', async () => {
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  const init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.equal(init.source, 'settings');
+  const detected = (init.detected || []).find((d) => d.kind === 'mcpJson');
+  assert.ok(detected, 'workspace mcp.json detected');
+  assert.equal(detected.hasWcli0, true);
+});
+
+test('switching to the mcp.json source loads the entry into the form', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@9.9.9', '--shell', 'cmd'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  const init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.equal(init.source, 'mcpJson');
+  assert.equal(init.settings.packageSpec, 'wcli0@9.9.9');
+  assert.equal(init.settings.shell, 'cmd');
+});
+
+test('switching to the mcp.json source errors when no wcli0 entry exists', async () => {
+  seedWorkspaceMcpJson({ servers: { other: { type: 'stdio' } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'init'), undefined);
+  assert.ok(vscode.__state.calls.error.some((m) => /no wcli0 server entry/.test(m)));
+});
+
+test('saving the mcp.json source writes the file and never touches settings', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'cmd'] },
+      other: { type: 'stdio' },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  await panel.webview._handler({ type: 'saveToFile', values: { commandTimeout: 50 } });
+
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.ok(parsed.servers.other, 'other server preserved');
+  assert.ok(parsed.servers.wcli0.args.includes('--commandTimeout'), 'edit written to the file');
+  assert.ok(parsed.servers.wcli0.args.includes('50'));
+  // The edit went to the file only — no wcli0.* setting was written.
+  assert.equal(vscode.__state.configWorkspace.has('wcli0.commandTimeout'), false);
+  assert.equal(vscode.__state.configGlobal.has('wcli0.commandTimeout'), false);
+  assert.ok(panel.webview.posted.some((m) => m.type === 'saved'));
+});
+
+test('the read-only home config is never accepted as a source target', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'sourceChange', source: 'homeConfig' });
+  // Unknown/read-only source target is ignored: no reload, no error.
+  assert.equal(panel.webview.posted.find((m) => m.type === 'init'), undefined);
+});
+
+test('a dirty source switch requests confirmation before discarding edits', async () => {
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  // Decline the discard prompt: the source must not switch.
+  vscode.__state.calls.warnReturn = undefined;
+  await panel.webview._handler({ type: 'sourceChangeRequest', source: 'mcpJson' });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'init'), undefined);
+  assert.equal(vscode.__state.calls.warn.length, 1);
+});
+
+test('a confirmed revert reloads the file entry and signals reverted', async () => {
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  // Load the file source so a revert has an entry to reload.
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  panel.webview.posted = [];
+  vscode.__state.calls.warnReturn = 'Discard changes';
+  await panel.webview._handler({ type: 'revertFileRequest' });
+  const init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.ok(init, 'the file entry is re-posted on revert');
+  assert.equal(init.source, 'mcpJson');
+  assert.ok(panel.webview.posted.find((m) => m.type === 'reverted'), 'reverted signal sent');
+  assert.equal(vscode.__state.calls.warn.length, 1, 'revert confirms before discarding');
+});
+
+test('a declined revert neither reloads nor signals reverted', async () => {
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  panel.webview.posted = [];
+  vscode.__state.calls.warnReturn = undefined; // dismiss the modal
+  await panel.webview._handler({ type: 'revertFileRequest' });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'init'), undefined, 'no reload on cancel');
+  assert.equal(panel.webview.posted.find((m) => m.type === 'reverted'), undefined, 'no reverted signal on cancel');
+});
+
+test('Save to file writes the wcli0 entry to .vscode/mcp.json and confirms', async () => {
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  panel.webview.posted = [];
+  // The Save button in file mode posts saveToFile with only the changed fields.
+  await panel.webview._handler({ type: 'saveToFile', values: { shell: 'cmd' } });
+  const raw = await vscode.workspace.fs.readFile(
+    vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, '.vscode', 'mcp.json'),
+  );
+  const parsed = JSON.parse(Buffer.from(raw).toString('utf8'));
+  assert.ok(parsed.servers.wcli0.args.includes('--shell'), JSON.stringify(parsed.servers.wcli0.args));
+  assert.ok(parsed.servers.wcli0.args.includes('cmd'));
+  assert.ok(panel.webview.posted.find((m) => m.type === 'saved'), 'saved confirmation sent');
+});
+
+test('Save to file with no workspace folder is refused (no write)', async () => {
+  vscode.__state.workspaceFolders = undefined;
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'saveToFile', values: { shell: 'cmd' } });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no save confirmation');
+  assert.ok(vscode.__state.calls.error.length >= 1, 'an error was surfaced');
+});
+
+test('P1: export actions are refused while editing a file source', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  vscode.__state.calls.executedCommands.length = 0;
+  vscode.__state.calls.error.length = 0;
+  // An export carrying form values must NOT persist them to wcli0.* settings nor run
+  // the export command while a file source is active.
+  await panel.webview._handler({
+    type: 'writeMcpJson',
+    target: 'Workspace',
+    values: { shell: 'cmd' },
+  });
+  assert.equal(vscode.__state.calls.executedCommands.length, 0, 'no export command ran');
+  assert.equal(vscode.__state.configWorkspace.has('wcli0.shell'), false, 'no setting written');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /export actions are unavailable/.test(m)),
+    'refusal surfaced',
+  );
+});
+
+test('P2: changing the primary workspace folder resets a loaded file source', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // The primary folder changes to a different folder (multi-root removal/reorder),
+  // still returning a folder but no longer the one the file source was loaded from.
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/other' }, name: 'other', index: 0 }];
+  panel.webview.posted = [];
+  for (const cb of vscode.__state.workspaceFoldersChangeListeners) cb();
+  const init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.ok(init, 're-posted after the folder change');
+  assert.equal(init.source, 'settings', 'stale file source reset to settings');
+});
+
+test('P25: a folder change pushes a source-reset so a dirty file form leaves the file source', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/other' }, name: 'other', index: 0 }];
+  panel.webview.posted = [];
+  for (const cb of vscode.__state.workspaceFoldersChangeListeners) cb();
+  // The external init is ignored by a dirty webview, so a dedicated source-reset message
+  // carries the switch off the now-gone file source (P25).
+  const reset = panel.webview.posted.find((m) => m.type === 'sourceReset');
+  assert.ok(reset, 'a sourceReset message is posted on the folder change');
+  assert.equal(reset.source, 'settings', 'the reset targets the settings source');
+});
+
+test('P25: no source-reset is pushed when the file source was not active', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  // Stay on the settings source; a folder change must not emit a source reset.
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/other' }, name: 'other', index: 0 }];
+  panel.webview.posted = [];
+  for (const cb of vscode.__state.workspaceFoldersChangeListeners) cb();
+  assert.equal(
+    panel.webview.posted.find((m) => m.type === 'sourceReset'),
+    undefined,
+    'no sourceReset when settings was the active source',
+  );
+});
+
+test('P4: omitting env on save clears it from the file-source baseline', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', 'wcli0@latest', '--shell', 'cmd'],
+        env: { SECRET: 'x' },
+      },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  const envWarns = () =>
+    vscode.__state.calls.warn.filter((w) => /launch\.env/.test(w.message)).length;
+  // First save: choose to omit the env inherited from the loaded entry.
+  vscode.__state.calls.warnReturn = 'Omit environment';
+  await panel.webview._handler({ type: 'saveToFile', values: { commandTimeout: 30 } });
+  let parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.env, undefined, 'env omitted from the written entry');
+  const afterFirst = envWarns();
+  assert.equal(afterFirst, 1, 'env prompt shown once');
+  // A later unrelated save must neither resurrect the omitted env nor prompt again,
+  // because the baseline was re-read from the env-less file on disk.
+  await panel.webview._handler({ type: 'saveToFile', values: { maxCommandLength: 100 } });
+  parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.env, undefined, 'env stays omitted on the next save');
+  assert.equal(envWarns(), afterFirst, 'no second env prompt — baseline cleared');
+});
+
+test('P23: a file save preserves env added on disk after the panel loaded', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', 'wcli0@latest', '--shell', 'cmd'],
+        env: { SECRET: 'x' },
+      },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // Another process adds a variable (a non-string value VS Code allows) to the on-disk
+  // entry AFTER the panel loaded its snapshot.
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', 'wcli0@latest', '--shell', 'cmd'],
+        env: { SECRET: 'x', PORT: 3000 },
+      },
+    },
+  });
+  // An unrelated save keeps the env: it must come from the CURRENT on-disk entry, not the
+  // stale panel snapshot, so the newly added PORT is not silently dropped (P23).
+  vscode.__state.calls.warnReturn = 'Include environment';
+  await panel.webview._handler({ type: 'saveToFile', values: { commandTimeout: 30 } });
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.deepEqual(
+    parsed.servers.wcli0.env,
+    { SECRET: 'x', PORT: 3000 },
+    'the env added on disk survives the unrelated save',
+  );
+});
+
+test('P80: a file save keeps a modeled field another process changed after the load', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'cmd'] },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // Another editor changes the shell on disk AFTER the panel loaded its snapshot.
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'bash'] },
+    },
+  });
+  // The user changes only Debug. buildLaunchSpec rebuilds the whole args array, so the
+  // unchanged --shell must come from the CURRENT entry, not the stale panel snapshot.
+  await panel.webview._handler({ type: 'saveToFile', values: { debug: true } });
+  const args = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0.args;
+  assert.ok(args.includes('--debug'), 'the submitted edit is written');
+  assert.equal(args[args.indexOf('--shell') + 1], 'bash', 'the concurrent shell change survives');
+  assert.equal(args.includes('cmd'), false, 'the stale loaded value is not restored');
+});
+
+test('P80: a submitted edit still wins over the on-disk value for the same field', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'cmd'] },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'bash'] },
+    },
+  });
+  await panel.webview._handler({ type: 'saveToFile', values: { shell: 'powershell' } });
+  const args = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0.args;
+  assert.equal(args[args.indexOf('--shell') + 1], 'powershell', 'the user edit is not overwritten');
+});
+
+test('P103/P104: an empty allowed-directory entry survives an unrelated file save', () => {
+  // End-to-end guard for the whole path: the client does not submit the untouched list (P104),
+  // and the builder re-emits the authored empty entry (P103), so the server keeps
+  // restrictWorkingDirectory ON with its empty allowlist instead of falling back to the
+  // configured/default allowed paths.
+  return (async () => {
+    seedWorkspaceMcpJson({
+      servers: {
+        wcli0: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', 'wcli0@latest', '--allowedDir', ''],
+        },
+      },
+    });
+    openConfigPanel(makeContext());
+    const panel = vscode.__state.lastWebviewPanel;
+    await panel.webview._handler({ type: 'ready' });
+    await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+    // An unrelated edit: the allowed-directories field is not among the submitted changes.
+    await panel.webview._handler({ type: 'saveToFile', values: { commandTimeout: 45 } });
+    const args = JSON.parse(
+      vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+    ).servers.wcli0.args;
+    assert.equal(args[args.indexOf('--allowedDir') + 1], '', 'the empty entry is still written');
+    assert.ok(args.includes('--commandTimeout'), 'the edit is written');
+  })();
+});
+
+test('P95: a save is refused when the entry changes between the two reads', async () => {
+  // The handler reads the entry to overlay the form's changes onto; the writer takes its own
+  // full-file snapshot. A write landing between them would pair stale modeled fields with a newer
+  // merge base and silently overwrite the concurrent change, so the save must refuse instead.
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'cmd'] },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // Change the file on the NEXT read only: the handler's read sees --shell cmd, the writer's
+  // snapshot sees --shell bash.
+  const realReadFile = vscode.workspace.fs.readFile;
+  let reads = 0;
+  vscode.workspace.fs.readFile = async (uri) => {
+    reads += 1;
+    if (reads === 2) {
+      seedWorkspaceMcpJson({
+        servers: {
+          wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest', '--shell', 'bash'] },
+        },
+      });
+    }
+    return realReadFile(uri);
+  };
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  try {
+    await panel.webview._handler({ type: 'saveToFile', values: { debug: true } });
+  } finally {
+    vscode.workspace.fs.readFile = realReadFile;
+  }
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no false Saved');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /changed while saving/.test(m)),
+    'the race is reported',
+  );
+  const args = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0.args;
+  assert.equal(args[args.indexOf('--shell') + 1], 'bash', 'the concurrent change is intact');
+  assert.equal(args.includes('--debug'), false, 'nothing was written');
+});
+
+test('P80: a file save is refused when the entry changed transport type on disk', async () => {
+  // The two modes model different fields, so the form's stdio edits cannot be overlaid onto an
+  // http entry (nor the reverse); ask for a reload rather than guessing.
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'http', url: 'http://127.0.0.1:9444/mcp' } },
+  });
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'saveToFile', values: { debug: true } });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no false Saved');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /different transport type/.test(m)),
+    'the refusal asks for a reload',
+  );
+  const entry = JSON.parse(
+    vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'),
+  ).servers.wcli0;
+  assert.equal(entry.type, 'http', 'the on-disk entry is untouched');
+  assert.equal(entry.url, 'http://127.0.0.1:9444/mcp');
+});
+
+test('P6: a stale file-source save after the primary folder changes is rejected', async () => {
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // The primary folder changes to a different folder (multi-root removal/reorder); the
+  // host resets the file source, but a dirty webview still posts saveToFile.
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/other' }, name: 'other', index: 0 }];
+  for (const cb of vscode.__state.workspaceFoldersChangeListeners) cb();
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'saveToFile', values: { commandTimeout: 50 } });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no save confirmation');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /workspace folder changed/.test(m)),
+    'the stale save is refused with an explanation',
+  );
+  assert.equal(
+    vscode.__state.files.has('/other/.vscode/mcp.json'),
+    false,
+    'nothing is written to the new folder',
+  );
+});
+
+test('P11: file-source init carries notes and a clean reload clears stale ones', async () => {
+  // A socket URL the host/port fields cannot model produces a parse note.
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'http', url: 'unix:///tmp/s.sock#/mcp' } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  let init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.ok(Array.isArray(init.notes) && init.notes.length > 0, 'notes sent for the un-modeled URL');
+  // Replace the file with a canonical entry that yields no notes, then reload (revert).
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'http', url: 'http://127.0.0.1:9444/mcp' } } });
+  panel.webview.posted = [];
+  vscode.__state.calls.warnReturn = 'Discard changes';
+  await panel.webview._handler({ type: 'revertFileRequest' });
+  init = panel.webview.posted.find((m) => m.type === 'init');
+  assert.ok(init, 're-posted on revert');
+  assert.deepEqual(init.notes, [], 'stale notes cleared on the clean reload');
+});
+
+test('P7: saving a file source preserves unmodeled http headers on disk', async () => {
+  seedWorkspaceMcpJson({
+    servers: {
+      wcli0: {
+        type: 'http',
+        url: 'http://127.0.0.1:9444/mcp',
+        headers: { Authorization: 'Bearer x' },
+      },
+    },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  await panel.webview._handler({ type: 'saveToFile', values: {} });
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.deepEqual(parsed.servers.wcli0.headers, { Authorization: 'Bearer x' }, 'headers survive the save');
+  assert.equal(parsed.servers.wcli0.url, 'http://127.0.0.1:9444/mcp', 'url round-trips unchanged');
+});
+
+test('P55: a network file save refuses a stale non-transport edit', async () => {
+  // The form disables the non-transport tabs for an http entry, but a value edited while the
+  // entry was still stdio is still submitted by collectChanged(). The network save would write
+  // only {type,url} and report "Saved" while silently dropping the edit, so it must be refused.
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'http', url: 'http://127.0.0.1:9444/mcp' } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'saveToFile', values: { safetyMode: 'yolo' } });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'no false Saved');
+  assert.ok(
+    vscode.__state.calls.error.some((m) => /stores only the transport type and URL/.test(m)),
+    'explains a network entry cannot store the non-transport edit',
+  );
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.url, 'http://127.0.0.1:9444/mcp', 'the entry is unchanged');
+  assert.equal(parsed.servers.wcli0.safetyMode, undefined, 'the stale edit was not written');
+});
+
+test('P55: a network file save allows a pure transport edit', async () => {
+  // Only transport.mode/host/port are storable in a network entry, so a host change alone is a
+  // legitimate save and must not be refused by the stale-edit guard.
+  seedWorkspaceMcpJson({ servers: { wcli0: { type: 'http', url: 'http://127.0.0.1:9444/mcp' } } });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({ type: 'saveToFile', values: { 'transport.host': '10.0.0.5' } });
+  assert.ok(panel.webview.posted.find((m) => m.type === 'saved'), 'a transport-only edit saves');
+  assert.equal(vscode.__state.calls.error.length, 0, 'no refusal for a transport-only edit');
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.match(parsed.servers.wcli0.url, /10\.0\.0\.5/, 'the new host is written');
+});
+
+test('P55: a stdio->http switch refuses a non-transport edit but allows the pure switch', async () => {
+  // Switching transport is storable, but a non-transport field changed in the same save is not,
+  // so the guard refuses the mixed save and accepts the pure switch.
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'sourceChange', source: 'mcpJson' });
+  // Mixed save: switch to http AND change safety -> refused.
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({
+    type: 'saveToFile',
+    values: { 'transport.mode': 'http', 'transport.host': '127.0.0.1', 'transport.port': 9000, safetyMode: 'yolo' },
+  });
+  assert.equal(panel.webview.posted.find((m) => m.type === 'saved'), undefined, 'mixed save refused');
+  assert.ok(vscode.__state.calls.error.some((m) => /stores only the transport type and URL/.test(m)));
+  // Pure switch: transport fields only -> written as an http entry.
+  vscode.__state.calls.error.length = 0;
+  panel.webview.posted = [];
+  await panel.webview._handler({
+    type: 'saveToFile',
+    values: { 'transport.mode': 'http', 'transport.host': '127.0.0.1', 'transport.port': 9000 },
+  });
+  assert.ok(panel.webview.posted.find((m) => m.type === 'saved'), 'the pure switch saves');
+  const parsed = JSON.parse(vscode.__state.files.get('/ws/.vscode/mcp.json').toString('utf8'));
+  assert.equal(parsed.servers.wcli0.type, 'http', 'the entry is now http');
+});
+
+test('P16: a folder change pushes a detection update so the banner can appear', async () => {
+  // Start with no workspace folder open.
+  vscode.__state.workspaceFolders = undefined;
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  // A folder that already has a wcli0 .vscode/mcp.json entry is opened.
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];
+  seedWorkspaceMcpJson({
+    servers: { wcli0: { type: 'stdio', command: 'npx', args: ['-y', 'wcli0@latest'] } },
+  });
+  panel.webview.posted = [];
+  for (const cb of vscode.__state.workspaceFoldersChangeListeners) cb();
+  // The detection refresh is async; flush microtasks so the follow-up push lands.
+  await new Promise((r) => setTimeout(r, 0));
+  const detected = panel.webview.posted.find((m) => m.type === 'detected');
+  assert.ok(detected, 'a detection update is pushed after the folder change');
+  const entry = (detected.detected || []).find((d) => d.kind === 'mcpJson');
+  assert.ok(entry && entry.hasWcli0, 'the workspace mcp.json wcli0 entry is detected');
+});
+
+test('the home config row opens the file read-only', async () => {
+  openConfigPanel(makeContext());
+  const panel = vscode.__state.lastWebviewPanel;
+  await panel.webview._handler({ type: 'ready' });
+  await panel.webview._handler({ type: 'openHomeConfig' });
+  // Opens a document, shows it, and marks the editor read-only in-session.
+  assert.equal(vscode.__state.calls.openedDocs.length, 1, 'opened the home config document');
+  assert.ok(/\.win-cli-mcp[\\/]config\.json$/.test(vscode.__state.calls.openedDocs[0].fsPath));
+  assert.equal(vscode.__state.calls.shownDocs.length, 1, 'showed the document');
+  assert.ok(
+    vscode.__state.calls.executedCommands.some(
+      (c) => c.id === 'workbench.action.files.setActiveEditorReadonlyInSession',
+    ),
+    'marked the editor read-only in session',
+  );
 });

--- a/vscode-extension/test/unit/webviewButtons.test.cjs
+++ b/vscode-extension/test/unit/webviewButtons.test.cjs
@@ -1,0 +1,430 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const vscode = require('../stubs/vscode.cjs');
+const { Wcli0ConfigViewProvider } = require('../../dist/webview.js');
+
+// Drive the webview's real browser-side <script> against a minimal DOM and assert
+// what each actionable button does: the message it posts to the host and/or the DOM
+// state it changes. This is the button-wiring half of the contract; the matching
+// host-side handlers (save / saveToFile / revertFileRequest / export commands /
+// openHomeConfig) are exercised separately in webview.test.cjs.
+//
+// Unlike a real Extension Host, these buttons live in a sandboxed webview whose DOM
+// cannot be clicked from the test process, so the established pattern is to run the
+// shipped script here and capture acquireVsCodeApi().postMessage calls.
+function makeHarness() {
+  vscode.__reset();
+  vscode.__state.workspaceFolders = [{ uri: { fsPath: '/ws' }, name: 'ws', index: 0 }];
+  const provider = new Wcli0ConfigViewProvider();
+  const view = vscode.__createWebviewView();
+  provider.resolveWebviewView(view);
+  const html = view.webview.html;
+  const script = html.match(/<script nonce="[^"]*">([\s\S]*?)<\/script>/)[1];
+
+  const els = new Map();
+  for (const m of html.matchAll(/id="([^"]+)"/g)) {
+    const id = m[1];
+    if (els.has(id)) continue;
+    els.set(id, {
+      id,
+      value: '',
+      checked: false,
+      disabled: false,
+      style: {},
+      textContent: '',
+      _l: {},
+      addEventListener(ev, cb) {
+        (this._l[ev] = this._l[ev] || []).push(cb);
+      },
+      reportValidity() {
+        return true;
+      },
+      checkValidity() {
+        return true;
+      },
+    });
+  }
+
+  const mkRadio = (value, checked) => ({
+    name: 'scope',
+    value,
+    checked,
+    disabled: false,
+    _l: {},
+    addEventListener(ev, cb) {
+      (this._l[ev] = this._l[ev] || []).push(cb);
+    },
+  });
+  const radios = [mkRadio('Workspace', true), mkRadio('Global', false)];
+
+  const docL = {};
+  const document = {
+    getElementById: (id) => els.get(id) || null,
+    querySelector: (sel) => {
+      if (sel === 'input[name=scope]:checked') return radios.find((r) => r.checked) || null;
+      const m = sel.match(/input\[name=scope\]\[value=([^\]]+)\]/);
+      if (m) return radios.find((r) => r.value === m[1]) || null;
+      if (sel === '.scope-radio') return els.get('switchSourceBtn') ? { style: {} } : null;
+      return null;
+    },
+    querySelectorAll: (sel) => (sel === 'input[name=scope]' ? radios : []),
+    addEventListener: (ev, cb) => {
+      (docL[ev] = docL[ev] || []).push(cb);
+    },
+  };
+
+  let messageListener;
+  const window = {
+    addEventListener: (ev, cb) => {
+      if (ev === 'message') messageListener = cb;
+    },
+  };
+  const captured = [];
+  const acquireVsCodeApi = () => ({
+    postMessage: (m) => captured.push(m),
+    getState() {},
+    setState() {},
+  });
+
+  const fn = new Function(
+    'document',
+    'window',
+    'acquireVsCodeApi',
+    'setTimeout',
+    'clearTimeout',
+    'console',
+    script,
+  );
+  fn(document, window, acquireVsCodeApi, () => 0, () => {}, console);
+
+  const click = (id) => {
+    const el = els.get(id);
+    assert.ok(el, `button #${id} exists`);
+    (el._l.click || []).forEach((cb) => cb());
+  };
+  return {
+    els,
+    captured,
+    click,
+    dispatch: (data) => messageListener({ data }),
+    fireInput: () => (docL.input || []).forEach((cb) => cb()),
+    last: (type) => [...captured].reverse().find((m) => m.type === type),
+  };
+}
+
+const FILE_INIT = {
+  type: 'init',
+  hasWorkspace: true,
+  scope: 'Workspace',
+  source: 'mcpJson',
+  settings: {},
+  detected: [{ kind: 'mcpJson', fsPath: '/ws/.vscode/mcp.json', exists: true, hasWcli0: true }],
+};
+const SETTINGS_INIT = {
+  type: 'init',
+  hasWorkspace: true,
+  scope: 'Workspace',
+  source: 'settings',
+  settings: {},
+  detected: [],
+};
+
+test('Save (settings source) posts a save with the selected scope', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('save');
+  const msg = h.last('save');
+  assert.ok(msg, 'a save message was posted');
+  assert.equal(msg.target, 'Workspace');
+  assert.ok(msg.values, 'carries the changed values');
+});
+
+test('Save (file source) posts saveToFile instead of save', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.captured.length = 0;
+  h.click('save');
+  assert.ok(h.last('saveToFile'), 'posts saveToFile in file mode');
+  assert.equal(h.last('save'), undefined, 'does not post a settings save');
+});
+
+test('Generate config.json posts generateConfig with form state', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('genConfig');
+  const msg = h.last('generateConfig');
+  assert.ok(msg, 'generateConfig posted');
+  assert.equal(msg.target, 'Workspace');
+});
+
+test('Write .vscode/mcp.json posts writeMcpJson', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('writeMcp');
+  assert.ok(h.last('writeMcpJson'), 'writeMcpJson posted');
+});
+
+test('Show launch command posts showCommand', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('showCommand');
+  assert.ok(h.last('showCommand'), 'showCommand posted');
+});
+
+test('P1: export buttons are disabled on a file source and re-enabled on settings', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  for (const id of ['showCommand', 'genConfig', 'writeMcp']) {
+    assert.equal(h.els.get(id).disabled, true, `${id} disabled in file mode`);
+  }
+  // Switching back to the settings source restores them (a workspace is open here).
+  h.dispatch(SETTINGS_INIT);
+  for (const id of ['showCommand', 'genConfig', 'writeMcp']) {
+    assert.equal(h.els.get(id).disabled, false, `${id} re-enabled on settings`);
+  }
+});
+
+// Fire the change listeners registered on an element (the harness has no real events).
+function fireChange(h, id) {
+  const el = h.els.get(id);
+  (el._l.change || []).forEach((cb) => cb());
+}
+
+test('P-httpdrop: an http file source shows the network-lock notice', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  // Switch the loaded entry to http on the Transport tab.
+  h.els.get('transport.mode').value = 'http';
+  fireChange(h, 'transport.mode');
+  assert.equal(
+    h.els.get('networkLockNote').style.display,
+    '',
+    'the lock notice is shown for an http file source (non-transport tabs are inert)',
+  );
+});
+
+test('P-httpdrop: a stdio file source does NOT lock the non-transport tabs', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT); // stdio by default
+  assert.equal(
+    h.els.get('networkLockNote').style.display,
+    'none',
+    'no lock for a stdio file source — its launch/shell/safety fields are editable',
+  );
+});
+
+test('P-httpdrop: an http SETTINGS source is not locked (values persist in settings)', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.els.get('transport.mode').value = 'http';
+  fireChange(h, 'transport.mode');
+  assert.equal(
+    h.els.get('networkLockNote').style.display,
+    'none',
+    'a settings source stays fully editable regardless of transport mode',
+  );
+});
+
+test('Load & edit mcp.json requests a switch to the file source', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('loadMcpJson');
+  const msg = h.last('sourceChange') || h.last('sourceChangeRequest');
+  assert.ok(msg, 'a source switch was requested');
+  assert.equal(msg.source, 'mcpJson');
+});
+
+test('Dismiss hides the detection banner', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.click('dismissBanner');
+  assert.equal(h.els.get('detectBanner').style.display, 'none');
+});
+
+test('Switch source toggles the source menu visibility', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.els.get('sourceMenu').style.display = 'none';
+  h.click('switchSourceBtn');
+  assert.equal(h.els.get('sourceMenu').style.display, 'block', 'opens the menu');
+  h.click('switchSourceBtn');
+  assert.equal(h.els.get('sourceMenu').style.display, 'none', 'closes the menu');
+});
+
+test('Revert is disabled on a clean file form and enabled after an edit', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  assert.equal(h.els.get('revertFile').disabled, true, 'clean form: nothing to revert');
+  // Edit a tracked field, then fire the delegated input handler.
+  h.els.get('commandTimeout').value = '999';
+  h.fireInput();
+  assert.equal(h.els.get('revertFile').disabled, false, 'edited form: revert enabled');
+});
+
+test('Revert posts revertFileRequest only when there are unsaved edits', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.captured.length = 0;
+  // Clean form: the guard suppresses the request.
+  h.click('revertFile');
+  assert.equal(h.last('revertFileRequest'), undefined, 'no request on a clean form');
+  // After an edit it posts the request.
+  h.els.get('commandTimeout').value = '123';
+  h.fireInput();
+  h.click('revertFile');
+  assert.ok(h.last('revertFileRequest'), 'posts revertFileRequest when dirty');
+});
+
+test('P22: the dirty indicator shows only on a dirty file form', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  assert.equal(h.els.get('dirtyMsg').style.display, 'none', 'clean file form: indicator hidden');
+  h.els.get('commandTimeout').value = '999';
+  h.fireInput();
+  assert.equal(h.els.get('dirtyMsg').style.display, '', 'dirty file form: indicator shown');
+});
+
+test('P22: the dirty indicator stays hidden on the settings source', () => {
+  const h = makeHarness();
+  h.dispatch(SETTINGS_INIT);
+  h.els.get('commandTimeout').value = '999';
+  h.fireInput();
+  assert.equal(
+    h.els.get('dirtyMsg').style.display,
+    'none',
+    'settings source has its own Save cue: indicator never shown',
+  );
+});
+
+test('P28: a settings save after a file-source reset flags the host to confirm', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.els.get('commandTimeout').value = '999'; // a dirty edit on the file form
+  h.fireInput();
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  h.captured.length = 0;
+  h.click('save');
+  const msg = h.last('save');
+  assert.ok(msg, 'a settings save is posted');
+  assert.equal(
+    msg.fromResetFileSource,
+    true,
+    'flagged so the host confirms before writing file edits into settings',
+  );
+});
+
+test('P28: an export after a file-source reset flags the host to confirm', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.els.get('commandTimeout').value = '999'; // a dirty edit on the file form
+  h.fireInput();
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  h.captured.length = 0;
+  // The export buttons are re-enabled off the file source, but the form still holds
+  // the now-gone file's values; an export persists them via applySettings just like a
+  // save, so it must carry the same confirm flag (otherwise it bypasses the guard).
+  h.click('genConfig');
+  const msg = h.last('generateConfig');
+  assert.ok(msg, 'an export is posted');
+  assert.equal(
+    msg.fromResetFileSource,
+    true,
+    'flagged so the host confirms before applySettings writes file edits into settings',
+  );
+});
+
+test('P28: the confirm flag clears once the form re-baselines to real settings', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.els.get('commandTimeout').value = '999';
+  h.fireInput();
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  // An explicit (non-external) settings init re-baselines the form to real values.
+  h.dispatch(SETTINGS_INIT);
+  h.captured.length = 0;
+  h.click('save');
+  const msg = h.last('save');
+  assert.ok(msg, 'a settings save is posted');
+  assert.ok(!msg.fromResetFileSource, 'no longer flagged after the re-baseline');
+});
+
+test('P25: a sourceReset switches the UI off the file source even when dirty', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.els.get('commandTimeout').value = '999';
+  h.fireInput();
+  assert.equal(h.els.get('save').textContent, 'Save to file', 'starts on the file source');
+  // The host reset the source because the loaded file's folder is no longer primary.
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  assert.equal(h.els.get('save').textContent, 'Save settings', 'switched to the settings source');
+  assert.equal(h.els.get('revertFile').style.display, 'none', 'revert hidden off the file source');
+  assert.equal(h.els.get('dirtyMsg').style.display, 'none', 'dirty indicator hidden off the file source');
+});
+
+test('P38: a sourceReset after a clean re-baseline does not flag the next save', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT); // file source loaded (clean)
+  // The real wsSub flow sends an external init (post(true)) BEFORE sourceReset. For a clean
+  // form that init re-baselines to settings values; a subsequent sourceReset must NOT arm the
+  // P28 flag, or a later settings save trips a false "came from a file source" confirmation.
+  h.dispatch(SETTINGS_INIT);
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  h.captured.length = 0;
+  h.els.get('commandTimeout').value = '999'; // a settings edit
+  h.fireInput();
+  h.click('save');
+  const msg = h.last('save');
+  assert.ok(msg, 'a settings save is posted');
+  assert.ok(!msg.fromResetFileSource, 'not flagged: the form was re-baselined before the reset');
+});
+
+test('P38: a sourceReset on a DIRTY form still flags the next save (P28 preserved)', () => {
+  const h = makeHarness();
+  h.dispatch(FILE_INIT);
+  h.els.get('commandTimeout').value = '999'; // a dirty file edit, no intervening re-baseline
+  h.fireInput();
+  h.dispatch({ type: 'sourceReset', source: 'settings', detected: [] });
+  h.captured.length = 0;
+  h.click('save');
+  const msg = h.last('save');
+  assert.ok(msg, 'a settings save is posted');
+  assert.ok(msg.fromResetFileSource, 'flagged: the dirty form still holds file-derived values');
+});
+
+test('P104: a loaded empty allowed-directory entry is not submitted by an unrelated save', () => {
+  // A file entry with `--allowedDir ""` loads as allowedDirectories: [''], which renders as a
+  // blank textarea. collect() normalizes that back to []/null -- but so does the `initial =
+  // collect()` baseline, so the field is NOT dirty and collectChanged() does not submit it. The
+  // host therefore keeps the parsed [''] and the builder re-emits `--allowedDir ""` (P103).
+  const h = makeHarness();
+  h.dispatch({
+    ...FILE_INIT,
+    settings: { allowedDirectories: [''], commandTimeout: 30 },
+    setArrayKeys: [],
+  });
+  h.captured.length = 0;
+  h.els.get('commandTimeout').value = '45';
+  h.click('save');
+  const values = (h.last('saveToFile') || {}).values;
+  assert.deepEqual(values, { commandTimeout: 45 }, 'only the edited field is submitted');
+  assert.equal('allowedDirectories' in values, false, 'the untouched list is not overwritten');
+});
+
+test('P104: editing the allowed-directories textarea still submits the new list', () => {
+  const h = makeHarness();
+  h.dispatch({
+    ...FILE_INIT,
+    settings: { allowedDirectories: [''] },
+    setArrayKeys: ['allowedDirectories'],
+  });
+  h.captured.length = 0;
+  h.els.get('allowedDirectories').value = '/ws/a';
+  h.click('save');
+  assert.deepEqual((h.last('saveToFile') || {}).values, { allowedDirectories: ['/ws/a'] });
+});


### PR DESCRIPTION
Re-lands #89, which was reverted in #92 because it had been merged while **six Codex findings were still unresolved** — one P1 and five P2. All six are fixed here.

## Why #89 was reverted

The task loop's completeness check used `reviewThreads(first: 100)` with no pagination. #89 had **106** threads, so its six newest findings were never returned and every check reported "0 unresolved". The thread count sitting at exactly 100 was the tell; `pageInfo.hasNextPage` was never read. The re-land was audited by paginating to exhaustion: 106 threads, 100 resolved, 6 unresolved, no P0.

## What is fixed here

| # | Sev | Fix |
| --- | --- | --- |
| P105 | **P1** | A direct `command: "wcli0"` entry parses its **whole** arg list instead of scanning for a flag suffix. A positional between a boolean and its negation (`--allowAllDirs marker --no-allowAllDirs`) split the list at the wrong place, leaving the *enabling* flag in `customArgs` and modeling false — so a no-op save wrote `--allowAllDirs marker` and flipped the server from restricted to **unrestricted directories** |
| P106 | P2 | A preserved **valueless** value option is re-emitted so it cannot capture a following token. The builder appends `extraArgs` after the modeled flags, so `--shell --debug cmd` (shell='', `cmd` positional) was rebuilt as `--debug --shell cmd`, making `cmd` the shell. string/csv → `--flag=`; inert number/array → dropped; `c` bundle → `-<letters> --config=` |
| P107 | P2 | A transport host carrying `/ ? # @`, whitespace or an embedded port is refused before interpolation, instead of writing `http://gateway.example/api:9444/mcp` and losing the edit on reload |
| P108 | P2 | `--no-debug=false` no longer proves a wrapper server suffix — yargs applies `--name=value` before negation, so it defines an unrelated `no-debug` key. A bare `--no-debug` still counts |
| P109 | P2 | The array half of P106. `--allowedDir --debug C:/work` gives yargs an *empty* array with the path positional; re-emitted adjacently it became an allowed directory, switching `restrictWorkingDirectory` **ON** and injection protection **OFF** |
| P110 | P2 | A save carrying a method-specific launch field is refused when the entry's launch method changed on disk — the P80 transport-mode guard one level down |

## How the behavioural rules were established

Every parser rule here was checked against the **installed yargs-parser**, not inferred:

- `--shell=` parses exactly like a valueless `--shell` (`''`) and consumes nothing — safe to rewrite
- `--allowedDir=` yields `['']`, **not** `[]` — that is the P103 deny-all, so arrays are dropped instead
- a valueless *number* option defines no key, while `--flag=` defines `0` — dropped, not rewritten
- `-c=` swallows the next token, so a `c` bundle becomes `-<letters> --config=` (verified equivalent)
- `--no-debug=false` → `{ 'no-debug': false }`, leaving `debug` untouched

## Verification

- Extension: `tsc --noEmit` clean, **659/659** unit tests pass
- Server: **1089 passed** / 24 skipped, `tsc --noEmit` clean
- Every fix is pinned by a test that **fails against the pre-fix source** (verified by stashing `src/` and re-running: 7 targeted failures)
- The already-safe preservation shapes (P30, P44, P78, P98) still round-trip byte-for-byte — the P106/P109 rewrite fires only when a real positional follows

Full rationale per finding is in `docs/tasks/autodetect_mcp_source/analysis_105..110_*.md`.